### PR TITLE
Don't keep reconnecting if the initial connect fails

### DIFF
--- a/src/asynk/connection.rs
+++ b/src/asynk/connection.rs
@@ -24,7 +24,7 @@ impl Connection {
         url: &str,
         options: Options,
     ) -> io::Result<Connection> {
-        let client = Client::new(url, options)?;
+        let client = Client::connect(url, options).await?;
         client.flush().await?;
         Ok(Connection { client })
     }


### PR DESCRIPTION
With the latest client rewrite we reintroduced the annoying issue where the client keeps reconnecting if the initial connect has failed. We should fail fast because `Options` were most likely misconfigured and the connection will never be established.

The guts of `Client::connect()` are kind of gross right now, and that is partly due to the way smol is currently designed. We *must* spawn a thread running `smol::run()`, or else `Async` and `Timer` do not work. This is because `smol::run()` "drives" the I/O reactor. The next version of smol (soon to be released) will create an I/O reactor thread on its own so this will become much cleaner and we'll be able to begin connecting without spawning the client thread. I'll simplify the code, I promise!