### PR TITLE
Don't split a header into more than two parts

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -120,7 +120,7 @@ impl TryFrom<&[u8]> for Headers {
         };
 
         for line in lines {
-            let splits = line.split(':').map(str::trim).collect::<Vec<_>>();
+            let splits = line.splitn(2, ':').map(str::trim).collect::<Vec<_>>();
             match splits[..] {
                 [k, v] => {
                     let entry = inner


### PR DESCRIPTION
Fixes issue #166.
