### PR TITLE
Use fine-grained locking on read and write-related state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
-# 0.9.15
+# 0.9.16
 
 ## Improvements
 
-- #177 Add support of request_timeout for async-nats
+- #178 client state has been reorganized to allow
+  reading and writing to make progress independently,
+  preventing issues that were sometimes encountered
+  where the act of creating a subscription would lead
+  to a connection timing out after a slow consumer
+  was detected by the server.
+
+# 0.9.15
+
+## New Features
+
+- #177 Add `request_timeout` support for async-nats
 
 # 0.9.14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nats"
-version = "0.9.15"
+version = "0.9.16"
 description = "A Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-nats"
-version = "0.9.15"
+version = "0.9.16"
 description = "An async Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 blocking = "1.0.2"
-nats = { path = "..", version = "0.9.15" }
+nats = { path = "..", version = "0.9.16" }
 
 [dev-dependencies]
 smol = "1.2.5"

--- a/examples/nats_bench.rs
+++ b/examples/nats_bench.rs
@@ -100,13 +100,15 @@ fn main() -> std::io::Result<()> {
         let nc = nc.clone();
         let subject = args.subject.clone();
         threads.push(thread::spawn(move || {
-            barrier.wait();
             let s = nc.subscribe(&subject).unwrap();
-            for _ in 0..messages {
+            barrier.wait();
+            for i in 0..messages {
                 s.next().unwrap();
             }
         }));
     }
+
+    barrier.wait();
 
     println!(
         "Starting benchmark [msgs={}, msgsize={}, pubs={}, subs={}]",
@@ -115,8 +117,6 @@ fn main() -> std::io::Result<()> {
         args.publishers.get(),
         args.subscribers
     );
-
-    barrier.wait();
 
     let start = Instant::now();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -248,8 +248,7 @@ impl Client {
         // Initiate shutdown process.
         if self.shutdown() {
             // Clear all subscriptions.
-            let old_subscriptions =
-                mem::replace(&mut read.subscriptions, HashMap::new());
+            let old_subscriptions = mem::take(&mut read.subscriptions);
             for (sid, _) in old_subscriptions {
                 // Send an UNSUB message and ignore errors.
                 if let Some(writer) = write.writer.as_mut() {
@@ -286,10 +285,7 @@ impl Client {
 
     fn check_shutdown(&self) -> io::Result<()> {
         if *self.shutdown.lock() {
-            return Err(Error::new(
-                ErrorKind::NotConnected,
-                "the client is closed",
-            ));
+            Err(Error::new(ErrorKind::NotConnected, "the client is closed"))
         } else {
             Ok(())
         }
@@ -589,7 +585,7 @@ impl Client {
         }
 
         // Take out expected PONGs.
-        let pongs = mem::replace(&mut read.pongs, VecDeque::new());
+        let pongs = mem::take(&mut read.pongs);
 
         // Take out buffered operations.
         let buffered = write.buffer.clear();

--- a/src/jetstream.rs
+++ b/src/jetstream.rs
@@ -1184,9 +1184,7 @@ impl IntervalTree {
     ///
     /// assert_eq!(gaps, vec![Range { start: 123, end: 222 }]);
     /// ```
-    pub fn gaps<'a>(
-        &'a self,
-    ) -> impl 'a + DoubleEndedIterator<Item = Range<u64>> {
+    pub fn gaps(&self) -> impl '_ + DoubleEndedIterator<Item = Range<u64>> {
         let mut iter = self.inner.iter();
         let mut last_hi = iter.next().map(|(_l, h)| *h);
         iter.map(move |(lo, hi)| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,6 @@
         missing_docs,
         nonstandard_style,
         rust_2018_idioms,
-        rustdoc::all,
         trivial_casts,
         trivial_numeric_casts,
         unsafe_code,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,20 +103,23 @@
 //! ```
 
 #![cfg_attr(test, deny(warnings))]
-#![deny(
-    future_incompatible,
-    missing_copy_implementations,
-    missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unused,
-    unused_qualifications
+#![cfg_attr(
+    feature = "fault_injection",
+    deny(
+        future_incompatible,
+        missing_copy_implementations,
+        missing_docs,
+        nonstandard_style,
+        rust_2018_idioms,
+        rustdoc::all,
+        trivial_casts,
+        trivial_numeric_casts,
+        unsafe_code,
+        unused,
+        unused_qualifications
+    )
 )]
-#![deny(
+#![cfg_attr(feature = "fault_injection", deny(
     // over time, consider enabling the following commented-out lints:
     // clippy::else_if_without_else,
     // clippy::indexing_slicing,
@@ -135,15 +138,15 @@
     clippy::explicit_iter_loop,
     clippy::expl_impl_clone_on_copy,
     clippy::fallible_impl_from,
-    clippy::filter_map,
     clippy::filter_map_next,
-    clippy::manual_find_map,
     clippy::float_arithmetic,
     clippy::get_unwrap,
     clippy::if_not_else,
     clippy::inline_always,
     clippy::invalid_upcast_comparisons,
     clippy::items_after_statements,
+    clippy::manual_filter_map,
+    clippy::manual_find_map,
     clippy::map_flatten,
     clippy::map_unwrap_or,
     clippy::match_same_arms,
@@ -170,7 +173,7 @@
     clippy::wildcard_dependencies,
     clippy::wildcard_enum_match_arm,
     clippy::wrong_pub_self_convention,
-)]
+))]
 #![allow(
     clippy::match_like_matches_macro,
     clippy::await_holding_lock,


### PR DESCRIPTION
This is the real fix for the issue encountered in benchmarks where subscriptions would cause lock-ups due to slow consumers.

This comes with the introduction of a mandatory locking protocol which must always be followed to avoid deadlocks going forward. But this is important for allowing reads and writes to make progress independently of each other, and the situations that require both locks to be held are pretty infrequent.