### PR TITLE
Add async request_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.9.15
+
+## Improvements
+
+- #177 Add support of request_timeout for async-nats
+
 # 0.9.14
 
 ## New Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nats"
-version = "0.9.14"
+version = "0.9.15"
 description = "A Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-nats"
-version = "0.9.14"
+version = "0.9.15"
 description = "An async Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 blocking = "1.0.2"
-nats = { path = "..", version = "0.9.14" }
+nats = { path = "..", version = "0.9.15" }
 
 [dev-dependencies]
 smol = "1.2.5"

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -160,6 +160,21 @@ impl Connection {
         Ok(Message::new(msg))
     }
 
+    /// Publishes a message and waits for the response or until the
+    /// timeout duration is reached
+    pub async fn request_timeout(
+        &self,
+        subject: &str,
+        msg: impl AsRef<[u8]>,
+        timeout: Duration,
+    ) -> io::Result<Message> {
+        let subject = subject.to_string();
+        let msg = msg.as_ref().to_vec();
+        let inner = self.inner.clone();
+        let msg = unblock(move || inner.request_timeout(&subject, msg, timeout)).await?;
+        Ok(Message::new(msg))
+    }
+
     /// Publishes a message and returns a subscription for awaiting the
     /// response.
     pub async fn request_multi(


### PR DESCRIPTION
- Add support for request_timeout in async nats

Why: 
- If we get disconnected from NATS for reason, as the lib use unblock() under the hood, the application will leak threads waiting for the operation to receive a reply that will never comeback.
- Even if we get back the connection to NATS, those threads are lost in the limbo as they will never be able to receive a reply
- Wrapping `async request` within a futures::timeout, works but does not kill the underlying threads used by unblock

What:
- The PR exposes the `request_timeout` function in async-nats 
