### PR TITLE
Give access to Subscription's crossbeam channel

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -50,6 +50,34 @@ impl Subscription {
         }))
     }
 
+    /// Get a crossbeam Receiver for subscription messages.
+    /// Useful for crossbeam_channel::select macro
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> std::io::Result<()> {
+    /// # let nc = nats::connect("demo.nats.io")?;
+    /// # let sub1 = nc.subscribe("foo")?;
+    /// # let sub2 = nc.subscribe("bar")?;
+    /// # nc.publish("foo", "hello")?;
+    /// let sub1_ch = sub1.receiver();
+    /// let sub2_ch = sub2.receiver();
+    /// crossbeam_channel::select! {
+    ///     recv(sub1_ch) -> msg {
+    ///         println!("Got message from sub1: {:?}", msg);
+    ///         Ok(())
+    ///     }
+    ///     recv(sub2_ch) -> msg {
+    ///         println!("Got message from sub2: {:?}", msg);
+    ///         Ok(())
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    pub fn receiver(&self) -> &channel::Receiver<Message> {
+        &self.0.messages
+    }
+
     /// Get the next message, or None if the subscription
     /// has been unsubscribed or the connection closed.
     ///

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -63,11 +63,11 @@ impl Subscription {
     /// let sub1_ch = sub1.receiver();
     /// let sub2_ch = sub2.receiver();
     /// crossbeam_channel::select! {
-    ///     recv(sub1_ch) -> msg {
+    ///     recv(sub1_ch) -> msg => {
     ///         println!("Got message from sub1: {:?}", msg);
     ///         Ok(())
     ///     }
-    ///     recv(sub2_ch) -> msg {
+    ///     recv(sub2_ch) -> msg => {
     ///         println!("Got message from sub2: {:?}", msg);
     ///         Ok(())
     ///     }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -51,7 +51,7 @@ impl Subscription {
     }
 
     /// Get a crossbeam Receiver for subscription messages.
-    /// Useful for crossbeam_channel::select macro
+    /// Useful for `crossbeam_channel::select` macro
     ///
     /// # Example
     /// ```


### PR DESCRIPTION
Gives access to the a crossbeam Receiver in the Subscription struct. Useful for [crossbeam_channel::select][0] macro. Diff should speak for itself. I didn't find a way to select on multiple Subscriptions in one thread without access to the crossbeam channel. Is there a better way? 

Offtopic: I used the async-nats with tokio at first, but I think [async_nats::Subsciption::next][1] implementation will lose messages if canceled by [tokio::select][2].

[0]: https://docs.rs/crossbeam-channel/0.5.0/crossbeam_channel/macro.select.html
[1]: https://github.com/nats-io/nats.rs/blob/master/async-nats/src/lib.rs#L285
[2]: https://docs.rs/tokio/0.2.18/tokio/macro.select.html