### PR TITLE
Remove crossbeam-channel from the public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ async-mutex = "1.3.0"
 async-net = "1.2.0"
 async-tls = { version = "0.10.0", default-features = false, features = ["client"] }
 base64-url = "1.4.5"
-crossbeam-channel = "0.4.2"
 futures-lite = "1.3.0"
 itoa = "0.4.6"
 json = "0.12.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,7 +581,7 @@ impl Connection {
     /// # }
     /// ```
     pub fn close(self) {
-        let _ = future::block_on(self.0.close());
+        future::block_on(self.0.close()).ok();
     }
 
     /// Calculates the round trip time between this client and the server,


### PR DESCRIPTION
We're not using `crossbeam-channel` anywhere, and yet there were some remnants of it our public API. I'm removing those and also removing `const` annotations on some functions that are not really useful (they may only be useful on *constructors*, perhaps).

I'm planning to further clean up the API after the next release.