### PR TITLE
TLS Support. Closes #5.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ nom = "5.1"
 crossbeam-channel = "0.4"
 parking_lot = "0.10.0"
 rand = "0.7.3"
+native-tls = "0.2.4"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,7 +510,7 @@ impl<TypeState> ConnectionOptions<TypeState> {
     /// # Examples
     /// ```no_run
     /// # fn main() -> std::io::Result<()> {
-    /// let mut tls_connector = nats::tls::tls_builder()
+    /// let mut tls_connector = nats::tls::builder()
     ///     .identity(nats::tls::Identity::from_pkcs12(b"der_bytes", "my_password").unwrap())
     ///     .add_root_certificate(nats::tls::Certificate::from_pem(b"my_pem_bytes").unwrap())
     ///     .build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ mod inbound;
 mod outbound;
 mod parser;
 mod shared_state;
+mod tls;
 
 /// Functionality relating to subscribing to a
 /// subject.
@@ -109,13 +110,89 @@ use serde::{Deserialize, Serialize};
 pub use subscription::Subscription;
 
 use {
-    inbound::Inbound,
-    outbound::Outbound,
+    inbound::{Inbound, Reader},
+    outbound::{Outbound, Writer},
     shared_state::{parse_server_addresses, Server, SharedState, SubscriptionState},
+    tls::{split_tls, TlsReader, TlsWriter},
 };
 
 const VERSION: &str = "0.0.1";
 const LANG: &str = "rust";
+
+/*
+#[derive(Debug)]
+enum Stream {
+    Tcp(TcpStream),
+    Tls(TlsStream<TcpStream>),
+}
+
+impl Stream {
+    fn upgrade(&mut self) -> io::Result<()> {
+        let stream = if let Stream::Tcp(tcp) = self {
+            tcp.try_clone().unwrap()
+        } else {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "cannot upgrade a TLS connection, as it is already upgraded",
+            ));
+        };
+
+        let connector = match TlsConnector::new() {
+            Ok(connector) => connector,
+            Err(e) => {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!("failed to create TLS connector: {}", e),
+                ));
+            }
+        };
+
+        match connector.connect("", stream) {
+            Ok(tls) => *self = Stream::Tls(tls),
+            Err(e) => {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!("failed to upgrade connection to TLS: {}", e),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn shutdown(&mut self) -> io::Result<()> {
+        match self {
+            Stream::Tcp(tcp) => tcp.shutdown(Shutdown::Both),
+            Stream::Tls(tls) => tls.shutdown(),
+        }
+    }
+}
+
+impl Read for Stream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Stream::Tcp(tcp) => tcp.read(buf),
+            Stream::Tls(tls) => tls.read(buf),
+        }
+    }
+}
+
+impl Write for Stream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Stream::Tcp(tcp) => tcp.write(buf),
+            Stream::Tls(tls) => tls.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Stream::Tcp(tcp) => tcp.flush(),
+            Stream::Tls(tls) => tls.flush(),
+        }
+    }
+}
+*/
 
 /// Information sent by the server back to this client
 /// during initial connection, and possibly again later.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,13 +96,15 @@ pub mod subscription;
 use std::{
     fmt,
     io::{self, Error, ErrorKind},
-    sync::{atomic::Ordering, Arc},
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
 use serde::{Deserialize, Serialize};
-
-use std::{marker::PhantomData, sync::atomic::AtomicUsize};
 
 pub use subscription::Subscription;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,9 @@ mod inbound;
 mod outbound;
 mod parser;
 mod shared_state;
-mod tls;
+
+/// Functionality relating to TLS configuration
+pub mod tls;
 
 /// Functionality relating to subscribing to a
 /// subject.
@@ -118,81 +120,6 @@ use {
 
 const VERSION: &str = "0.0.1";
 const LANG: &str = "rust";
-
-/*
-#[derive(Debug)]
-enum Stream {
-    Tcp(TcpStream),
-    Tls(TlsStream<TcpStream>),
-}
-
-impl Stream {
-    fn upgrade(&mut self) -> io::Result<()> {
-        let stream = if let Stream::Tcp(tcp) = self {
-            tcp.try_clone().unwrap()
-        } else {
-            return Err(Error::new(
-                ErrorKind::Other,
-                "cannot upgrade a TLS connection, as it is already upgraded",
-            ));
-        };
-
-        let connector = match TlsConnector::new() {
-            Ok(connector) => connector,
-            Err(e) => {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    format!("failed to create TLS connector: {}", e),
-                ));
-            }
-        };
-
-        match connector.connect("", stream) {
-            Ok(tls) => *self = Stream::Tls(tls),
-            Err(e) => {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    format!("failed to upgrade connection to TLS: {}", e),
-                ));
-            }
-        }
-
-        Ok(())
-    }
-
-    fn shutdown(&mut self) -> io::Result<()> {
-        match self {
-            Stream::Tcp(tcp) => tcp.shutdown(Shutdown::Both),
-            Stream::Tls(tls) => tls.shutdown(),
-        }
-    }
-}
-
-impl Read for Stream {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match self {
-            Stream::Tcp(tcp) => tcp.read(buf),
-            Stream::Tls(tls) => tls.read(buf),
-        }
-    }
-}
-
-impl Write for Stream {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match self {
-            Stream::Tcp(tcp) => tcp.write(buf),
-            Stream::Tls(tls) => tls.write(buf),
-        }
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        match self {
-            Stream::Tcp(tcp) => tcp.flush(),
-            Stream::Tls(tls) => tls.flush(),
-        }
-    }
-}
-*/
 
 /// Information sent by the server back to this client
 /// during initial connection, and possibly again later.
@@ -290,7 +217,6 @@ pub mod options_typestate {
 type FinalizedOptions = ConnectionOptions<options_typestate::Finalized>;
 
 /// A configuration object for a NATS connection.
-#[derive(Clone, Debug)]
 pub struct ConnectionOptions<TypeState> {
     typestate: PhantomData<TypeState>,
     auth: AuthStyle,
@@ -300,6 +226,8 @@ pub struct ConnectionOptions<TypeState> {
     reconnect_buffer_size: usize,
     disconnect_callback: Callback,
     reconnect_callback: Callback,
+    tls_connector: Option<tls::TlsConnector>,
+    tls_required: bool,
 }
 
 impl Default for ConnectionOptions<options_typestate::NoAuth> {
@@ -313,7 +241,32 @@ impl Default for ConnectionOptions<options_typestate::NoAuth> {
             max_reconnects: Some(60),
             disconnect_callback: Callback(None),
             reconnect_callback: Callback(None),
+            tls_connector: None,
+            tls_required: false,
         }
+    }
+}
+
+impl<T> fmt::Debug for ConnectionOptions<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_map()
+            .entry(&"auth", &self.auth)
+            .entry(&"name", &self.name)
+            .entry(&"no_echo", &self.no_echo)
+            .entry(&"reconnect_buffer_size", &self.reconnect_buffer_size)
+            .entry(&"max_reconnects", &self.max_reconnects)
+            .entry(&"disconnect_callback", &self.disconnect_callback)
+            .entry(&"reconnect_callback", &self.reconnect_callback)
+            .entry(
+                &"tls_connector",
+                if self.tls_connector.is_some() {
+                    &"set"
+                } else {
+                    &"unset"
+                },
+            )
+            .entry(&"tls_required", &self.tls_required)
+            .finish()
     }
 }
 
@@ -353,6 +306,8 @@ impl ConnectionOptions<options_typestate::NoAuth> {
             reconnect_callback: self.reconnect_callback,
             reconnect_buffer_size: self.reconnect_buffer_size,
             max_reconnects: self.max_reconnects,
+            tls_connector: self.tls_connector,
+            tls_required: self.tls_required,
         }
     }
 
@@ -381,6 +336,8 @@ impl ConnectionOptions<options_typestate::NoAuth> {
             disconnect_callback: self.disconnect_callback,
             reconnect_callback: self.reconnect_callback,
             max_reconnects: self.max_reconnects,
+            tls_connector: self.tls_connector,
+            tls_required: self.tls_required,
         }
     }
 }
@@ -479,6 +436,8 @@ impl<TypeState> ConnectionOptions<TypeState> {
             max_reconnects: self.max_reconnects,
             disconnect_callback: self.disconnect_callback,
             reconnect_callback: self.reconnect_callback,
+            tls_connector: self.tls_connector,
+            tls_required: self.tls_required,
             // move options into the Finalized state by setting
             // `typestate` to `PhantomData<Finalized>`
             typestate: PhantomData,
@@ -513,6 +472,59 @@ impl<TypeState> ConnectionOptions<TypeState> {
         F: Fn(&ServerInfo) + Send + Sync + 'static,
     {
         self.disconnect_callback = Callback(Some(Arc::new(cb)));
+        self
+    }
+
+    /// Setting this requires that TLS be set for all server connections.
+    ///
+    /// If you only want to use TLS for some server connections, you may
+    /// declare them separately in the connect string by prefixing them
+    /// with `tls://host:port` instead of `nats://host:port`.
+    ///
+    /// If you want to use a particular TLS configuration, see
+    /// the `nats::tls::tls_connector` method and the
+    /// `nats::ConnectionOptions::tls_connector` method below
+    /// to apply the desired configuration to all server connections.
+    ///
+    /// # Examples
+    /// ```
+    /// # fn main() -> std::io::Result<()> {
+    ///
+    /// let nc = nats::ConnectionOptions::new()
+    ///     .tls_required(true)
+    ///     .connect("demo.nats.io")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn tls_required(mut self, tls_required: bool) -> Self {
+        self.tls_required = tls_required;
+        self
+    }
+
+    /// Allows a particular TLS configuration to be set
+    /// for upgrading TCP connections to TLS connections.
+    ///
+    /// Note that this also enforces that TLS will be
+    /// enabled for all connections to all servers.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> {
+    /// let mut tls_connector = nats::tls::tls_builder()
+    ///     .identity(nats::tls::Identity::from_pkcs12(b"der_bytes", "my_password").unwrap())
+    ///     .add_root_certificate(nats::tls::Certificate::from_pem(b"my_pem_bytes").unwrap())
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let nc = nats::ConnectionOptions::new()
+    ///     .tls_connector(tls_connector)
+    ///     .connect("demo.nats.io")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn tls_connector(mut self, connector: tls::TlsConnector) -> Self {
+        self.tls_connector = Some(connector);
+        self.tls_required = true;
         self
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -115,6 +115,8 @@ fn parse_err(args: &[u8]) -> ControlOp {
 }
 
 pub(crate) fn expect_info(reader: &mut TcpStream) -> io::Result<ServerInfo> {
+    // TODO(spacejam) revisit this with a profiler and make it
+    // more optimized to minimize time-to-first-byte.
     let mut buf = Vec::with_capacity(512);
 
     while !buf.ends_with(b"\r\n") {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, BufRead, BufReader, Error, ErrorKind},
+    io::{self, BufRead, Error, ErrorKind, Read},
     net::TcpStream,
     str::FromStr,
 };
@@ -114,14 +114,21 @@ fn parse_err(args: &[u8]) -> ControlOp {
     ControlOp::Err(err_description.to_string())
 }
 
-pub(crate) fn expect_info(reader: &mut BufReader<TcpStream>) -> io::Result<ServerInfo> {
-    let op = parse_control_op(reader)?;
+pub(crate) fn expect_info(reader: &mut TcpStream) -> io::Result<ServerInfo> {
+    let mut buf = Vec::with_capacity(512);
 
-    if let ControlOp::Info(info) = op {
-        Ok(info)
-    } else {
-        Err(Error::new(ErrorKind::Other, "INFO proto not found"))
+    while !buf.ends_with(b"\r\n") {
+        let byte = &mut [0];
+        reader.read_exact(byte)?;
+        buf.push(byte[0]);
     }
+
+    if buf.starts_with(b"INFO ") {
+        if let Ok(info) = serde_json::from_slice(&buf[b"INFO ".len()..]) {
+            return Ok(info);
+        }
+    }
+    Err(Error::new(ErrorKind::Other, "INFO proto not found"))
 }
 
 const CRLF: &str = "\r\n";

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -172,11 +172,10 @@ impl Server {
                 let attempt = if let Some(ref tls_connector) = options.tls_connector {
                     tls_connector.connect(&self.host, stream)
                 } else {
-                    let connector = native_tls::TlsConnector::builder()
-                        .danger_accept_invalid_certs(true)
-                        .build()
-                        .unwrap();
-                    connector.connect(&self.host, stream)
+                    match native_tls::TlsConnector::new() {
+                        Ok(connector) => connector.connect(&self.host, stream),
+                        Err(e) => return Err(Error::new(ErrorKind::Other, e)),
+                    }
                 };
                 match attempt {
                     Ok(tls) => {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -14,7 +14,7 @@ pub use native_tls::{Certificate, Identity, TlsConnector, TlsConnectorBuilder};
 /// # Examples
 /// ```no_run
 /// # fn main() -> std::io::Result<()> {
-/// let mut tls_connector = nats::tls::tls_builder()
+/// let mut tls_connector = nats::tls::builder()
 ///     .identity(nats::tls::Identity::from_pkcs12(b"der_bytes", "my_password").unwrap())
 ///     .add_root_certificate(nats::tls::Certificate::from_pem(b"my_pem_bytes").unwrap())
 ///     .build()
@@ -26,7 +26,7 @@ pub use native_tls::{Certificate, Identity, TlsConnector, TlsConnectorBuilder};
 /// # Ok(())
 /// # }
 /// ```
-pub fn tls_builder() -> TlsConnectorBuilder {
+pub fn builder() -> TlsConnectorBuilder {
     TlsConnector::builder()
 }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,68 @@
+use std::{
+    io::{self, Read, Write},
+    net::TcpStream,
+    sync::{Arc, Mutex},
+};
+
+use native_tls::TlsStream;
+
+pub(crate) fn split_tls(tls: TlsStream<TcpStream>) -> (TlsReader, TlsWriter) {
+    let tls_reader = TlsReader {
+        raw_socket: tls.get_ref().try_clone().unwrap(),
+        tls: Arc::new(Mutex::new(tls)),
+    };
+
+    let tls_writer = TlsWriter {
+        tls: tls_reader.tls.clone(),
+    };
+
+    (tls_reader, tls_writer)
+}
+
+#[derive(Debug)]
+pub(crate) struct TlsReader {
+    tls: Arc<Mutex<TlsStream<TcpStream>>>,
+    raw_socket: TcpStream,
+}
+
+impl TlsReader {
+    fn wait_for_readable(&self) -> io::Result<()> {
+        let mut peek_buf = [0];
+        self.raw_socket.peek(&mut peek_buf)?;
+        Ok(())
+    }
+}
+
+impl Read for TlsReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.wait_for_readable()?;
+
+        let mut tls = self.tls.lock().unwrap();
+
+        tls.read(buf)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TlsWriter {
+    tls: Arc<Mutex<TlsStream<TcpStream>>>,
+}
+
+impl Write for TlsWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut tls = self.tls.lock().unwrap();
+        tls.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut tls = self.tls.lock().unwrap();
+        tls.flush()
+    }
+}
+
+impl TlsWriter {
+    pub(crate) fn shutdown(&mut self) -> io::Result<()> {
+        let mut tls = self.tls.lock().unwrap();
+        tls.shutdown()
+    }
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -6,6 +6,30 @@ use std::{
 
 use native_tls::TlsStream;
 
+pub use native_tls::{Certificate, Identity, TlsConnector, TlsConnectorBuilder};
+
+/// Returns a new TLS configuration object for use
+/// with `ConnectionOptions::set_tls_connector`.
+///
+/// # Examples
+/// ```no_run
+/// # fn main() -> std::io::Result<()> {
+/// let mut tls_connector = nats::tls::tls_builder()
+///     .identity(nats::tls::Identity::from_pkcs12(b"der_bytes", "my_password").unwrap())
+///     .add_root_certificate(nats::tls::Certificate::from_pem(b"my_pem_bytes").unwrap())
+///     .build()
+///     .unwrap();
+///
+/// let nc = nats::ConnectionOptions::new()
+///     .tls_connector(tls_connector)
+///     .connect("demo.nats.io")?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn tls_builder() -> TlsConnectorBuilder {
+    TlsConnector::builder()
+}
+
 pub(crate) fn split_tls(tls: TlsStream<TcpStream>) -> (TlsReader, TlsWriter) {
     let tls_reader = TlsReader {
         raw_socket: tls.get_ref().try_clone().unwrap(),

--- a/tests/reconnection.rs
+++ b/tests/reconnection.rs
@@ -18,11 +18,11 @@ struct Client {
     outstanding_pings: usize,
 }
 
-fn ends_with_crlf(buf: &[u8]) -> bool {
-    buf.len() >= 2 && buf[buf.len() - 2] == b'\r' && buf[buf.len() - 1] == b'\n'
-}
-
 fn read_line(stream: &mut TcpStream) -> Option<String> {
+    fn ends_with_crlf(buf: &[u8]) -> bool {
+        buf.len() >= 2 && buf[buf.len() - 2] == b'\r' && buf[buf.len() - 1] == b'\n'
+    }
+
     let mut buf = vec![];
     while !ends_with_crlf(&buf) {
         let mut read_buf = [0];


### PR DESCRIPTION
- [x] TLS may be enabled for all outgoing connections by calling `nats::ConnectionOptions::tls_required(true)`
- [x] TLS may be enabled for a specific connection by specifying a server with the prefix `tls://host:port` rather than `nats://host:port`
- [x] TLS may be configured for all connections by using the `nats::tls::tls_connector()` method which returns a re-exported [`native_tls::TlsConnector`](https://docs.rs/native-tls/0.2.4/native_tls/struct.TlsConnectorBuilder.html) that allows various TLS settings to be configured. This applies the desired TLS configuration to all outgoing connections. Is this desired behavior?
- [x] client identity is configurable using the above `tls_connector` object