### PR TITLE
Update smol

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,5 +80,5 @@ jobs:
       run: |
         set -eo pipefail
         echo "msrv check"
-        rustup install 1.40.0
-        cargo +1.40.0 check
+        rustup install 1.41.0
+        cargo +1.41.0 check

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target/
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,12 @@ rustls-native-certs = "0.4.0"
 [dev-dependencies]
 criterion = "0.3.3"
 env_logger = "0.7.1"
-quicli = "0.4.0"
-structopt = "0.3.15"
 nats_test_server = { path = "nats_test_server" }
+quicli = "0.4.0"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
+smol = "1.0.0"
+structopt = "0.3.15"
 
 [[bench]]
 name = "nats_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,10 @@ maintenance = { status = "actively-developed" }
 panic = 'abort'
 
 [dependencies]
-async-channel = "1.2.0"
 async-dup = "1.2.1"
-async-mutex = "1.1.5"
 async-tls = "0.8.0"
 base64-url = "1.4.5"
 crossbeam-channel = "0.4.2"
-futures-channel = "0.3.5"
 itoa = "0.4.6"
 lazy_static = "1.4.0"
 log = "0.4.8"
@@ -41,7 +38,7 @@ rustls = "0.18.0"
 rustls-native-certs = "0.4.0"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
-smol = "0.3.3"
+smol = "1.0.0"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ panic = 'abort'
 
 [dependencies]
 async-dup = "1.2.1"
-async-tls = { path = "../async-tls", default-features = false, features = ["client"] }
+async-tls = { version = "0.10.0", default-features = false, features = ["client"] }
 base64-url = "1.4.5"
 crossbeam-channel = "0.4.2"
 itoa = "0.4.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,16 @@ maintenance = { status = "actively-developed" }
 panic = 'abort'
 
 [dependencies]
+async-channel = "1.4.2"
 async-dup = "1.2.1"
+async-executor = "1.0.0"
+async-io = "1.0.1"
+async-mutex = "1.3.0"
+async-net = "1.2.0"
 async-tls = { version = "0.10.0", default-features = false, features = ["client"] }
 base64-url = "1.4.5"
 crossbeam-channel = "0.4.2"
+futures-lite = "1.3.0"
 itoa = "0.4.6"
 json = "0.12.4"
 log = "0.4.8"
@@ -36,7 +42,6 @@ rand = "0.7.3"
 regex = { version = "1.3.9", default-features = false, features = ["std"] }
 rustls = "0.18.0"
 rustls-native-certs = "0.4.0"
-smol = "1.0.0"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,19 @@ panic = 'abort'
 
 [dependencies]
 async-dup = "1.2.1"
-async-tls = "0.8.0"
+async-tls = { path = "../async-tls", default-features = false, features = ["client"] }
 base64-url = "1.4.5"
 crossbeam-channel = "0.4.2"
 itoa = "0.4.6"
-lazy_static = "1.4.0"
+json = "0.12.4"
 log = "0.4.8"
 nkeys = "0.0.9"
 nuid = "0.2.1"
 once_cell = "1.4.0"
 rand = "0.7.3"
-regex = "1.3.9"
+regex = { version = "1.3.9", default-features = false, features = ["std"] }
 rustls = "0.18.0"
 rustls-native-certs = "0.4.0"
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.56"
 smol = "1.0.0"
 
 [dev-dependencies]
@@ -46,6 +44,8 @@ env_logger = "0.7.1"
 quicli = "0.4.0"
 structopt = "0.3.15"
 nats_test_server = { path = "nats_test_server" }
+serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0.56"
 
 [[bench]]
 name = "nats_bench"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ let response = rsub.iter().take(1);
 
 ## Minimum Supported Rust Version (MSRV)
 
-The minimum supported Rust version is 1.40.0.
+The minimum supported Rust version is 1.41.0.
 
 ## Sync vs Async
 

--- a/src/asynk/client.rs
+++ b/src/asynk/client.rs
@@ -7,9 +7,8 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use smol::io::{AssertAsync, BufReader, BufWriter};
-use smol::{channel, future, lock, prelude::*, stream, Executor, Timer};
-
+use crate::smol::io::{AssertAsync, BufReader, BufWriter};
+use crate::smol::{self, channel, future, lock, prelude::*, stream, Executor, Timer};
 use crate::asynk::connector::Connector;
 use crate::asynk::message::Message;
 use crate::asynk::proto::{self, ClientOp, ServerOp};

--- a/src/asynk/client.rs
+++ b/src/asynk/client.rs
@@ -7,11 +7,11 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use crate::smol::io::{AssertAsync, BufReader, BufWriter};
-use crate::smol::{self, channel, future, lock, prelude::*, stream, Executor, Timer};
 use crate::asynk::connector::Connector;
 use crate::asynk::message::Message;
 use crate::asynk::proto::{self, ClientOp, ServerOp};
+use crate::smol::io::{AssertAsync, BufReader, BufWriter};
+use crate::smol::{self, channel, future, lock, prelude::*, stream, Executor, Timer};
 use crate::{inject_delay, inject_io_failure, Headers, Options, ServerInfo};
 
 /// Client state.

--- a/src/asynk/connection.rs
+++ b/src/asynk/connection.rs
@@ -2,8 +2,7 @@ use std::io::{self, Error, ErrorKind};
 use std::net::IpAddr;
 use std::time::{Duration, Instant};
 
-use smol::{prelude::*, Timer};
-
+use crate::smol::{prelude::*, Timer};
 use crate::asynk::client::Client;
 use crate::asynk::message::Message;
 use crate::asynk::subscription::Subscription;

--- a/src/asynk/connection.rs
+++ b/src/asynk/connection.rs
@@ -2,9 +2,7 @@ use std::io::{self, Error, ErrorKind};
 use std::net::IpAddr;
 use std::time::{Duration, Instant};
 
-use smol::future::FutureExt;
-use smol::stream::StreamExt;
-use smol::Timer;
+use smol::{prelude::*, Timer};
 
 use crate::asynk::client::Client;
 use crate::asynk::message::Message;
@@ -103,7 +101,7 @@ impl Connection {
         self.client
             .flush()
             .or(async {
-                Timer::new(timeout).await;
+                Timer::after(timeout).await;
                 Err(ErrorKind::TimedOut.into())
             })
             .await

--- a/src/asynk/connection.rs
+++ b/src/asynk/connection.rs
@@ -2,10 +2,10 @@ use std::io::{self, Error, ErrorKind};
 use std::net::IpAddr;
 use std::time::{Duration, Instant};
 
-use crate::smol::{prelude::*, Timer};
 use crate::asynk::client::Client;
 use crate::asynk::message::Message;
 use crate::asynk::subscription::Subscription;
+use crate::smol::{prelude::*, Timer};
 use crate::{Headers, Options};
 
 const DEFAULT_FLUSH_TIMEOUT: Duration = Duration::from_secs(10);

--- a/src/asynk/connector.rs
+++ b/src/asynk/connector.rs
@@ -9,9 +9,9 @@ use std::time::Duration;
 use async_tls::TlsConnector;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use rustls::ClientConfig;
-use smol::io::BufReader;
-use smol::{net, prelude::*, Timer};
 
+use crate::smol::io::BufReader;
+use crate::smol::{net, prelude::*, Timer};
 use crate::asynk::proto::{self, ClientOp, ServerOp};
 use crate::secure_wipe::SecureString;
 use crate::{connect::ConnectInfo, inject_io_failure, AuthStyle, Options, ServerInfo};

--- a/src/asynk/connector.rs
+++ b/src/asynk/connector.rs
@@ -10,10 +10,10 @@ use async_tls::TlsConnector;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use rustls::ClientConfig;
 
-use crate::smol::io::BufReader;
-use crate::smol::{net, prelude::*, Timer};
 use crate::asynk::proto::{self, ClientOp, ServerOp};
 use crate::secure_wipe::SecureString;
+use crate::smol::io::BufReader;
+use crate::smol::{net, prelude::*, Timer};
 use crate::{connect::ConnectInfo, inject_io_failure, AuthStyle, Options, ServerInfo};
 
 /// Maintains a list of servers and establishes connections.

--- a/src/asynk/connector.rs
+++ b/src/asynk/connector.rs
@@ -2,7 +2,6 @@ use std::cmp;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::io::{self, Error, ErrorKind};
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -10,7 +9,8 @@ use std::time::Duration;
 use async_tls::TlsConnector;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use rustls::ClientConfig;
-use smol::{io::BufReader, prelude::*, Async, Timer};
+use smol::io::BufReader;
+use smol::{net, prelude::*, Timer};
 
 use crate::asynk::proto::{self, ClientOp, ServerOp};
 use crate::secure_wipe::SecureString;
@@ -110,8 +110,8 @@ impl Connector {
                 // Resolve the server URL to socket addresses.
                 let host = server.host.clone();
                 let port = server.port;
-                let mut addrs = match smol::unblock!((host.as_str(), port).to_socket_addrs()) {
-                    Ok(addrs) => addrs.collect::<Vec<SocketAddr>>(),
+                let mut addrs = match net::resolve((host.as_str(), port)).await {
+                    Ok(addrs) => addrs,
                     Err(err) => {
                         last_err = err;
                         continue;
@@ -124,7 +124,7 @@ impl Connector {
                 for addr in addrs {
                     // Sleep for some time if this is not the first connection attempt for this
                     // server.
-                    Timer::new(sleep_duration).await;
+                    Timer::after(sleep_duration).await;
 
                     // Try connecting to this address.
                     let res = self.connect_addr(addr, server).await;
@@ -156,7 +156,7 @@ impl Connector {
     /// Attempts to establish a connection to a single socket address.
     async fn connect_addr(
         &self,
-        addr: SocketAddr,
+        addr: net::SocketAddr,
         server: &Server,
     ) -> io::Result<(
         ServerInfo,
@@ -167,7 +167,7 @@ impl Connector {
         inject_io_failure()?;
 
         // Connect to the remote socket.
-        let mut stream = Async::<TcpStream>::connect(addr).await?;
+        let mut stream = net::TcpStream::connect(addr).await?;
 
         // Expect an INFO message.
         let mut line = crate::SecureVec::with_capacity(512);
@@ -211,7 +211,6 @@ impl Connector {
             (Box::pin(stream.clone()), Box::pin(stream))
         } else {
             // Split the TCP stream into a reader and a writer.
-            let stream = async_dup::Arc::new(stream);
             (Box::pin(stream.clone()), Box::pin(stream))
         };
 

--- a/src/asynk/message.rs
+++ b/src/asynk/message.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt,
-    io,
-};
+use std::{fmt, io};
 
 use crate::{asynk::client::Client, Headers};
 

--- a/src/asynk/mod.rs
+++ b/src/asynk/mod.rs
@@ -19,7 +19,7 @@ pub use subscription::Subscription;
 ///
 /// ```
 /// # fn main() -> std::io::Result<()> {
-/// # smol::run(async {
+/// # smol::block_on(async {
 /// let nc = nats::asynk::connect("demo.nats.io").await?;
 /// # Ok(())
 /// # })

--- a/src/asynk/proto.rs
+++ b/src/asynk/proto.rs
@@ -2,8 +2,8 @@ use std::convert::TryFrom;
 use std::io::{self, Error, ErrorKind};
 use std::str::FromStr;
 
-use crate::smol::prelude::*;
 use crate::connect::ConnectInfo;
+use crate::smol::prelude::*;
 use crate::{inject_io_failure, Headers, ServerInfo};
 
 /// A protocol operation sent by the server.

--- a/src/asynk/proto.rs
+++ b/src/asynk/proto.rs
@@ -2,8 +2,7 @@ use std::convert::TryFrom;
 use std::io::{self, Error, ErrorKind};
 use std::str::FromStr;
 
-use smol::prelude::*;
-
+use crate::smol::prelude::*;
 use crate::connect::ConnectInfo;
 use crate::{inject_io_failure, Headers, ServerInfo};
 

--- a/src/asynk/proto.rs
+++ b/src/asynk/proto.rs
@@ -72,8 +72,8 @@ pub(crate) async fn decode(mut stream: impl AsyncBufRead + Unpin) -> io::Result<
 
     if line_uppercase.starts_with("INFO") {
         // Parse the JSON-formatted server information.
-        let server_info = serde_json::from_slice(line["INFO".len()..].as_bytes())
-            .map_err(|err| Error::new(ErrorKind::InvalidInput, err))?;
+        let server_info = ServerInfo::parse(&line["INFO".len()..])
+            .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "cannot parse server info"))?;
 
         return Ok(Some(ServerOp::Info(server_info)));
     }
@@ -281,7 +281,13 @@ pub(crate) async fn encode(
 ) -> io::Result<()> {
     match &op {
         ClientOp::Connect(connect_info) => {
-            let op = format!("CONNECT {}\r\n", serde_json::to_string(&connect_info)?);
+            let op = format!(
+                "CONNECT {}\r\n",
+                connect_info.dump().ok_or_else(|| Error::new(
+                    ErrorKind::InvalidData,
+                    "cannot serialize connect info"
+                ))?
+            );
             stream.write_all(op.as_bytes()).await?;
         }
 

--- a/src/asynk/subscription.rs
+++ b/src/asynk/subscription.rs
@@ -3,7 +3,8 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use smol::stream::Stream;
+use smol::channel;
+use smol::prelude::*;
 
 use crate::asynk::client::Client;
 use crate::asynk::message::Message;
@@ -17,7 +18,7 @@ pub struct Subscription {
     pub(crate) subject: String,
 
     /// MSG operations received from the server.
-    pub(crate) messages: async_channel::Receiver<Message>,
+    pub(crate) messages: channel::Receiver<Message>,
 
     /// Client associated with subscription.
     pub(crate) client: Client,
@@ -28,7 +29,7 @@ impl Subscription {
     pub(crate) fn new(
         sid: u64,
         subject: String,
-        messages: async_channel::Receiver<Message>,
+        messages: channel::Receiver<Message>,
         client: Client,
     ) -> Subscription {
         Subscription {

--- a/src/asynk/subscription.rs
+++ b/src/asynk/subscription.rs
@@ -3,11 +3,10 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use smol::channel;
-use smol::prelude::*;
-
 use crate::asynk::client::Client;
 use crate::asynk::message::Message;
+use crate::smol::channel;
+use crate::smol::prelude::*;
 
 /// A subscription to a subject.
 pub struct Subscription {

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -15,7 +15,6 @@ pub struct ConnectInfo {
     pub user_jwt: Option<SecureString>,
 
     /// Public nkey.
-    #[serde(skip_serializing_if = "is_empty_or_none")]
     pub nkey: Option<SecureString>,
 
     /// Signed nonce, encoded to Base64URL.

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,9 +1,7 @@
-use serde::Serialize;
-
 use crate::SecureString;
 
 /// Info to construct a CONNECT message.
-#[derive(Clone, Serialize, Debug)]
+#[derive(Clone, Debug)]
 #[doc(hidden)]
 #[allow(clippy::module_name_repetitions)]
 pub struct ConnectInfo {
@@ -14,21 +12,17 @@ pub struct ConnectInfo {
     pub pedantic: bool,
 
     /// User's JWT.
-    #[serde(rename = "jwt", skip_serializing_if = "is_empty_or_none")]
     pub user_jwt: Option<SecureString>,
 
     /// Signed nonce, encoded to Base64URL.
-    #[serde(rename = "sig", skip_serializing_if = "is_empty_or_none")]
     pub signature: Option<SecureString>,
 
     /// Optional client name.
-    #[serde(skip_serializing_if = "is_empty_or_none")]
     pub name: Option<SecureString>,
 
     /// If set to `true`, the server (version 1.2.0+) will not send originating messages from this
     /// connection to its own subscriptions. Clients should set this to `true` only for server
     /// supporting this feature, which is when proto in the INFO protocol is set to at least 1.
-    #[serde(skip_serializing_if = "is_true")]
     pub echo: bool,
 
     /// The implementation language of the client.
@@ -38,35 +32,52 @@ pub struct ConnectInfo {
     pub version: String,
 
     /// Indicates whether the client requires an SSL connection.
-    #[serde(default)]
     pub tls_required: bool,
 
     /// Connection username (if `auth_required` is set)
-    #[serde(skip_serializing_if = "is_empty_or_none")]
     pub user: Option<SecureString>,
 
     /// Connection password (if auth_required is set)
-    #[serde(skip_serializing_if = "is_empty_or_none")]
     pub pass: Option<SecureString>,
 
     /// Client authorization token (if auth_required is set)
-    #[serde(skip_serializing_if = "is_empty_or_none")]
     pub auth_token: Option<SecureString>,
 
     /// Whether the client supports the usage of headers.
     pub headers: bool,
 }
 
-#[allow(clippy::trivially_copy_pass_by_ref)]
-const fn is_true(field: &bool) -> bool {
-    *field
-}
-
-#[allow(clippy::trivially_copy_pass_by_ref)]
-#[inline]
-fn is_empty_or_none(field: &Option<SecureString>) -> bool {
-    match field {
-        Some(inner) => inner.is_empty(),
-        None => true,
+impl ConnectInfo {
+    pub(crate) fn dump(&self) -> Option<String> {
+        let mut obj = json::object! {
+            verbose: self.verbose,
+            pedantic: self.pedantic,
+            lang: self.lang.clone(),
+            version: self.version.clone(),
+            tls_required: self.tls_required,
+            headers: self.headers,
+        };
+        if let Some(s) = &self.user_jwt {
+            obj.insert("jwt", s.to_string()).ok()?;
+        }
+        if let Some(s) = &self.signature {
+            obj.insert("sig", s.to_string()).ok()?;
+        }
+        if let Some(s) = &self.name {
+            obj.insert("name", s.to_string()).ok()?;
+        }
+        if self.echo {
+            obj.insert("echo", true).ok()?;
+        }
+        if let Some(s) = &self.user {
+            obj.insert("user", s.to_string()).ok()?;
+        }
+        if let Some(s) = &self.pass {
+            obj.insert("pass", s.to_string()).ok()?;
+        }
+        if let Some(s) = &self.auth_token {
+            obj.insert("auth_token", s.to_string()).ok()?;
+        }
+        Some(obj.dump())
     }
 }

--- a/src/fault_injection.rs
+++ b/src/fault_injection.rs
@@ -4,7 +4,7 @@ use std::io::{self, Error, ErrorKind};
 use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
 use rand::{thread_rng, Rng};
-use smol::Timer;
+use crate::smol::Timer;
 
 /// This function is useful for inducing random jitter into our operations that trigger
 /// cross-thread communication, shaking out more possible interleavings quickly. It gets fully

--- a/src/fault_injection.rs
+++ b/src/fault_injection.rs
@@ -3,8 +3,8 @@
 use std::io::{self, Error, ErrorKind};
 use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
-use rand::{thread_rng, Rng};
 use crate::smol::Timer;
+use rand::{thread_rng, Rng};
 
 /// This function is useful for inducing random jitter into our operations that trigger
 /// cross-thread communication, shaking out more possible interleavings quickly. It gets fully

--- a/src/fault_injection.rs
+++ b/src/fault_injection.rs
@@ -38,7 +38,7 @@ pub async fn inject_delay() {
 
         #[allow(clippy::cast_possible_truncation)]
         #[allow(clippy::cast_sign_loss)]
-        Timer::new(Duration::from_millis(duration)).await;
+        Timer::after(Duration::from_millis(duration)).await;
     }
 
     if thread_rng().gen_ratio(1, 2) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,7 +468,7 @@ impl Connection {
             self.0
                 .request(subject, msg)
                 .or(async {
-                    Timer::new(timeout).await;
+                    Timer::after(timeout).await;
                     Err(ErrorKind::TimedOut.into())
                 })
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,12 +181,12 @@ pub(crate) mod smol {
     pub use async_channel as channel;
     pub use async_net as net;
 
-    pub use async_executor::{Executor, Task};
-    pub use async_io::{block_on, Timer};
+    pub use async_executor::*;
+    pub use async_io::*;
     pub use futures_lite::{future, io, pin, ready, stream};
 
     pub mod lock {
-        pub use async_mutex::{Mutex, MutexGuard};
+        pub use async_mutex::*;
     }
 
     pub mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,6 @@
     clippy::path_buf_push_overwrite,
     clippy::print_stdout,
     clippy::pub_enum_variant_names,
-    clippy::redundant_closure_for_method_calls,
     clippy::shadow_reuse,
     clippy::shadow_same,
     clippy::shadow_unrelated,
@@ -380,7 +379,7 @@ impl Connection {
     /// # }
     /// ```
     pub fn subscribe(&self, subject: &str) -> io::Result<Subscription> {
-        future::block_on(self.0.subscribe(subject)).map(|s| Subscription(Arc::new(s.into())))
+        future::block_on(self.0.subscribe(subject)).map(|s| Subscription(Arc::new(s)))
     }
 
     /// Create a queue subscription for the given NATS connection.
@@ -395,7 +394,7 @@ impl Connection {
     /// ```
     pub fn queue_subscribe(&self, subject: &str, queue: &str) -> io::Result<Subscription> {
         future::block_on(self.0.queue_subscribe(subject, queue))
-            .map(|s| Subscription(Arc::new(s.into())))
+            .map(|s| Subscription(Arc::new(s)))
     }
 
     /// Publish a message on the given subject.
@@ -506,7 +505,7 @@ impl Connection {
     /// ```
     pub fn request_multi(&self, subject: &str, msg: impl AsRef<[u8]>) -> io::Result<Subscription> {
         future::block_on(self.0.request_multi(subject, msg))
-            .map(|s| Subscription(Arc::new(s.into())))
+            .map(|s| Subscription(Arc::new(s)))
     }
 
     /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,9 @@ mod options;
 mod secure_wipe;
 
 /// A subset of the smol runtime.
+///
+/// We're only using a subset because async-process requires Rust 1.45, but our minimum required
+/// Rust version is older than that.
 pub(crate) mod smol {
     pub use async_channel as channel;
     pub use async_net as net;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,9 +166,8 @@
     clippy::wrong_pub_self_convention,
 )]
 
-use smol::{future, prelude::*, Timer};
-
 use crate::asynk::client::Client;
+use crate::smol::{future, prelude::*, Timer};
 
 pub mod asynk;
 mod auth_utils;
@@ -176,6 +175,28 @@ mod connect;
 mod headers;
 mod options;
 mod secure_wipe;
+
+/// A subset of the smol runtime.
+pub(crate) mod smol {
+    pub use async_channel as channel;
+    pub use async_net as net;
+
+    pub use async_executor::{Executor, Task};
+    pub use async_io::{block_on, Timer};
+    pub use futures_lite::{future, io, pin, ready, stream};
+
+    pub mod lock {
+        pub use async_mutex::{Mutex, MutexGuard};
+    }
+
+    pub mod prelude {
+        pub use futures_lite::{AsyncBufRead, AsyncBufReadExt};
+        pub use futures_lite::{AsyncRead, AsyncReadExt};
+        pub use futures_lite::{AsyncWrite, AsyncWriteExt};
+        pub use futures_lite::{Future, FutureExt};
+        pub use futures_lite::{Stream, StreamExt};
+    }
+}
 
 #[cfg(feature = "fault_injection")]
 mod fault_injection;

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,8 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use smol::future;
-
+use crate::smol::future;
 use crate::asynk;
 use crate::auth_utils;
 use crate::secure_wipe::SecureString;

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,10 +4,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::smol::future;
 use crate::asynk;
 use crate::auth_utils;
 use crate::secure_wipe::SecureString;
+use crate::smol::future;
 
 /// Connect options.
 pub struct Options {

--- a/src/options.rs
+++ b/src/options.rs
@@ -288,7 +288,7 @@ impl Options {
     ///
     /// ```
     /// # fn main() -> std::io::Result<()> {
-    /// # smol::run(async {
+    /// # smol::block_on(async {
     /// let options = nats::Options::new();
     /// let nc = options
     ///     .connect_async("nats://demo.nats.io:4222,tls://demo.nats.io:4443")

--- a/src/secure_wipe.rs
+++ b/src/secure_wipe.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use rand::{thread_rng, Rng};
-use serde::{Deserialize, Serialize};
 
 /// A `Vec<u8>` that gets scrambled on drop.
 /// Provides a vector that will scramble allocations as
@@ -19,7 +18,7 @@ use serde::{Deserialize, Serialize};
 /// Uses the basic idea (`write_volatile` + `compiler_fence`)
 /// from @bascule's zeroize crate but overwrites data with
 /// random bytes instead of zeros.
-#[derive(Clone, Default, Deserialize, Serialize)]
+#[derive(Clone, Default)]
 pub(crate) struct SecureVec(Vec<u8>);
 
 impl SecureVec {
@@ -82,7 +81,7 @@ impl Deref for SecureVec {
 /// random bytes instead of zeros.
 ///
 /// Public + hidden for testing purposes.
-#[derive(Clone, Default, Deserialize, Serialize)]
+#[derive(Clone, Default)]
 #[doc(hidden)]
 pub struct SecureString(String);
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -67,7 +67,7 @@ impl Subscription {
                 }
             }
             .or(async {
-                Timer::new(timeout).await;
+                Timer::after(timeout).await;
                 Err(RecvTimeoutError::Timeout)
             }),
         )

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -2,8 +2,8 @@ use std::io;
 use std::{sync::Arc, thread, time::Duration};
 
 use crossbeam_channel::RecvTimeoutError;
-use smol::{future, prelude::*, Timer};
 
+use crate::smol::{future, prelude::*, Timer};
 use crate::{asynk, Message};
 
 /// A `Subscription` receives `Message`s published to specific NATS `Subject`s.

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -12,5 +12,7 @@ fn connect_failure() {
 
 #[test]
 fn connect_tls() {
-    assert!(nats::Options::new().connect("tls://demo.nats.io:4443").is_ok());
+    assert!(nats::Options::new()
+        .connect("tls://demo.nats.io:4443")
+        .is_ok());
 }


### PR DESCRIPTION
This PR updates `smol` to v1.0 and replaces `serde` with `json`.

Compilation times are cut roughly in half on my 8-core machine, which means a debug build now takes 27 seconds. There are still ways to go, but it seems that the largest part of compilation is related to crypto stuff (`nkeys` and `async-tls`), which will be difficult to trim down. `smol` itself takes up only around 5 seconds.