### PR TITLE
further lock down io error handling

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -19,6 +19,7 @@ fn default_echo() -> bool {
 /// Info to construct a CONNECT message.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[doc(hidden)]
+#[allow(clippy::module_name_repetitions)]
 pub struct ConnectInfo {
     /// Turns on +OK protocol acknowledgements.
     pub verbose: bool,

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -3,7 +3,7 @@ use std::{
     net::{SocketAddr, TcpStream},
 };
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     inject_io_failure,
@@ -12,9 +12,14 @@ use crate::{
     split_tls, AuthStyle, FinalizedOptions, Reader, SecureString, ServerInfo, Writer,
 };
 
+fn default_echo() -> bool {
+    true
+}
+
 /// Info to construct a CONNECT message.
-#[derive(Clone, Serialize, Debug)]
-pub(crate) struct ConnectInfo {
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[doc(hidden)]
+pub struct ConnectInfo {
     /// Turns on +OK protocol acknowledgements.
     pub verbose: bool,
 
@@ -36,7 +41,7 @@ pub(crate) struct ConnectInfo {
     /// If set to `true`, the server (version 1.2.0+) will not send originating messages from this
     /// connection to its own subscriptions. Clients should set this to `true` only for server
     /// supporting this feature, which is when proto in the INFO protocol is set to at least 1.
-    #[serde(skip_serializing_if = "is_true")]
+    #[serde(skip_serializing_if = "is_true", default = "default_echo")]
     pub echo: bool,
 
     /// The implementation language of the client.

--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -66,7 +66,7 @@ impl Inbound {
 
                 if !self.reconnect() {
                     log::error!("shutting down the system after failing to reconnect",);
-                    self.shared_state.shutdown();
+                    self.shared_state.close();
                     return;
                 }
             }
@@ -98,9 +98,7 @@ impl Inbound {
         // we must call this while holding the pongs lock to ensure that
         // any calls to `Connection::flush` / `Connection::flush_timeout`
         // witness a disconnected outbound buffer state
-        self.shared_state
-            .outbound
-            .transition_to_disconnected(self.shared_state.options.reconnect_buffer_size);
+        self.shared_state.outbound.transition_to_disconnected();
 
         // flush outstanding pongs
         while let Some(s) = pongs.pop_front() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,9 @@ use serde::Deserialize;
 
 pub use subscription::Subscription;
 
+#[doc(hidden)]
+pub use connect::ConnectInfo;
+
 use {
     inbound::{Inbound, Reader},
     outbound::{Outbound, Writer},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,7 +654,7 @@ pub(crate) struct ShutdownDropper {
 
 impl Drop for ShutdownDropper {
     fn drop(&mut self) {
-        self.shared_state.shutdown();
+        self.shared_state.close();
 
         inject_delay();
         if let Some(mut threads) = self.shared_state.threads.lock().take() {
@@ -1057,7 +1057,7 @@ impl Connection {
     /// # }
     /// ```
     pub fn close(self) {
-        self.shared_state.shutdown()
+        self.shared_state.close()
     }
 
     /// Calculates the round trip time between this client and the server,

--- a/src/secure_wipe.rs
+++ b/src/secure_wipe.rs
@@ -80,8 +80,11 @@ impl Deref for SecureVec {
 /// Uses the basic idea (`write_volatile` + `compiler_fence`)
 /// from @bascule's zeroize crate but overwrites data with
 /// random bytes instead of zeros.
+///
+/// Public + hidden for testing purposes.
 #[derive(Clone, Default, Deserialize, Serialize)]
-pub(crate) struct SecureString(String);
+#[doc(hidden)]
+pub struct SecureString(String);
 
 impl SecureString {
     pub(crate) fn scramble(&mut self) {

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -176,7 +176,7 @@ impl SharedState {
 
         let (reader, writer, info) = connected_opt.unwrap();
 
-        let outbound = Outbound::new(writer);
+        let outbound = Outbound::new(writer, options.reconnect_buffer_size);
 
         let learned_servers = parse_server_addresses(&info.connect_urls);
 
@@ -216,8 +216,8 @@ impl SharedState {
         Ok(shared_state)
     }
 
-    pub(crate) fn shutdown(&self) {
+    pub(crate) fn close(&self) {
         self.shutting_down.store(true, Ordering::Release);
-        self.outbound.shutdown();
+        self.outbound.close();
     }
 }

--- a/tests/reconnection.rs
+++ b/tests/reconnection.rs
@@ -6,6 +6,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc, Barrier,
     },
+    thread,
     time::{Duration, Instant},
 };
 
@@ -133,7 +134,7 @@ fn bad_server(
                 continue;
             }
 
-            if client.has_sent_ping && client.last_ping.elapsed() > Duration::from_millis(50) {
+            if client.has_sent_ping && client.last_ping.elapsed() > Duration::from_micros(50) {
                 if client.socket.write_all(b"PING\r\n").is_err() {
                     to_evict.push(*client_id);
                     continue;
@@ -155,8 +156,10 @@ fn bad_server(
                 "PONG" => {
                     assert!(client.outstanding_pings > 0);
                     client.outstanding_pings -= 1;
+                    assert_eq!(parts.next(), None);
                 }
                 "PING" => {
+                    assert_eq!(parts.next(), None);
                     if client.socket.write_all(b"PONG\r\n").is_err() {
                         to_evict.push(*client_id);
                         continue;
@@ -168,10 +171,14 @@ fn bad_server(
                         port += 1;
                     }
                 }
-                "CONNECT" => (),
+                "CONNECT" => {
+                    let _: nats::ConnectInfo = serde_json::from_str(parts.next().unwrap()).unwrap();
+                    assert_eq!(parts.next(), None);
+                }
                 "SUB" => {
                     let subject = parts.next().unwrap();
                     let sid = parts.next().unwrap();
+                    assert_eq!(parts.next(), None);
                     let entry = subs.entry(subject.to_string()).or_insert(HashSet::new());
                     entry.insert(sid.to_string());
                 }
@@ -181,6 +188,8 @@ fn bad_server(
                         (Some(subject), Some(len), None) => (subject, None, len),
                         other => panic!("unknown args: {:?}", other),
                     };
+
+                    assert_eq!(parts.next(), None);
 
                     let next_line = if let Some(next_line) = read_line(&mut client.socket) {
                         next_line
@@ -226,9 +235,10 @@ fn bad_server(
                 }
                 "UNSUB" => {
                     let sid = parts.next().unwrap();
+                    assert_eq!(parts.next(), None);
                     subs.remove(sid);
                 }
-                other => log::error!("unknown command {}", other),
+                other => panic!("unknown command {}", other),
             }
         }
 
@@ -256,8 +266,20 @@ fn reconnect_test() {
     let restart = Arc::new(AtomicBool::new(false));
     let success = Arc::new(AtomicBool::new(false));
 
+    // kill process if we take longer than 5 minutes to run the test
+    thread::spawn({
+        let success = success.clone();
+        move || {
+            thread::sleep(Duration::from_secs(5 * 60));
+            if !success.load(Ordering::Acquire) {
+                log::error!("killing process after 5 minutes");
+                std::process::exit(1);
+            }
+        }
+    });
+
     let barrier = Arc::new(Barrier::new(2));
-    let server = std::thread::spawn({
+    let server = thread::spawn({
         let barrier = barrier.clone();
         let shutdown = shutdown.clone();
         let hop_ports = false;
@@ -286,7 +308,7 @@ fn reconnect_test() {
         }
     };
 
-    let tx = std::thread::spawn({
+    let tx = thread::spawn({
         let nc = nc.clone();
         let success = success.clone();
         let shutdown = shutdown.clone();


### PR DESCRIPTION
* fix several IO error handling issues where the outbound connect buffer was not transitioned to the Disconnected state immediately after encountering an error while sending data to the server, resulting in garbled commands being sent to the server after other IO errors were encountered
* have the reconnect test send far more PINGs to stress out the client more
* have the bad test server properly assert that commands end with the expected number of words