### PR TITLE
A few small cleanups, including a compilation fix for a future-incompatible example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,32 @@ jobs:
           rustup update
           cargo test --doc --features=jetstream
 
+  examples:
+    name: examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Rust
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-rust
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ env.cache-name }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
+      - name: install nats-server
+        run: go get github.com/nats-io/nats-server
+      - name: JetStream test
+        env:
+          RUST_LOG: trace
+        run: |
+          rustup update
+          cargo check --examples --features=jetstream
+
   jetstream:
     name: JetStream
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.9.13
+
+## Bug Fixes
+
+- #172 fix an issue with a newly future-incompatible
+  usage of the `log` crate's macros in a match arm.
+
 # 0.9.12
 
 ## Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nats"
-version = "0.9.12"
+version = "0.9.13"
 description = "A Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-nats"
-version = "0.9.12"
+version = "0.9.13"
 description = "An async Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 blocking = "1.0.2"
-nats = { path = "..", version = "0.9.12" }
+nats = { path = "..", version = "0.9.13" }
 
 [dev-dependencies]
 smol = "1.2.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -665,7 +665,9 @@ impl Client {
                     return Err(Error::new(ErrorKind::Other, msg));
                 }
 
-                ServerOp::Unknown(line) => log::warn!("unknown op: {}", line),
+                ServerOp::Unknown(line) => {
+                    log::warn!("unknown op: {}", line);
+                }
             }
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -219,7 +219,7 @@ impl Client {
     }
 
     /// Closes the client.
-    pub(crate) fn close(&self) -> io::Result<()> {
+    pub(crate) fn close(&self) {
         // Inject random delays when testing.
         inject_delay();
 
@@ -250,8 +250,6 @@ impl Client {
             state.pongs.clear();
             drop(state);
         }
-
-        Ok(())
     }
 
     /// Kicks off the shutdown process, but doesn't wait for its completion.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,7 +580,7 @@ impl Connection {
     /// ```
     pub fn close(self) {
         self.0.client.flush(DEFAULT_FLUSH_TIMEOUT).ok();
-        self.0.client.close().ok();
+        self.0.client.close();
     }
 
     /// Calculates the round trip time between this client and the server,
@@ -697,7 +697,7 @@ impl Connection {
     /// ```
     pub fn drain(&self) -> io::Result<()> {
         self.0.client.flush(DEFAULT_FLUSH_TIMEOUT)?;
-        self.0.client.close()?;
+        self.0.client.close();
         Ok(())
     }
 


### PR DESCRIPTION
* add CI test to ensure examples always compile
* fix future incompatibility issue while using the log macro in a match arm
* avoid using a result in a return type for infallibly closing a connection