### PR TITLE
Derive Clone for Message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -777,7 +777,7 @@ pub fn connect(nats_url: &str) -> io::Result<Connection> {
 }
 
 /// A `Message` that has been published to a NATS `Subject`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Message {
     /// The NATS `Subject` that this `Message` has been published to.
     pub subject: String,


### PR DESCRIPTION
I'd like to be able to clone() this type as I've refactored out previous usage of natsclient in a project which derived clone on message. It makes it easier to clone the message to be passed around to multiple threads