### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # TODO(stjepang): There's an issue with rustup installation on windows-latest.
+        # Re-enable windows-latest when it gets fixed.
+        os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Cache target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ maintenance = { status = "actively-developed" }
 panic = 'abort'
 
 [dependencies]
-async-channel = "1.1.0"
-async-dup = "1.1.0"
-async-mutex = "1.1.4"
-async-tls = "0.7.1"
-base64-url = "1.2.0"
+async-channel = "1.1.1"
+async-dup = "1.2.1"
+async-mutex = "1.1.5"
+async-tls = "0.8.0"
+base64-url = "1.4.5"
 blocking = "0.4.6"
 crossbeam-channel = "0.4.2"
 futures = "0.3.5"
@@ -41,11 +41,11 @@ regex = "1.3.9"
 rustls = "0.18.0"
 rustls-native-certs = "0.4.0"
 serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde_json = "1.0.56"
 smol = "0.1.18"
 
 [dev-dependencies]
-criterion = "0.3.2"
+criterion = "0.3.3"
 env_logger = "0.7.1"
 quicli = "0.4.0"
 structopt = "0.3.15"


### PR DESCRIPTION
The async-tls version we're using was yanked, see: https://github.com/async-rs/async-tls/issues/26

I also took this chance to update all of our dependencies.