### PR TITLE
Lower minimum supported Rust version to 1.37.0 and release 0.3.2 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+  - 1.37.0
   - stable
   - beta
   - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.3.2
+
+## Misc
+
+* The minimum supported Rust version (MSRV) is now
+  made explicit, and lowered to version 1.37.0 from
+  1.42.0. Crate version 0.3.1 has been yanked due to
+  it having silently broken older Rust versions than
+  1.42.0.
+
 # 0.3.1
 
 ## New Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "natsio"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,21 +22,21 @@ maintenance = { status = "actively-developed" }
 panic = 'abort'
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-regex = "1"
-nuid = "~0.2"
-lazy_static = "1.4"
-nom = "5.1"
-crossbeam-channel = "0.4"
-parking_lot = "0.10.0"
+serde = { version = "1.0.106", features = ["derive"] }
+serde_json = "1.0.51"
+regex = "1.3.7"
+nuid = "0.2.1"
+lazy_static = "1.4.0"
+nom = "5.1.1"
+crossbeam-channel = "0.4.2"
+parking_lot = "0.10.2"
 rand = "0.7.3"
 native-tls = "0.2.4"
 
 [dev-dependencies]
-criterion = "0.3"
-quicli = "0.4"
-structopt = "0.3.5"
+criterion = "0.3.1"
+quicli = "0.4.0"
+structopt = "0.3.14"
 
 [[bench]]
 name = "nats_bench"

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The following is a list of features currently supported and planned for the near
   * [ ] Nkeys
   * [ ] User JWTs (NATS 2.0)
 * [X] Reconnect logic
-* [ ] TLS support
+* [X] TLS support
 * [ ] Direct async support
 * [X] Crates.io listing
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ nc.publish_request("foo", reply, "Help me!")?;
 let response = rsub.iter().take(1);
 ```
 
+## Minimum Supported Rust Version (MSRV)
+
+The minimum supported Rust version is 1.37.0.
+
 ## Sync vs Async
 
 The Rust ecosystem has a diverse set of options for async behaviors. This client library can be used somewhat effectively already with async runtimes such as async-std and tokio. Going forward we look to provide an async client. Publish today is mostly non-blocking, so largest API change would be around subscriptions being streams vs iterators by default. Also been researching sinks and whether or not they make sense. Would probably be a config feature for async wnd options for most runtimes like async-std and tokio.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,12 +487,12 @@ impl<TypeState> ConnectionOptions<TypeState> {
     /// to apply the desired configuration to all server connections.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     ///
     /// let nc = nats::ConnectionOptions::new()
     ///     .tls_required(true)
-    ///     .connect("demo.nats.io")?;
+    ///     .connect("my.nats.server")?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -112,7 +112,11 @@ impl Outbound {
     }
 
     pub(crate) fn is_disconnected(&self) -> bool {
-        matches!(*self.writer.lock(), Writer::Disconnected(_))
+        if let Writer::Disconnected(_) = *self.writer.lock() {
+            true
+        } else {
+            false
+        }
     }
 
     pub(crate) fn transition_to_disconnect_buffer(&self, buf_sz: usize) {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -6,7 +6,7 @@ use std::{
 
 use native_tls::TlsStream;
 
-pub use native_tls::{Certificate, Identity, TlsConnector, TlsConnectorBuilder};
+pub use native_tls::{Certificate, Identity, Protocol, TlsConnector, TlsConnectorBuilder};
 
 /// Returns a new TLS configuration object for use
 /// with `ConnectionOptions::set_tls_connector`.


### PR DESCRIPTION
Version 0.3.1 caused breakage for users of Rust with a compiler version 1.41 or earlier, due to the usage of the `matches!` macro which stabilized in Rust `1.41.0`. This patch does two things:
* lowers MSRV to 1.37.0
* makes our MSRV explicit

I am going to publish 0.3.2 and "yank" 0.3.1 to prevent breakage for users.