### PR TITLE
Flush before dropping the connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,3 +687,10 @@ impl Connection {
         ))
     }
 }
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // Flush to make sure buffered published messages reach the server.
+        future::block_on(self.0.flush()).ok();
+    }
+}

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -1,0 +1,39 @@
+use std::io;
+
+use smol::prelude::*;
+
+#[test]
+fn sync_drop_flushes() -> io::Result<()> {
+    let nc1 = nats::connect("demo.nats.io")?;
+    let nc2 = nats::connect("demo.nats.io")?;
+
+    let inbox = nc1.new_inbox();
+    let sub = nc2.subscribe(&inbox)?;
+    nc2.flush()?;
+
+    nc1.publish(&inbox, b"hello")?;
+    drop(nc1); // Dropping should flush the published message.
+
+    assert_eq!(sub.next().unwrap().data, b"hello");
+
+    Ok(())
+}
+
+#[test]
+fn async_drop_flushes() -> io::Result<()> {
+    smol::block_on(async {
+        let nc1 = nats::asynk::connect("demo.nats.io").await?;
+        let nc2 = nats::asynk::connect("demo.nats.io").await?;
+
+        let inbox = nc1.new_inbox();
+        let mut sub = nc2.subscribe(&inbox).await?;
+        nc2.flush().await?;
+
+        nc1.publish(&inbox, b"hello").await?;
+        drop(nc1); // Dropping doesn't flush, but the client thread will flush before shutdown.
+
+        assert_eq!(sub.next().await.unwrap().data, b"hello");
+
+        Ok(())
+    })
+}


### PR DESCRIPTION
Discussed this with @derekcollison - I'm proposing a simple solution here. Changes:

1. When `nats::Connection` is dropped, we flush (and wait for the flush to complete).
2. When `nats::asynk::Connection` is dropped, we let the client thread asynchronously flush (but we don't wait for it).

cc @andrewbanchich 