### PR TITLE
Fix unsubscription

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ maintenance = { status = "actively-developed" }
 panic = 'abort'
 
 [dependencies]
-async-channel = "1.1.1"
+async-channel = "1.2.0"
 async-dup = "1.2.1"
 async-mutex = "1.1.5"
 async-tls = "0.8.0"

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -188,7 +188,7 @@ impl Subscription {
     /// # }
     /// ```
     pub fn unsubscribe(self) -> io::Result<()> {
-        Ok(())
+        future::block_on(self.0.unsubscribe())
     }
 
     /// Close a subscription. Same as `unsubscribe`
@@ -206,7 +206,7 @@ impl Subscription {
     /// # }
     /// ```
     pub fn close(self) -> io::Result<()> {
-        Ok(())
+        self.unsubscribe()
     }
 
     /// Send an unsubscription then flush the connection,


### PR DESCRIPTION
Previously, `Subscription::unsubscribe()` and `Subscription::close()` were doing nothing. This PR adds the missing logic - the subscription gets recorded in the `unsubscribed` set denoting dead subscriptions for which we haven't sent UNSUB yet. Eventually, `cleanup_subscriptions()` will be called that collects dead subscriptions and sends UNSUB to the server.

Closes #82 