### PR TITLE
small cleanups

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ impl<TypeState> ConnectionOptions<TypeState> {
         });
         conn.reader = Some(read_loop);
 
-        let usec = Duration::new(0, 1_000);
+        let usec = Duration::from_micros(1);
         let wait: [Duration; 5] = [10 * usec, 100 * usec, 500 * usec, 1000 * usec, 5000 * usec];
         let wbuf = conn.writer.clone();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1128,29 +1128,16 @@ struct ServerInfo {
     host: String,
     port: i16,
     version: String,
-    #[serde(default = "default_false")]
+    #[serde(default)]
     auth_required: bool,
-    #[serde(default = "default_false")]
+    #[serde(default)]
     tls_required: bool,
     max_payload: i32,
     proto: i8,
     client_id: u64,
     go: String,
-    #[serde(default = "default_empty")]
+    #[serde(default)]
     nonce: String,
-    #[serde(default = "default_no_urls")]
+    #[serde(default)]
     connect_urls: Vec<String>,
-}
-
-const fn default_false() -> bool {
-    false
-}
-
-#[inline]
-fn default_empty() -> String {
-    "".to_string()
-}
-
-const fn default_no_urls() -> Vec<String> {
-    Vec::new()
 }


### PR DESCRIPTION
We can rely on the default implementation for the same functionality as the provided functions to serde.