### PR TITLE
Refactor shared state behind a single Arc to simplify the dependency graph

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,30 +49,6 @@ pub(crate) fn read_loop(state: &mut ReadLoopState) -> io::Result<()> {
 }
 
 impl ReadLoopState {
-    fn reconnect(&mut self) -> io::Result<()> {
-        // flush outstanding pongs
-        {
-            let mut pongs = self.shared_state.pongs.lock().unwrap();
-            while let Some(s) = pongs.pop_front() {
-                s.send(true).unwrap();
-            }
-        }
-
-        todo!("clear any captured errors");
-        /*
-        todo!("execute disconnect callback if registered");
-
-        // for each server in the server pool:
-        todo!("wait backoff");
-        todo!("record retry stats");
-        todo!("clear particular server stats");
-        todo!("resend subscriptions");
-        todo!("send the buffered items");
-        todo!("trigger reconnected callback");
-        todo!("flush buffers to server");
-        Ok(())
-        */
-    }
     fn process_pong(&mut self) {
         let mut pongs = self.shared_state.pongs.lock().unwrap();
         if let Some(s) = pongs.pop_front() {

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -1,0 +1,17 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    io::{self},
+    sync::{Mutex, RwLock},
+};
+
+use crossbeam_channel::Sender;
+
+use crate::{Message, Outbound};
+
+#[derive(Debug)]
+pub(crate) struct SharedState {
+    pub(crate) last_error: RwLock<io::Result<()>>,
+    pub(crate) subs: RwLock<HashMap<usize, Sender<Message>>>,
+    pub(crate) pongs: Mutex<VecDeque<Sender<bool>>>,
+    pub(crate) writer: Mutex<Outbound>,
+}


### PR DESCRIPTION
The `SharedState` object is where I'm putting the various reconnection-related parameters. With ad-hoc `Arc`s used in different places in more fine-grained ways it's easy to cause cycles and violate assumptions about lifetimes. Now there's just one type behind a single `Arc`, simplifying the dependency graph and reducing arc-related overhead (no need to clone and store multiple `Arc`s). 