### PR TITLE
Fix regex usage by enabling the unicode-perl feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.8.4
+
+## Bug Fixes
+
+- #123 Fix regex error when parsing creds due to missing
+  the `unicode-perl` feature flag on the regex crate.
+
 # 0.8.3
 
 ## New Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nats"
-version = "0.8.3"
+version = "0.8.4"
 description = "A Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ log = "0.4.8"
 nkeys = "0.0.11"
 nuid = "0.2.1"
 once_cell = "1.4.0"
-regex = { version = "1.3.9", default-features = false, features = ["std"] }
+regex = { version = "1.3.9", default-features = false, features = ["std", "unicode-perl"] }
 rustls-native-certs = "0.4.0"
 
 [dev-dependencies]


### PR DESCRIPTION
fixes issue when using the regex crate to process creds:
```
 Running `target/release/ngs-usage-server-rs`
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
regex parse error:
    \s*(?:(?:[-]{3,}.*[-]{3,}\r?\n)([\w\-.=]+)(?:\r?\n[-]{3,}.*[-]{3,}\r?\n))
    ^^
error: Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
)', /home/t/.cargo/registry/src/github.com-1ecc6299db9ec823/nats-0.8.3/src/auth_utils.rs:67:10
stack backtrace:
   0: rust_begin_unwind
             at /rustc/1773f60ea5d42e86b8fdf78d2fc5221ead222bc1/library/std/src/panicking.rs:495:5
   1: core::panicking::panic_fmt
             at /rustc/1773f60ea5d42e86b8fdf78d2fc5221ead222bc1/library/core/src/panicking.rs:92:14
   2: core::option::expect_none_failed
             at /rustc/1773f60ea5d42e86b8fdf78d2fc5221ead222bc1/library/core/src/option.rs:1268:5
   3: core::ops::function::FnOnce::call_once
   4: once_cell::imp::OnceCell<T>::initialize::{{closure}}
   5: once_cell::imp::initialize_inner
   6: once_cell::imp::OnceCell<T>::initialize
   7: nats::auth_utils::load_creds
   8: nats::options::Options::with_credentials::{{closure}}
   9: nats::asynk::connector::Connector::connect_addr::{{closure}
```