### PR TITLE
Fix the no_echo setting

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -57,6 +57,7 @@ impl ConnectInfo {
         let mut obj = json::object! {
             verbose: self.verbose,
             pedantic: self.pedantic,
+            echo: self.echo,
             lang: self.lang.clone(),
             version: self.version.clone(),
             tls_required: self.tls_required,
@@ -73,9 +74,6 @@ impl ConnectInfo {
         }
         if let Some(s) = &self.name {
             obj.insert("name", s.to_string()).ok()?;
-        }
-        if self.echo {
-            obj.insert("echo", true).ok()?;
         }
         if let Some(s) = &self.user {
             obj.insert("user", s.to_string()).ok()?;


### PR DESCRIPTION
Just a really silly bug... The "echo" option was specified only when set to true, but it should've been specified when it's false because true is the default. Now we always specify it in the NATS protocol.

Fixes #147 