### PR TITLE
Name all threads created for normal system operation

### DIFF
--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -200,13 +200,13 @@ impl SharedState {
         };
 
         let inbound_thread = thread::Builder::new()
-            .name("nats_inbound_read_loop".to_string())
+            .name(format!("nats_inbound_{}", shared_state.id))
             .spawn(move || inbound.read_loop())
             .expect("threads should be spawnable");
 
         let outbound_state = shared_state.clone();
         let outbound_thread = thread::Builder::new()
-            .name("nats_outbound_flush_loop".to_string())
+            .name(format!("nats_outbound_{}", shared_state.id))
             .spawn(move || outbound_state.outbound.flush_loop())
             .expect("threads should be spawnable");
 

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -199,10 +199,16 @@ impl SharedState {
             shared_state: shared_state.clone(),
         };
 
-        let inbound_thread = thread::spawn(move || inbound.read_loop());
+        let inbound_thread = thread::Builder::new()
+            .name("nats_inbound_read_loop".to_string())
+            .spawn(move || inbound.read_loop())
+            .expect("threads should be spawnable");
 
         let outbound_state = shared_state.clone();
-        let outbound_thread = thread::spawn(move || outbound_state.outbound.flush_loop());
+        let outbound_thread = thread::Builder::new()
+            .name("nats_outbound_flush_loop".to_string())
+            .spawn(move || outbound_state.outbound.flush_loop())
+            .expect("threads should be spawnable");
 
         {
             inject_delay();


### PR DESCRIPTION
Now that performance is becoming a subject of conversation, this will surface information to profilers to improve output

(screenshot from using [hotspot](https://github.com/KDAB/hotspot) w/ data generated from [cargo flamegraph](https://github.com/flamegraph-rs/flamegraph) with the command `cargo flamegraph --example nats_bench -- test -n 10000000` using the new bench tool.

#### before

![before](https://user-images.githubusercontent.com/1505488/82325638-d6de4580-99db-11ea-8c64-457ab391bc7f.png)

#### after
![after](https://user-images.githubusercontent.com/1505488/82325636-d5ad1880-99db-11ea-9fd0-5f949232d299.png)


