### PR TITLE
retry initial connection in now occasionally-failing reconnect test

### DIFF
--- a/tests/reconnection.rs
+++ b/tests/reconnection.rs
@@ -241,7 +241,11 @@ fn simple_reconnect() {
 
     barrier.wait();
 
-    let nc = Arc::new(nats::connect("localhost:22222").unwrap());
+    let nc = loop {
+        if let Ok(nc) = nats::connect("localhost:22222") {
+            break Arc::new(nc);
+        }
+    };
 
     let tx = std::thread::spawn({
         let nc = nc.clone();


### PR DESCRIPTION
After #21, the reconnection test will fail due to not being able to establish a connection to the intentionally-bad server initially.

This has the test retry connection initially, to account for the new initial connection semantics.

cc @derekcollison 