### PR TITLE
Fix Mutex usage in asynk::client::cleanup_subscriptions function.

### DIFF
--- a/src/asynk/client.rs
+++ b/src/asynk/client.rs
@@ -557,7 +557,10 @@ impl Client {
 
     /// Sends UNSUB for dead subscriptions.
     async fn cleanup_subscriptions(&self, state: &mut async_mutex::MutexGuard<'_, State>) {
-        for sid in mem::replace(&mut *self.unsubscribed.lock().unwrap(), HashSet::new()) {
+        // Keep unsubscribed list in separate variable so it won't be captured by for loop context.
+        let unsubscribed = mem::replace(&mut *self.unsubscribed.lock().unwrap(), HashSet::new());
+        
+        for sid in unsubscribed {
             // Remove the subscription from the map.
             state.subscriptions.remove(&sid);
 


### PR DESCRIPTION
Fix mutex usage for https://github.com/nats-io/nats.rs/issues/92 

MutexGuard for unsubscribed list was captured by for loop context.