### PR TITLE
Use unpacked split-debuginfo for speeding up macos builds of the crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,11 @@ maintenance = { status = "actively-developed" }
 
 [profile.release]
 debug = true
+split-debuginfo = "unpacked"
 
 [profile.dev]
 panic = 'abort'
+split-debuginfo = "unpacked"
 
 [dependencies]
 base64 = "0.13.0"


### PR DESCRIPTION
context: https://jakedeichert.com/blog/reducing-rust-incremental-compilation-times-on-macos-by-70-percent/