### PR TITLE
Cut 0.9.9. Closes #163.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.9.9
+
+## Bug Fixes
+
+- #164 `Consumer::process_timeout` properly times out
+  from all branches.
+- #164 `Consumer::pull_opt` now properly checks the
+  `Consumer.deliver_subject`.
+
 # 0.9.8
 
 ## Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nats"
-version = "0.9.8"
+version = "0.9.9"
 description = "A Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-nats"
-version = "0.9.8"
+version = "0.9.9"
 description = "An async Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 blocking = "1.0.2"
-nats = { path = "..", version = "0.9.8" }
+nats = { path = "..", version = "0.9.9" }
 
 [dev-dependencies]
 smol = "1.2.5"

--- a/src/jetstream.rs
+++ b/src/jetstream.rs
@@ -926,7 +926,7 @@ impl Consumer {
                     return Err(Error::new(
                         ErrorKind::InvalidInput,
                         "process and process_batch are only usable from \
-                Pull-based Consumers if there is a a durable_name set",
+                        Pull-based Consumers if there is a a durable_name set",
                     ));
                 }
 
@@ -937,7 +937,7 @@ impl Consumer {
                     self.cfg.durable_name.as_ref().unwrap()
                 );
 
-                self.nc.request(&subject, b"")?
+                self.nc.request_timeout(&subject, b"", self.timeout)?
             };
 
             let next_id = next.jetstream_message_info().unwrap().stream_seq;

--- a/src/jetstream.rs
+++ b/src/jetstream.rs
@@ -1004,11 +1004,11 @@ impl Consumer {
             ));
         }
 
-        if self.cfg.deliver_subject.is_none() {
+        if self.cfg.deliver_subject.is_some() {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
                 "this method is only usable from \
-                Pull-based Consumers with a deliver_subject set",
+                Pull-based Consumers with a deliver_subject set to None",
             ));
         }
 

--- a/tests/jetstream.rs
+++ b/tests/jetstream.rs
@@ -162,14 +162,17 @@ fn jetstream_libdoc_test() {
     )
     .unwrap();
 
-    let msg_data_len: usize = consumer
+    // set this very high for CI
+    consumer.timeout = std::time::Duration::from_millis(500);
+
+    consumer
         .process(|msg| {
             println!("got message {:?}", msg);
             Ok(msg.data.len())
         })
         .unwrap();
 
-    let msg_data_len: usize = consumer
+    consumer
         .process_timeout(|msg| {
             println!("got message {:?}", msg);
             Ok(msg.data.len())

--- a/tests/jetstream.rs
+++ b/tests/jetstream.rs
@@ -140,3 +140,48 @@ fn jetstream_basics() -> io::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn jetstream_libdoc_test() {
+    use nats::jetstream::{AckPolicy, Consumer, ConsumerConfig};
+
+    let server = server();
+
+    let nc = nats::connect(&format!("localhost:{}", server.port)).unwrap();
+
+    nc.create_stream("my_stream").unwrap();
+    nc.publish("my_stream", "1").unwrap();
+    nc.publish("my_stream", "2").unwrap();
+    nc.publish("my_stream", "3").unwrap();
+    nc.publish("my_stream", "4").unwrap();
+
+    let mut consumer = Consumer::create_or_open(
+        nc,
+        "my_stream",
+        "existing_or_created_consumer",
+    )
+    .unwrap();
+
+    let msg_data_len: usize = consumer
+        .process(|msg| {
+            println!("got message {:?}", msg);
+            Ok(msg.data.len())
+        })
+        .unwrap();
+
+    let msg_data_len: usize = consumer
+        .process_timeout(|msg| {
+            println!("got message {:?}", msg);
+            Ok(msg.data.len())
+        })
+        .unwrap();
+
+    let msg = consumer.pull().unwrap();
+    msg.ack().unwrap();
+
+    let batch_size = 128;
+    let results: Vec<std::io::Result<usize>> =
+        consumer.process_batch(batch_size, |msg| Ok(msg.data.len()));
+    let flipped: std::io::Result<Vec<usize>> = results.into_iter().collect();
+    let sizes: Vec<usize> = flipped.unwrap();
+}


### PR DESCRIPTION
Fixes two JetStream related bugs:

- #164 `Consumer::process_timeout` properly times out
  from all branches.
- #164 `Consumer::pull_opt` now properly checks the
  `Consumer.deliver_subject`.