### PR TITLE
Separate complex initialization-only typestate from Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+## Breaking Changes
+
+* `Connection::new` has been renamed `Options::new`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Basic connections, and those with options. The compiler will force these to be c
 ```rust
 let nc = nats::connect("localhost")?;
 
-let nc2 = nats::Connection::new()
+let nc2 = nats::Options::new()
     .with_name("My Rust NATS App")
     .with_user_pass("derek", "s3cr3t!")
     .connect("127.0.0.1")?;

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Basic connections, and those with options. The compiler will force these to be c
 ```rust
 let nc = nats::connect("localhost")?;
 
-let nc2 = nats::Options::new()
+let nc2 = nats::ConnectionOptions::new()
     .with_name("My Rust NATS App")
     .with_user_pass("derek", "s3cr3t!")
     .connect("127.0.0.1")?;

--- a/examples/nats-box/main.rs
+++ b/examples/nats-box/main.rs
@@ -28,7 +28,7 @@ enum Command {
 
 fn main() -> CliResult {
     let args = Cli::from_args();
-    let nc = nats::Connection::new()
+    let nc = nats::Options::new()
         .with_name("nats-box rust example")
         .connect(&args.server)?;
 

--- a/examples/nats-box/main.rs
+++ b/examples/nats-box/main.rs
@@ -28,7 +28,7 @@ enum Command {
 
 fn main() -> CliResult {
     let args = Cli::from_args();
-    let nc = nats::Options::new()
+    let nc = nats::ConnectionOptions::new()
         .with_name("nats-box rust example")
         .connect(&args.server)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,8 @@ impl ConnectionOptions<options_typestate::NoAuth> {
     /// # Example
     /// ```
     /// # fn main() -> std::io::Result<()> {
-    /// let nc = nats::ConnectionOptions::new().connect("demo.nats.io")?;
+    /// let options = nats::ConnectionOptions::new();
+    /// let nc = options.connect("demo.nats.io")?;
     /// # Ok(())
     /// # }
     /// ```
@@ -247,7 +248,8 @@ impl<TypeState> ConnectionOptions<TypeState> {
     /// # Example
     /// ```
     /// # fn main() -> std::io::Result<()> {
-    /// let nc = nats::ConnectionOptions::new().connect("demo.nats.io")?;
+    /// let options = nats::ConnectionOptions::new();
+    /// let nc = options.connect("demo.nats.io")?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub mod options_typestate {
     /// any auth-related configuration
     /// provided yet.
     #[derive(Debug, Copy, Clone, Default)]
-    pub struct Unauthenticated;
+    pub struct NoAuth;
 
     /// `ConnectionOptions` typestate indicating
     /// that auth-related configuration
@@ -130,14 +130,14 @@ pub mod options_typestate {
 
 /// A configuration object for a NATS connection.
 #[derive(Clone, Debug, Default)]
-pub struct ConnectionOptions<TypeState = options_typestate::Unauthenticated> {
+pub struct ConnectionOptions<TypeState> {
     auth: AuthStyle,
     name: Option<String>,
     no_echo: bool,
     typestate: PhantomData<TypeState>,
 }
 
-impl ConnectionOptions<options_typestate::Unauthenticated> {
+impl ConnectionOptions<options_typestate::NoAuth> {
     /// `ConnectionOptions` for establishing a new NATS `Connection`.
     ///
     /// # Example
@@ -147,7 +147,7 @@ impl ConnectionOptions<options_typestate::Unauthenticated> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new() -> ConnectionOptions<options_typestate::Unauthenticated> {
+    pub fn new() -> ConnectionOptions<options_typestate::NoAuth> {
         ConnectionOptions::default()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ impl<TypeState> ConnectionOptions<TypeState> {
         }
     }
 
-    /// Connect to a NATS server and establish a `Connection`.
+    /// Establish a `Connection` with a NATS server.
     ///
     /// # Example
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub struct Options<Typestate = options_typestate::Unauthenticated> {
 }
 
 impl Options<options_typestate::Unauthenticated> {
-    /// Create a new NATS connection. This will not be a connected connection.
+    /// `Options` for establishing a new NATS `Connection`.
     ///
     /// # Example
     /// ```
@@ -151,7 +151,7 @@ impl Options<options_typestate::Unauthenticated> {
         Options::default()
     }
 
-    /// Authenticate this NATS connection with a token.
+    /// Authenticate with NATS using a token.
     ///
     /// # Example
     /// ```
@@ -171,7 +171,7 @@ impl Options<options_typestate::Unauthenticated> {
         }
     }
 
-    /// Authenticate this NATS connection with a username and password.
+    /// Authenticate with NATS using a username and password.
     ///
     /// # Example
     /// ```
@@ -197,7 +197,7 @@ impl Options<options_typestate::Unauthenticated> {
 }
 
 impl<TypeState> Options<TypeState> {
-    /// Add a name option for the unconnected connection.
+    /// Add a name option to this configuration.
     ///
     /// # Example
     /// ```
@@ -242,7 +242,7 @@ impl<TypeState> Options<TypeState> {
         }
     }
 
-    /// Connect an unconnected NATS connection.
+    /// Connect to a NATS server and establish a `Connection`.
     ///
     /// # Example
     /// ```
@@ -350,7 +350,7 @@ impl<TypeState> Options<TypeState> {
     }
 }
 
-/// A `ConnectionStatus` describes the current sub-status of a `Connected` connection.
+/// A `ConnectionStatus` describes the current sub-status of a `Connection`.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ConnectionStatus {
     /// A connection in the process of establishing a connection.


### PR DESCRIPTION
In the lead-up to implementing reconnection logic, it's important to reduce some complexity where possible to reduce the friction of introducing changes over time. I started diving into reconnection, but found myself getting a bit confused with the various typestates relating to connectivity etc... and only later did I realize they were only really being used at initialization time.

This separates concerns a bit by splitting the complex typestate into different objects that do different things: 
* `Options` which are now a publicly documented type that can be operated on in the same way that Connection could be before when it had the complex typestate. 
* `Connection` now doesn't have any complex typestate, and all access to its state has been simplified by allow it to avoid referring to the `state` member.

Personally, I'm uncertain if `Options` is the best name, but I figured I'd start with this to minimize change for now.

I've added a new file, `CHANGELOG.md` which can be used for basically copying + pasting into release notes when a new version is put out, and it documents things like breaking changes and interesting new features. I'm modeling it off of [sled's](https://github.com/spacejam/sled/blob/d6e039b24760d9a14cdf7df998f69c64b47f1cb7/CHANGELOG.md) for now, but I don't have many strong opinions about it. I mostly treat it as a way to make release notes easier by writing relevant things as they change instead of flipping through commit history since the last release.