### PR TITLE
Refactor Message::respond()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,17 +609,18 @@ impl Message {
     /// # }
     /// ```
     pub fn respond(&self, msg: impl AsRef<[u8]>) -> io::Result<()> {
-        if let Some(shared_state) = &self.responder {
-            if let Some(reply) = &self.reply {
-                shared_state.outbound.send_response(reply, msg.as_ref())?;
+        match (&self.responder, &self.reply) {
+            (Some(shared_state), Some(reply)) => {
+                shared_state.outbound.send_response(reply, msg.as_ref())
             }
-        } else {
-            return Err(Error::new(
+            (None, None) => Err(Error::new(
                 ErrorKind::InvalidInput,
                 "No reply subject available",
-            ));
+            )),
+            (Some(_), None) | (None, Some(_)) => unreachable!(
+                "`reply` and `shared_state` should either both be `Some` or both be `None`"
+            ),
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
It turns out that `shared_state` and `reply` fields in `Message` are always either both `Some` or both `None`.

In theory, it'd be great if those were a part of the same `Option`, something ilke:

```rust
reply: Option<(String, Arc<SharedState>)>,
```

However, field `reply` is already public with the `Option<String>` type so changing this would be a breaking change.

I restructured the `respond()` function to be a bit more indicative of this invariant and to fail fast if we break it.