### PR TITLE
Make the asynk module public

### DIFF
--- a/CRATE.md
+++ b/CRATE.md
@@ -121,13 +121,9 @@ The minimum supported Rust version is 1.40.0.
 
 ## Sync vs Async
 
-The Rust ecosystem has a diverse set of options for async behaviors. This
-client library can be used somewhat effectively already with async runtimes
-such as async-std and tokio. Going forward we look to provide an async client.
-Publish today is mostly non-blocking, so largest API change would be around
-subscriptions being streams vs iterators by default. Also been researching
-sinks and whether or not they make sense. Would probably be a config feature
-for async and options for most runtimes like async-std and tokio.
+The Rust ecosystem has a diverse set of options for async programming. This client library can be used with any async runtime out of the box, such as async-std and tokio.
+
+The sync interface provided by this library is implemented as just a thin wrapper around its async interface. Those two interface styles look very similar, and you're free to choose whichever works best for your application.
 
 ## Features
 The following is a list of features currently supported and planned for the near future.
@@ -141,7 +137,7 @@ The following is a list of features currently supported and planned for the near
   * [X] User JWTs (NATS 2.0)
 * [X] Reconnect logic
 * [X] TLS support
-* [ ] Direct async support
+* [X] Direct async support
 * [X] Crates.io listing
 * [ ] Header Support
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ The minimum supported Rust version is 1.40.0.
 
 ## Sync vs Async
 
-The Rust ecosystem has a diverse set of options for async behaviors. This client library can be used somewhat effectively already with async runtimes such as async-std and tokio. Going forward we look to provide an async client. Publish today is mostly non-blocking, so largest API change would be around subscriptions being streams vs iterators by default. Also been researching sinks and whether or not they make sense. Would probably be a config feature for async wnd options for most runtimes like async-std and tokio.
+The Rust ecosystem has a diverse set of options for async programming. This client library can be used with any async runtime out of the box, such as async-std and tokio.
+
+The sync interface provided by this library is implemented as just a thin wrapper around its async interface. Those two interface styles look very similar, and you're free to choose whichever works best for your application.
 
 ## Features
 The following is a list of features currently supported and planned for the near future.
@@ -127,7 +129,7 @@ The following is a list of features currently supported and planned for the near
   * [X] User JWTs (NATS 2.0)
 * [X] Reconnect logic
 * [X] TLS support
-* [ ] Direct async support
+* [X] Direct async support
 * [X] Crates.io listing
 * [ ] Header Support
 

--- a/src/asynk/mod.rs
+++ b/src/asynk/mod.rs
@@ -1,4 +1,4 @@
-//! A proof-of-concept client based on smol.
+//! Asynchronous interface for the NATS client.
 
 pub(crate) mod client;
 mod connection;
@@ -7,6 +7,24 @@ mod message;
 mod proto;
 mod subscription;
 
+use std::io;
+
 pub use connection::Connection;
 pub use message::Message;
 pub use subscription::Subscription;
+
+/// Connect to a NATS server at the given url.
+///
+/// # Example
+///
+/// ```
+/// # fn main() -> std::io::Result<()> {
+/// # smol::run(async {
+/// let nc = nats::asynk::connect("demo.nats.io").await?;
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub async fn connect(nats_url: &str) -> io::Result<Connection> {
+    crate::Options::new().connect_async(nats_url).await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ use smol::{future, prelude::*, Timer};
 
 use crate::asynk::client::Client;
 
-mod asynk;
+pub mod asynk;
 mod connect;
 mod creds_utils;
 mod headers;

--- a/src/options.rs
+++ b/src/options.rs
@@ -243,8 +243,24 @@ impl Options {
         )?))
     }
 
-    /// Establishes a `Connection` with a NATS server asynchronously.
-    #[doc(hidden)]
+    /// Establish a `Connection` with a NATS server asynchronously.
+    ///
+    /// Multiple servers may be specified by separating
+    /// them with commas.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> std::io::Result<()> {
+    /// # smol::run(async {
+    /// let options = nats::Options::new();
+    /// let nc = options
+    ///     .connect_async("nats://demo.nats.io:4222,tls://demo.nats.io:4443")
+    ///     .await?;
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn connect_async(self, nats_url: &str) -> io::Result<asynk::Connection> {
         asynk::Connection::connect_with_options(nats_url, self).await
     }


### PR DESCRIPTION
This PR finally exposes the long-awaited async interface for the NATS client. :)

Will publish a new version of the crate when this PR gets merged. 