### PR TITLE
Add authentication with credentials file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ parking_lot = "0.10.2"
 rand = "0.7.3"
 native-tls = "0.2.4"
 log = "0.4.8"
+nkeys = "0.0.9"
+base64-url = "1.1.13"
 
 [dev-dependencies]
 criterion = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ native-tls = "0.2.4"
 log = "0.4.8"
 nkeys = "0.0.9"
 base64-url = "1.1.13"
+once_cell = "1.3.1"
 
 [dev-dependencies]
 criterion = "0.3.2"

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,4 +1,15 @@
+use std::{
+    io::{self, BufReader, BufWriter, Write},
+    net::{SocketAddr, TcpStream},
+};
+
+use nkeys::KeyPair;
 use serde::Serialize;
+
+use crate::{
+    inject_io_failure, parser::parse_control_op, parser::ControlOp, split_tls, FinalizedOptions,
+    Reader, ServerInfo, Writer,
+};
 
 /// Info to construct a CONNECT message.
 #[derive(Clone, Serialize, Debug)]
@@ -62,5 +73,78 @@ fn is_empty_or_none(field: &Option<String>) -> bool {
     match field {
         Some(inner) => inner.is_empty(),
         None => true,
+    }
+}
+
+/// Attempts to connect to a server using a single address.
+pub(crate) fn connect_to_addr(
+    host: String,
+    tls_required: bool,
+    options: &FinalizedOptions,
+    addr: SocketAddr,
+    mut connect_op: ConnectInfo,
+    nkey: Option<&KeyPair>,
+) -> io::Result<(Reader, Writer, ServerInfo)> {
+    inject_io_failure()?;
+    let mut stream = TcpStream::connect(&addr)?;
+    let info = crate::parser::expect_info(&mut stream)?;
+
+    if !info.nonce.is_empty() {
+        if let Some(nkey) = nkey {
+            let sig = nkey
+                .sign(info.nonce.as_bytes())
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+            let sig = base64_url::encode(&sig);
+            connect_op.sig = Some(sig);
+        }
+    }
+
+    let op = format!(
+        "CONNECT {}\r\nPING\r\n",
+        serde_json::to_string(&connect_op)?
+    );
+
+    // potentially upgrade to TLS
+    let (mut reader, mut writer) = if options.tls_required || info.tls_required || tls_required {
+        let attempt = if let Some(ref tls_connector) = options.tls_connector {
+            tls_connector.connect(&host, stream)
+        } else {
+            match native_tls::TlsConnector::new() {
+                Ok(connector) => connector.connect(&host, stream),
+                Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
+            }
+        };
+        match attempt {
+            Ok(tls) => {
+                let (tls_reader, tls_writer) = split_tls(tls);
+                let reader = Reader::Tls(BufReader::with_capacity(64 * 1024, tls_reader));
+                let writer = Writer::Tls(BufWriter::with_capacity(64 * 1024, tls_writer));
+                (reader, writer)
+            }
+            Err(e) => {
+                log::error!("failed to upgrade TLS: {:?}", e);
+                return Err(io::Error::new(io::ErrorKind::PermissionDenied, e));
+            }
+        }
+    } else {
+        let reader = Reader::Tcp(BufReader::with_capacity(64 * 1024, stream.try_clone()?));
+        let writer = Writer::Tcp(BufWriter::with_capacity(64 * 1024, stream));
+        (reader, writer)
+    };
+
+    writer.write_all(op.as_bytes())?;
+    writer.flush()?;
+    let parsed_op = parse_control_op(&mut reader)?;
+
+    match parsed_op {
+        ControlOp::Pong => Ok((reader, writer, info)),
+        ControlOp::Err(e) => Err(io::Error::new(io::ErrorKind::ConnectionRefused, e)),
+        ControlOp::Ping | ControlOp::Msg(_) | ControlOp::Info(_) | ControlOp::Unknown(_) => {
+            log::error!(
+                "encountered unexpected control op during connection: {:?}",
+                parsed_op
+            );
+            Err(io::Error::new(io::ErrorKind::ConnectionRefused, "Protocol Error"))
+        }
     }
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,0 +1,66 @@
+use serde::Serialize;
+
+/// Info to construct a CONNECT message.
+#[derive(Clone, Serialize, Debug)]
+pub(crate) struct ConnectInfo {
+    /// Turns on +OK protocol acknowledgements.
+    pub verbose: bool,
+
+    /// Turns on additional strict format checking, e.g. for properly formed subjects.
+    pub pedantic: bool,
+
+    #[serde(skip_serializing_if = "is_empty_or_none")]
+    pub user_jwt: Option<String>,
+
+    #[serde(skip_serializing_if = "is_empty_or_none")]
+    pub nkey: Option<String>,
+
+    /// Optional client name.
+    #[serde(skip_serializing_if = "is_empty_or_none")]
+    pub name: Option<String>,
+
+    /// If set to `true`, the server (version 1.2.0+) will not send originating messages from this
+    /// connection to its own subscriptions. Clients should set this to `true` only for server
+    /// supporting this feature, which is when proto in the INFO protocol is set to at least 1.
+    #[serde(skip_serializing_if = "is_true")]
+    pub echo: bool,
+
+    /// The implementation language of the client.
+    pub lang: String,
+
+    /// The version of the client.
+    pub version: String,
+
+    /// Indicates whether the client requires an SSL connection.
+    #[serde(default)]
+    pub tls_required: bool,
+
+    /// Connection username (if `auth_required` is set)
+    #[serde(skip_serializing_if = "is_empty_or_none")]
+    pub user: Option<String>,
+
+    /// Connection password (if auth_required is set)
+    #[serde(skip_serializing_if = "is_empty_or_none")]
+    pub pass: Option<String>,
+
+    /// Client authorization token (if auth_required is set)
+    #[serde(skip_serializing_if = "is_empty_or_none")]
+    pub auth_token: Option<String>,
+
+    #[serde(skip_serializing_if = "is_empty_or_none")]
+    pub sig: Option<String>,
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_true(field: &bool) -> bool {
+    *field
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+#[inline]
+fn is_empty_or_none(field: &Option<String>) -> bool {
+    match field {
+        Some(inner) => inner.is_empty(),
+        None => true,
+    }
+}

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,14 +1,16 @@
 use std::{
+    fs,
     io::{self, BufReader, BufWriter, Write},
     net::{SocketAddr, TcpStream},
 };
 
 use nkeys::KeyPair;
+use regex::Regex;
 use serde::Serialize;
 
 use crate::{
-    inject_io_failure, parser::parse_control_op, parser::ControlOp, split_tls, FinalizedOptions,
-    Reader, ServerInfo, Writer,
+    inject_io_failure, parser::parse_control_op, parser::ControlOp, split_tls, AuthStyle,
+    FinalizedOptions, Reader, ServerInfo, Writer,
 };
 
 /// Info to construct a CONNECT message.
@@ -20,11 +22,17 @@ pub(crate) struct ConnectInfo {
     /// Turns on additional strict format checking, e.g. for properly formed subjects.
     pub pedantic: bool,
 
-    #[serde(skip_serializing_if = "is_empty_or_none")]
+    /// User's JWT.
+    #[serde(rename = "jwt", skip_serializing_if = "is_empty_or_none")]
     pub user_jwt: Option<String>,
 
+    /// User's Nkey.
     #[serde(skip_serializing_if = "is_empty_or_none")]
     pub nkey: Option<String>,
+
+    /// Signed nonce, formatted using base64 URL encoding.
+    #[serde(rename = "sig", skip_serializing_if = "is_empty_or_none")]
+    pub signature: Option<String>,
 
     /// Optional client name.
     #[serde(skip_serializing_if = "is_empty_or_none")]
@@ -57,9 +65,6 @@ pub(crate) struct ConnectInfo {
     /// Client authorization token (if auth_required is set)
     #[serde(skip_serializing_if = "is_empty_or_none")]
     pub auth_token: Option<String>,
-
-    #[serde(skip_serializing_if = "is_empty_or_none")]
-    pub sig: Option<String>,
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -76,75 +81,160 @@ fn is_empty_or_none(field: &Option<String>) -> bool {
     }
 }
 
-/// Attempts to connect to a server using a single address.
-pub(crate) fn connect_to_addr(
+/// Attempts to connect to a server using a single socket addrs.
+pub(crate) fn connect_to_socket_addr(
+    addr: SocketAddr,
     host: String,
     tls_required: bool,
-    options: &FinalizedOptions,
-    addr: SocketAddr,
-    mut connect_op: ConnectInfo,
-    nkey: Option<&KeyPair>,
+    options: FinalizedOptions,
 ) -> io::Result<(Reader, Writer, ServerInfo)> {
     inject_io_failure()?;
-    let mut stream = TcpStream::connect(&addr)?;
-    let info = crate::parser::expect_info(&mut stream)?;
 
-    if !info.nonce.is_empty() {
-        if let Some(nkey) = nkey {
-            let sig = nkey
-                .sign(info.nonce.as_bytes())
-                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-            let sig = base64_url::encode(&sig);
-            connect_op.sig = Some(sig);
-        }
-    }
+    let mut stream = TcpStream::connect(&addr)?;
+    let server_info = crate::parser::expect_info(&mut stream)?;
+
+    let connect_info = authenticate(server_info.clone(), options.clone(), tls_required)?;
 
     let op = format!(
         "CONNECT {}\r\nPING\r\n",
-        serde_json::to_string(&connect_op)?
+        serde_json::to_string(&connect_info)?
     );
 
     // potentially upgrade to TLS
-    let (mut reader, mut writer) = if options.tls_required || info.tls_required || tls_required {
-        let attempt = if let Some(ref tls_connector) = options.tls_connector {
-            tls_connector.connect(&host, stream)
+    let (mut reader, mut writer) =
+        if options.tls_required || server_info.tls_required || tls_required {
+            let attempt = if let Some(ref tls_connector) = options.tls_connector {
+                tls_connector.connect(&host, stream)
+            } else {
+                match native_tls::TlsConnector::new() {
+                    Ok(connector) => connector.connect(&host, stream),
+                    Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
+                }
+            };
+            match attempt {
+                Ok(tls) => {
+                    let (tls_reader, tls_writer) = split_tls(tls);
+                    let reader = Reader::Tls(BufReader::with_capacity(64 * 1024, tls_reader));
+                    let writer = Writer::Tls(BufWriter::with_capacity(64 * 1024, tls_writer));
+                    (reader, writer)
+                }
+                Err(e) => {
+                    log::error!("failed to upgrade TLS: {:?}", e);
+                    return Err(io::Error::new(io::ErrorKind::PermissionDenied, e));
+                }
+            }
         } else {
-            match native_tls::TlsConnector::new() {
-                Ok(connector) => connector.connect(&host, stream),
-                Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
-            }
+            let reader = Reader::Tcp(BufReader::with_capacity(64 * 1024, stream.try_clone()?));
+            let writer = Writer::Tcp(BufWriter::with_capacity(64 * 1024, stream));
+            (reader, writer)
         };
-        match attempt {
-            Ok(tls) => {
-                let (tls_reader, tls_writer) = split_tls(tls);
-                let reader = Reader::Tls(BufReader::with_capacity(64 * 1024, tls_reader));
-                let writer = Writer::Tls(BufWriter::with_capacity(64 * 1024, tls_writer));
-                (reader, writer)
-            }
-            Err(e) => {
-                log::error!("failed to upgrade TLS: {:?}", e);
-                return Err(io::Error::new(io::ErrorKind::PermissionDenied, e));
-            }
-        }
-    } else {
-        let reader = Reader::Tcp(BufReader::with_capacity(64 * 1024, stream.try_clone()?));
-        let writer = Writer::Tcp(BufWriter::with_capacity(64 * 1024, stream));
-        (reader, writer)
-    };
 
     writer.write_all(op.as_bytes())?;
     writer.flush()?;
     let parsed_op = parse_control_op(&mut reader)?;
 
     match parsed_op {
-        ControlOp::Pong => Ok((reader, writer, info)),
+        ControlOp::Pong => Ok((reader, writer, server_info)),
         ControlOp::Err(e) => Err(io::Error::new(io::ErrorKind::ConnectionRefused, e)),
         ControlOp::Ping | ControlOp::Msg(_) | ControlOp::Info(_) | ControlOp::Unknown(_) => {
             log::error!(
                 "encountered unexpected control op during connection: {:?}",
                 parsed_op
             );
-            Err(io::Error::new(io::ErrorKind::ConnectionRefused, "Protocol Error"))
+            Err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                "Protocol Error",
+            ))
         }
     }
+}
+
+fn authenticate(
+    server_info: ServerInfo,
+    options: FinalizedOptions,
+    tls_required: bool,
+) -> io::Result<ConnectInfo> {
+    // This regex parses a credentials file.
+    //
+    // The credentials file is typically `~/.nkeys/creds/synadia/<account/<account>.creds` and
+    // looks as follows:
+    //
+    // ```
+    // -----BEGIN NATS USER JWT-----
+    // <public jwt>
+    // ------END NATS USER JWT------
+    //
+    // ************************* IMPORTANT *************************
+    // NKEY Seed printed below can be used to sign and prove identity.
+    // NKEYs are sensitive and should be treated as secrets.
+    //
+    // -----BEGIN USER NKEY SEED-----
+    // <private nkey>
+    // ------END USER NKEY SEED------
+    //
+    // *************************************************************
+    // ```
+    const CREDS_FILE_REGEX: &str =
+        r"\s*(?:(?:[-]{3,}.*[-]{3,}\r?\n)([\w\-.=]+)(?:\r?\n[-]{3,}.*[-]{3,}\r?\n))";
+
+    let mut connect_info = ConnectInfo {
+        tls_required: tls_required,
+        name: options.name.to_owned(),
+        nkey: None,
+        pedantic: false,
+        verbose: false,
+        lang: crate::LANG.into(),
+        version: crate::VERSION.into(),
+        user: None,
+        pass: None,
+        auth_token: None,
+        user_jwt: None,
+        signature: None,
+        echo: !options.no_echo,
+    };
+
+    let mut nkey = None;
+
+    match &options.auth {
+        AuthStyle::UserPass(user, pass) => {
+            connect_info.user = Some(user.into());
+            connect_info.pass = Some(pass.into());
+        }
+        AuthStyle::Token(token) => connect_info.auth_token = Some(token.into()),
+        AuthStyle::Credentials(path) => {
+            let contents = fs::read_to_string(&path)?;
+            let re = Regex::new(CREDS_FILE_REGEX).unwrap();
+            let captures = re.captures_iter(&contents).collect::<Vec<_>>();
+
+            let (user_jwt, seed) = match &captures[..] {
+                [jwt, seed, ..] => (jwt[1].to_string(), seed[1].to_string()),
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("cannot parse credentials in {}", path.display()),
+                    ))
+                }
+            };
+
+            let key_pair = KeyPair::from_seed(&seed)
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+            nkey = Some(key_pair);
+
+            let jwt = Some(user_jwt);
+            connect_info.user_jwt = jwt.into();
+        }
+        AuthStyle::None => {}
+    }
+
+    if !server_info.nonce.is_empty() {
+        if let Some(nkey) = nkey {
+            let sig = nkey
+                .sign(server_info.nonce.as_bytes())
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+            let sig = base64_url::encode(&sig);
+            connect_info.signature = Some(sig);
+        }
+    }
+
+    Ok(connect_info)
 }

--- a/src/creds_utils.rs
+++ b/src/creds_utils.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use crate::SecureString;
 
 /// Loads user JWT from a credentials file.
-pub(crate) fn user_jwt_from_file(path: &Path) -> io::Result<String> {
+pub(crate) fn user_jwt_from_file(path: &Path) -> io::Result<SecureString> {
     let contents = SecureString::from(fs::read_to_string(path)?);
     parse_decorated_jwt(&contents).ok_or_else(|| {
         io::Error::new(
@@ -63,9 +63,9 @@ static USER_CONFIG_RE: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Parses a credentials file and returns its user JWT.
-fn parse_decorated_jwt(contents: &SecureString) -> Option<String> {
+fn parse_decorated_jwt(contents: &SecureString) -> Option<SecureString> {
     let capture = USER_CONFIG_RE.captures_iter(contents).next()?;
-    Some(capture[1].to_string())
+    Some(SecureString::from(capture[1].to_string()))
 }
 
 /// Parses a credentials file and returns its nkey.

--- a/src/creds_utils.rs
+++ b/src/creds_utils.rs
@@ -1,0 +1,75 @@
+use std::{fs, io, path::Path};
+
+use nkeys::KeyPair;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::SecureString;
+
+/// Loads user JWT from a credentials file.
+pub(crate) fn user_jwt_from_file(path: &Path) -> io::Result<String> {
+    let contents = SecureString::from(fs::read_to_string(path)?);
+    parse_decorated_jwt(&contents).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "cannot parse user JWT from the credentails file",
+        )
+    })
+}
+
+/// Signs nonce using a credentials file.
+pub(crate) fn sign_nonce_with_file(nonce: &[u8], path: &Path) -> io::Result<SecureString> {
+    // Load the private nkey.
+    let contents = SecureString::from(fs::read_to_string(path)?);
+    let nkey = parse_decorated_nkey(&contents).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "cannot parse nkey from the credentails file",
+        )
+    })?;
+
+    // Use the nkey to sign the nonce.
+    let key_pair =
+        KeyPair::from_seed(&nkey).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    let sig = key_pair
+        .sign(nonce)
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+    // Encode the signature to Base64URL.
+    Ok(SecureString::from(base64_url::encode(&sig)))
+}
+
+// This regex parses a credentials file.
+//
+// The credentials file is typically `~/.nkeys/creds/synadia/<account/<account>.creds`
+// and looks like this:
+//
+// ```
+// -----BEGIN NATS USER JWT-----
+// eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5...
+// ------END NATS USER JWT------
+//
+// ************************* IMPORTANT *************************
+// NKEY Seed printed below can be used sign and prove identity.
+// NKEYs are sensitive and should be treated as secrets.
+//
+// -----BEGIN USER NKEY SEED-----
+// SUAIO3FHUX5PNV2LQIIP7TZ3N4L7TX3W53MQGEIVYFIGA635OZCKEYHFLM
+// ------END USER NKEY SEED------
+// ```
+static USER_CONFIG_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\s*(?:(?:[-]{3,}.*[-]{3,}\r?\n)([\w\-.=]+)(?:\r?\n[-]{3,}.*[-]{3,}\r?\n))")
+        .unwrap()
+});
+
+/// Parses a credentials file and returns its user JWT.
+fn parse_decorated_jwt(contents: &SecureString) -> Option<String> {
+    let capture = USER_CONFIG_RE.captures_iter(&contents).nth(0)?;
+    Some(capture[1].to_string())
+}
+
+/// Parses a credentials file and returns its nkey.
+fn parse_decorated_nkey(contents: &SecureString) -> Option<SecureString> {
+    let capture = USER_CONFIG_RE.captures_iter(&contents).nth(1)?;
+    Some(SecureString::from(capture[1].to_string()))
+}

--- a/src/creds_utils.rs
+++ b/src/creds_utils.rs
@@ -64,12 +64,12 @@ static USER_CONFIG_RE: Lazy<Regex> = Lazy::new(|| {
 
 /// Parses a credentials file and returns its user JWT.
 fn parse_decorated_jwt(contents: &SecureString) -> Option<String> {
-    let capture = USER_CONFIG_RE.captures_iter(&contents).nth(0)?;
+    let capture = USER_CONFIG_RE.captures_iter(contents).next()?;
     Some(capture[1].to_string())
 }
 
 /// Parses a credentials file and returns its nkey.
 fn parse_decorated_nkey(contents: &SecureString) -> Option<SecureString> {
-    let capture = USER_CONFIG_RE.captures_iter(&contents).nth(1)?;
+    let capture = USER_CONFIG_RE.captures_iter(contents).nth(1)?;
     Some(SecureString::from(capture[1].to_string()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,13 @@
 //!
 //! `git clone https://github.com/nats-io/nats.rs`
 //!
-//! NATS.io is a simple, secure and high performance open source messaging system for cloud native applications,
-//! `IoT` messaging, and microservices architectures.
+//! NATS.io is a simple, secure and high performance open source messaging system for cloud native
+//! applications, `IoT` messaging, and microservices architectures.
 //!
 //! For more information see [https://nats.io/].
 //!
 //! [https://nats.io/]: https://nats.io/
-//!
+
 #![cfg_attr(test, deny(warnings))]
 #![deny(
     missing_docs,
@@ -114,6 +114,7 @@ use std::{
     fmt,
     io::{self, Error, ErrorKind},
     marker::PhantomData,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -195,8 +196,7 @@ impl fmt::Debug for Callback {
     }
 }
 
-#[doc(hidden)]
-pub mod options_typestate {
+mod options_typestate {
     /// `ConnectionOptions` typestate indicating
     /// that there has not yet been
     /// any auth-related configuration
@@ -342,6 +342,35 @@ impl ConnectionOptions<options_typestate::NoAuth> {
             name: self.name,
             reconnect_buffer_size: self.reconnect_buffer_size,
             close_callback: self.close_callback,
+            disconnect_callback: self.disconnect_callback,
+            reconnect_callback: self.reconnect_callback,
+            max_reconnects: self.max_reconnects,
+            tls_connector: self.tls_connector,
+            tls_required: self.tls_required,
+        }
+    }
+
+    /// Authenticate with NATS using a credentials file
+    ///
+    /// # Example
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> {
+    /// let nc = nats::ConnectionOptions::new()
+    ///     .with_credentials("path/to/my.creds")
+    ///     .connect("demo.nats.io")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_credentials(
+        self,
+        path: impl AsRef<Path>,
+    ) -> ConnectionOptions<options_typestate::Authenticated> {
+        ConnectionOptions {
+            auth: AuthStyle::Credentials(path.as_ref().into()),
+            typestate: PhantomData,
+            no_echo: self.no_echo,
+            name: self.name,
+            reconnect_buffer_size: self.reconnect_buffer_size,
             disconnect_callback: self.disconnect_callback,
             reconnect_callback: self.reconnect_callback,
             max_reconnects: self.max_reconnects,
@@ -597,9 +626,16 @@ pub struct Connection {
 
 #[derive(Serialize, Clone, Debug)]
 enum AuthStyle {
-    //    Credentials(String, String),
+    /// Authenticate using a token.
     Token(String),
+
+    /// Authenticate using a username and password.
     UserPass(String, String),
+
+    /// Authenticate using a `.creds` file.
+    Credentials(PathBuf),
+
+    /// No authentication.
     None,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@
     clippy::wrong_pub_self_convention,
 )]
 
-mod inbound;
 mod connect;
+mod inbound;
 mod outbound;
 mod parser;
 mod shared_state;
@@ -375,6 +375,7 @@ impl ConnectionOptions<options_typestate::NoAuth> {
             disconnect_callback: self.disconnect_callback,
             reconnect_callback: self.reconnect_callback,
             max_reconnects: self.max_reconnects,
+            close_callback: self.close_callback,
             tls_connector: self.tls_connector,
             tls_required: self.tls_required,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ pub use subscription::Subscription;
 use {
     inbound::{Inbound, Reader},
     outbound::{Outbound, Writer},
-    secure_wipe::SecureString,
+    secure_wipe::{SecureString, SecureVec},
     shared_state::{parse_server_addresses, Server, SharedState, SubscriptionState},
     tls::{split_tls, TlsReader, TlsWriter},
 };
@@ -650,7 +650,7 @@ enum AuthStyle {
     /// Authenticate using a `.creds` file.
     Credentials {
         /// Securely loads the user JWT.
-        jwt_cb: Arc<dyn Fn() -> io::Result<String> + Send + Sync>,
+        jwt_cb: Arc<dyn Fn() -> io::Result<SecureString> + Send + Sync>,
         /// Securely loads the nkey and signs the nonce passed as an argument.
         sig_cb: Arc<dyn Fn(&[u8]) -> io::Result<SecureString> + Send + Sync>,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,7 +362,7 @@ impl ConnectionOptions<options_typestate::NoAuth> {
     /// # fn main() -> std::io::Result<()> {
     /// let nc = nats::ConnectionOptions::new()
     ///     .with_credentials("path/to/my.creds")
-    ///     .connect("demo.nats.io")?;
+    ///     .connect("connect.ngs.global")?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ const LANG: &str = "rust";
 
 /// Information sent by the server back to this client
 /// during initial connection, and possibly again later.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ServerInfo {
     /// The unique identifier of the NATS server.
     pub server_id: String,
@@ -222,6 +222,7 @@ mod options_typestate {
 type FinalizedOptions = ConnectionOptions<options_typestate::Finalized>;
 
 /// A configuration object for a NATS connection.
+#[derive(Clone)]
 pub struct ConnectionOptions<TypeState> {
     typestate: PhantomData<TypeState>,
     auth: AuthStyle,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@
 )]
 
 mod inbound;
+mod connect;
 mod outbound;
 mod parser;
 mod shared_state;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,7 +13,7 @@ use nom::{
     IResult,
 };
 
-use crate::{inject_io_failure, ServerInfo};
+use crate::{inject_io_failure, SecureVec, ServerInfo};
 
 // Protocol
 const INFO: &[u8] = b"INFO";
@@ -120,7 +120,7 @@ pub(crate) fn expect_info(reader: &mut TcpStream) -> io::Result<ServerInfo> {
     inject_io_failure()?;
     // TODO(spacejam) revisit this with a profiler and make it
     // more optimized to minimize time-to-first-byte.
-    let mut buf = Vec::with_capacity(512);
+    let mut buf = SecureVec::with_capacity(512);
 
     while !buf.ends_with(b"\r\n") {
         let byte = &mut [0];

--- a/src/secure_wipe.rs
+++ b/src/secure_wipe.rs
@@ -23,6 +23,26 @@ use serde::{Deserialize, Serialize};
 pub(crate) struct SecureVec(Vec<u8>);
 
 impl SecureVec {
+    pub(crate) fn with_capacity(sz: usize) -> SecureVec {
+        SecureVec(Vec::with_capacity(sz))
+    }
+
+    pub(crate) fn push(&mut self, item: u8) {
+        if self.0.len() == self.0.capacity() {
+            let cap = std::cmp::max(16, self.0.capacity());
+            let mut next = Vec::with_capacity(cap * 2);
+
+            // copy toxic waste to next destination
+            next.extend_from_slice(&self.0);
+
+            // replace old home of toxic waste with random data
+            self.scramble();
+
+            self.0 = next;
+        }
+        self.0.push(item);
+    }
+
     pub(crate) fn scramble(&mut self) {
         let mut rng = thread_rng();
         for byte in &mut self.0 {

--- a/src/secure_wipe.rs
+++ b/src/secure_wipe.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Also scrambles data on Drop.
 ///
-/// Uses the basic idea (write_volatile + compiler_fence)
+/// Uses the basic idea (`write_volatile` + `compiler_fence`)
 /// from @bascule's zeroize crate but overwrites data with
 /// random bytes instead of zeros.
 #[derive(Clone, Default, Deserialize, Serialize)]
@@ -57,7 +57,7 @@ impl Deref for SecureVec {
 
 /// A `String` that gets scrambled on drop.
 ///
-/// Uses the basic idea (write_volatile + compiler_fence)
+/// Uses the basic idea (`write_volatile` + `compiler_fence`)
 /// from @bascule's zeroize crate but overwrites data with
 /// random bytes instead of zeros.
 #[derive(Clone, Default, Deserialize, Serialize)]

--- a/src/secure_wipe.rs
+++ b/src/secure_wipe.rs
@@ -1,0 +1,104 @@
+use std::{
+    fmt,
+    ops::Deref,
+    ptr::write_volatile,
+    sync::atomic::{compiler_fence, Ordering::SeqCst},
+};
+
+use rand::{thread_rng, Rng};
+use serde::{Deserialize, Serialize};
+
+/// A `Vec<u8>` that gets scrambled on drop.
+/// Provides a vector that will scramble allocations as
+/// they are discarded when the vector grows.
+///
+/// Allows users to scamble the data whenever they want.
+///
+/// Also scrambles data on Drop.
+///
+/// Uses the basic idea (write_volatile + compiler_fence)
+/// from @bascule's zeroize crate but overwrites data with
+/// random bytes instead of zeros.
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub(crate) struct SecureVec(Vec<u8>);
+
+impl SecureVec {
+    pub(crate) fn scramble(&mut self) {
+        let mut rng = thread_rng();
+        for byte in &mut self.0 {
+            #[allow(unsafe_code)]
+            unsafe {
+                write_volatile(byte, rng.gen());
+            }
+        }
+        compiler_fence(SeqCst);
+    }
+}
+
+impl Drop for SecureVec {
+    fn drop(&mut self) {
+        self.scramble();
+    }
+}
+
+impl From<Vec<u8>> for SecureVec {
+    fn from(inner: Vec<u8>) -> SecureVec {
+        SecureVec(inner)
+    }
+}
+
+impl Deref for SecureVec {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// A `String` that gets scrambled on drop.
+///
+/// Uses the basic idea (write_volatile + compiler_fence)
+/// from @bascule's zeroize crate but overwrites data with
+/// random bytes instead of zeros.
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub(crate) struct SecureString(String);
+
+impl SecureString {
+    pub(crate) fn scramble(&mut self) {
+        let mut rng = thread_rng();
+
+        #[allow(unsafe_code)]
+        unsafe {
+            for byte in self.0.as_bytes_mut() {
+                write_volatile(byte, rng.gen());
+            }
+        }
+        compiler_fence(SeqCst);
+    }
+}
+
+impl Drop for SecureString {
+    fn drop(&mut self) {
+        self.scramble();
+    }
+}
+
+impl fmt::Debug for SecureString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_map().entry(&"secure_data", &"***********").finish()
+    }
+}
+
+impl From<String> for SecureString {
+    fn from(inner: String) -> SecureString {
+        SecureString(inner)
+    }
+}
+
+impl Deref for SecureString {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -201,10 +201,12 @@ impl Server {
         let info = crate::parser::expect_info(&mut stream)?;
 
         if !info.nonce.is_empty() {
-            let nkey = nkey.unwrap();
-            let sig = nkey.sign(info.nonce.as_bytes()).unwrap();
-            let sig = base64_url::encode(&sig);
-            connect_op.sig = Some(sig);
+            if let Some(nkey) = nkey {
+                let sig = nkey.sign(info.nonce.as_bytes())
+                    .map_err(|err| Error::new(ErrorKind::Other, err))?;
+                let sig = base64_url::encode(&sig);
+                connect_op.sig = Some(sig);
+            }
         }
 
         let op = format!(

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -118,9 +118,9 @@ impl Server {
 
             match crate::connect::connect_to_socket_addr(
                 addr,
-                self.host.clone(),
+                &self.host,
                 self.tls_required,
-                options.clone(),
+                options,
             ) {
                 Ok(result) => return Ok(result),
                 Err(e) => last_err = e,


### PR DESCRIPTION
This PR adds `ConnectionOptions::with_credentials()` that allows you to specify a `.cred` file to authenticate.

Connection options handling is becoming unwieldy - would you be okay with me doing a little bit refactoring around that? In particular, I'd like to move everything options-related into a dedicated file.