### PR TITLE
Add support for RTT calculation, as well as flush_timeout

### DIFF
--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -95,7 +95,7 @@ impl Inbound {
         {
             let mut pongs = self.shared_state.pongs.lock();
             while let Some(s) = pongs.pop_front() {
-                s.send(true).unwrap();
+                s.send(false).unwrap();
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -821,7 +821,7 @@ impl Connection {
     }
 
     /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.
-    /// Will fail with `TimedOut` if the server does not respond with in 60 seconds.
+    /// Will fail with `TimedOut` if the server does not respond with in 10 seconds.
     /// Will fail with `NotConnected` if the server is not currently connected.
     /// Will fail with `BrokenPipe` if the connection to the server is lost.
     ///
@@ -834,7 +834,7 @@ impl Connection {
     /// # }
     /// ```
     pub fn flush(&self) -> io::Result<()> {
-        self.flush_timeout(Duration::from_secs(3))
+        self.flush_timeout(Duration::from_secs(10))
     }
 
     /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,7 +823,7 @@ impl Connection {
     /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.
     /// Will fail with `TimedOut` if the server does not respond with in 10 seconds.
     /// Will fail with `NotConnected` if the server is not currently connected.
-    /// Will fail with `BrokenPipe` if the connection to the server is lost.
+    /// Will fail with `ConnectionReset` if the connection to the server is lost.
     ///
     /// # Example
     /// ```
@@ -840,7 +840,7 @@ impl Connection {
     /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.
     /// Will fail with `TimedOut` if the server takes longer than this duration to respond.
     /// Will fail with `NotConnected` if the server is not currently connected.
-    /// Will fail with `BrokenPipe` if the connection to the server is lost.
+    /// Will fail with `ConnectionReset` if the connection to the server is lost.
     ///
     /// # Example
     /// ```
@@ -866,7 +866,7 @@ impl Connection {
 
         if !success {
             return Err(Error::new(
-                ErrorKind::BrokenPipe,
+                ErrorKind::ConnectionReset,
                 "The connection to the remote server was lost",
             ));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -825,7 +825,7 @@ impl Connection {
     /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.
     /// Will fail with `TimedOut` if the server does not respond with in 10 seconds.
     /// Will fail with `NotConnected` if the server is not currently connected.
-    /// Will fail with `ConnectionReset` if the connection to the server is lost.
+    /// Will fail with `BrokenPipe` if the connection to the server is lost.
     ///
     /// # Example
     /// ```
@@ -842,7 +842,7 @@ impl Connection {
     /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.
     /// Will fail with `TimedOut` if the server takes longer than this duration to respond.
     /// Will fail with `NotConnected` if the server is not currently connected.
-    /// Will fail with `ConnectionReset` if the connection to the server is lost.
+    /// Will fail with `BrokenPipe` if the connection to the server is lost.
     ///
     /// # Example
     /// ```
@@ -868,7 +868,7 @@ impl Connection {
 
         if !success {
             return Err(Error::new(
-                ErrorKind::ConnectionReset,
+                ErrorKind::BrokenPipe,
                 "The connection to the remote server was lost",
             ));
         }
@@ -908,7 +908,7 @@ impl Connection {
         self.flush_timeout(Duration::from_secs(10))?;
         Ok(start.elapsed())
     }
-  
+
     /// Returns the client IP as known by the server.
     /// Supported as of server version 2.1.6.
     /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -834,7 +834,7 @@ impl Connection {
     /// # }
     /// ```
     pub fn flush(&self) -> io::Result<()> {
-        self.flush_timeout(Duration::from_secs(60))
+        self.flush_timeout(Duration::from_secs(3))
     }
 
     /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -76,6 +76,14 @@ impl Writer {
             Writer::Disconnected(_) => Ok(()),
         }
     }
+
+    pub(crate) fn is_disconnected(&self) -> bool {
+        if let Writer::Disconnected(_) = self {
+            true
+        } else {
+            false
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -172,6 +180,14 @@ impl Outbound {
 
     pub(crate) fn send_ping(&self) -> io::Result<()> {
         let mut writer = self.writer.lock();
+
+        if writer.is_disconnected() {
+            return Err(Error::new(
+                ErrorKind::NotConnected,
+                "The client is not currently connected to a server",
+            ));
+        }
+
         writer.write_all(b"PING\r\n")?;
         // Flush in place on pings.
         writer.flush()


### PR DESCRIPTION
I've also implemented flush_timeout to have parity with the Go client.