### PR TITLE
Use raw bytes instead of utf-8 chars in the nats_bench program

### DIFF
--- a/examples/nats_bench.rs
+++ b/examples/nats_bench.rs
@@ -75,7 +75,7 @@ fn main() -> std::io::Result<()> {
         let subject = args.subject.clone();
         threads.push(thread::spawn(move || {
             let mut rng = thread_rng();
-            let msg: String = (0..message_size).map(|_| rng.gen::<char>()).collect();
+            let msg: Vec<u8> = (0..message_size).map(|_| rng.gen::<u8>()).collect();
             barrier.wait();
             for _ in 0..messages {
                 nc.publish(&subject, &msg).unwrap();


### PR DESCRIPTION
small bugfix in the new benchmarking tool. `char` is 4 bytes, and `String` uses 1-4 bytes per char. this uses a normal `Vec<u8>` to make it similar to the go bench. @stjepang caught this while using it.