### PR TITLE
reusable fault injection server binary

### DIFF
--- a/nats_test_server/Cargo.toml
+++ b/nats_test_server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nats_test_server"
 description = "An intentionally buggy NATS server that facilitates fault injection for testing error paths in NATS-based libraries"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Tyler Neely <tyler@nats.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/nats_test_server/Cargo.toml
+++ b/nats_test_server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nats_test_server"
 description = "An intentionally buggy NATS server that facilitates fault injection for testing error paths in NATS-based libraries"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Tyler Neely <tyler@nats.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,3 +14,4 @@ log = "0.4.8"
 serde_json = "1.0.55"
 serde = "1.0.114"
 serde_derive = "1.0.114"
+env_logger = "0.7.1"

--- a/nats_test_server/src/bin/nats_test_server.rs
+++ b/nats_test_server/src/bin/nats_test_server.rs
@@ -1,0 +1,77 @@
+const USAGE: &str = "
+Usage: nats_test_server [--host=<s>] [--port=<#>] [--hop-ports] [--bugginess=<s>]
+
+Options:
+    --host=<s>      Host to listen on [default: 0.0.0.0].
+    --port=<n>      Port to listen on [default: 4222].
+    --bugginess=<#> 1 in <bugginess> operations will fail [default: 200].
+    --hop-ports     Hop ports to test client server learning [default: false].
+";
+
+#[derive(Clone, Debug)]
+struct Args {
+    port: u16,
+    host: String,
+    bugginess: u32,
+    hop_ports: bool,
+}
+
+impl Default for Args {
+    fn default() -> Args {
+        Args {
+            port: 4222,
+            host: "0.0.0.0".into(),
+            bugginess: 200,
+            hop_ports: false,
+        }
+    }
+}
+
+fn parse<'a, I, T>(mut iter: I) -> T
+where
+    I: Iterator<Item = &'a str>,
+    T: std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Debug,
+{
+    iter.next().expect(USAGE).parse().expect(USAGE)
+}
+
+impl Args {
+    fn parse() -> Args {
+        let mut args = Args::default();
+        for raw_arg in std::env::args().skip(1) {
+            let mut splits = raw_arg[2..].split('=');
+            match splits.next().unwrap() {
+                "host" => args.host = parse(&mut splits),
+                "port" => args.port = parse(&mut splits),
+                "bugginess" => args.bugginess = parse(&mut splits),
+                "hop-ports" => args.hop_ports = true,
+                other => panic!("unknown option: {}, {}", other, USAGE),
+            }
+        }
+        args
+    }
+}
+
+fn main() {
+    use std::sync::{atomic::AtomicBool, Arc, Barrier};
+
+    env_logger::init();
+
+    let args = Args::parse();
+    log::info!("starting test server with args {:?}", &args);
+
+    let barrier = Arc::new(Barrier::new(1));
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let restart = Arc::new(AtomicBool::new(false));
+
+    nats_test_server::nats_test_server(
+        &args.host,
+        args.port,
+        barrier,
+        shutdown,
+        restart,
+        args.bugginess,
+        args.hop_ports,
+    )
+}

--- a/nats_test_server/src/bin/nats_test_server.rs
+++ b/nats_test_server/src/bin/nats_test_server.rs
@@ -40,8 +40,8 @@ impl Args {
     fn parse() -> Args {
         let mut args = Args::default();
         for raw_arg in std::env::args().skip(1) {
-            let mut splits = raw_arg[2..].split('=');
-            match splits.next().unwrap() {
+            let mut splits = raw_arg.get(2..).expect(USAGE).split('=');
+            match splits.next().expect(USAGE) {
                 "host" => args.host = parse(&mut splits),
                 "port" => args.port = parse(&mut splits),
                 "bugginess" => args.bugginess = parse(&mut splits),
@@ -56,7 +56,7 @@ impl Args {
 fn main() {
     use std::sync::{atomic::AtomicBool, Arc, Barrier};
 
-    env_logger::init();
+    env_logger::from_env(env_logger::Env::default().default_filter_or("debug")).init();
 
     let args = Args::parse();
     log::info!("starting test server with args {:?}", &args);


### PR DESCRIPTION
this lets anyone run `cargo install nats_test_server` and get this server to test their clients against, similarly to how we tested things while writing the rust client