### PR TITLE
Address bug with PONG receiver leaks during disconnection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -854,14 +854,19 @@ impl Connection {
     /// # }
     /// ```
     pub fn flush_timeout(&self, duration: Duration) -> io::Result<()> {
-        // TODO(dlc) - bounded or oneshot?
         let (s, r) = crossbeam_channel::bounded(1);
-        {
-            let mut pongs = self.shared_state.pongs.lock();
-            pongs.push_back(s);
-        }
 
+        // We take out the mutex before sending a ping (which may fail)
+        let mut pongs = self.shared_state.pongs.lock();
+
+        // This will throw an error if the system is disconnected.
         self.shared_state.outbound.send_ping()?;
+
+        // We only push to the mutex if the ping was successfully queued.
+        // By holding the mutex across calls, we guarantee ordering in the
+        // queue.
+        pongs.push_back(s);
+        drop(pongs);
 
         let success = r
             .recv_timeout(duration)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,7 +864,7 @@ impl Connection {
 
         // We only push to the mutex if the ping was successfully queued.
         // By holding the mutex across calls, we guarantee ordering in the
-        // queue.
+        // queue will match the order of calls to `send_ping`.
         pongs.push_back(s);
         drop(pongs);
 


### PR DESCRIPTION
Just realized this bug exists while scanning the source code

Bug:
* client is disconnected
* client calls `Connection::flush`
  * a `crossbeam_channel::Sender` is pushed into the pongs `VecDeque`
  * `Outbound::send_ping` is called, which returns `Err(NotConnected)`
  * the client early-exits from `Connection::flush`
* client reconnects
* client calls `Connection::flush` again, adds new `Sender` to pong queue, sends PING to server
* server sends back PONG
* `Inbound` receives and parses the PONG, pops the first `Sender` from the pong queue (which is no longer waiting)
* the second client call hangs on the crossbeam_channel's Receiver until the receive timeout fires, when it should have actually received a success.

We need to hold the pong queue mutex across the call to send_ping (which may fail) because we must linearize the items in the queue with calls to send_ping. Only holding it on one end of this operation will race other calls to flush as well as transitions into the disconnected state.

We need to hold the pong queue mutex across calls to `Outbound::transition_to_disconnect_buffer` because otherwise, it may not synchronize properly with the calls to `flush`.

@stjepang and I are thinking about a simpler, lower-mutex architecture that we can shift to after implementing nkeys, where only a single thread controls a simple state machine and basically guarantees bugs like this are impossible by handling events in a serialized way.