### PR TITLE
Fix connection leak

### DIFF
--- a/src/asynk/connection.rs
+++ b/src/asynk/connection.rs
@@ -190,3 +190,9 @@ impl Connection {
         ))
     }
 }
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        self.client.shutdown();
+    }
+}


### PR DESCRIPTION
This problem was reported by @dontlaugh on Slack (#rust channel),

The issue is that dropping `Connection` does not trigger thread shutdown, so if you drop it without calling `.close().await` on it, the thread simply keeps running and therefore keeps holding an active NATS connection.

The solution is to signal to the thread that it must shutdown when `Connection` is dropped.