### PR TITLE
Add latency breakdown for nats_bech test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ quicli = "0.4.0"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 structopt = "0.3.15"
+historian = "4.0"
+lazy_static = "1.4"
 
 [[bench]]
 name = "nats_bench"

--- a/examples/nats_bench.rs
+++ b/examples/nats_bench.rs
@@ -131,7 +131,7 @@ fn main() -> std::io::Result<()> {
         end, frequency, mbps
     );
 
-    println!("publish latency breakdown in microseconds:");
+    println!("publish latency breakdown in nanoseconds:");
     println!("                min: {:10.0} ns", HISTOGRAM.percentile(0.0));
     for pctl in &[50., 75., 90., 95., 97.5, 99.0, 99.99, 99.999] {
         println!(


### PR DESCRIPTION
cc @derekcollison 
```
λ cargo run --example=nats_bench --release -- test --number-of-messages=100000000
    Finished release [optimized] target(s) in 0.05s
     Running `target/release/examples/nats_bench test --number-of-messages=100000000`
Starting benchmark [msgs=100000000, msgsize=128, pubs=1, subs=0]
duration: 18.103644136s frequency: 5523946 mbps: 690
latency breakdown in microseconds:
                min:         65 ns
    50th percentile:         94 ns
    75th percentile:         95 ns
    90th percentile:        100 ns
    95th percentile:        108 ns
  97.5th percentile:        115 ns
    99th percentile:        127 ns
 99.99th percentile:      26369 ns
99.999th percentile:      34543 ns
                max:     830679 ns
```
(above numbers targeting a local 2.1.6 nats server)