### PR TITLE
Test server subject matching bug fix

### DIFF
--- a/nats_test_server/src/lib.rs
+++ b/nats_test_server/src/lib.rs
@@ -552,7 +552,7 @@ fn subject_match(subject: &str, subject_pattern: &str) -> bool {
         }
         return false;
     }
-    true
+    pattern_parts.next().is_none()
 }
 
 #[test]
@@ -561,6 +561,8 @@ fn test_subject_match() {
     assert!(subject_match("sub", "*"));
     assert!(subject_match("sub", ">"));
     assert!(!subject_match("pub", "sub"));
+    assert!(!subject_match("sub", "sub.pub"));
+    assert!(!subject_match("sub", "*.pub"));
     assert!(subject_match("sub.pub", "sub.pub"));
     assert!(subject_match("sub.pub", "sub.*"));
     assert!(subject_match("sub.pub", "*.pub"));
@@ -568,6 +570,7 @@ fn test_subject_match() {
     assert!(subject_match("sub.pub", ">"));
     assert!(!subject_match("sub.pub", "sub"));
     assert!(!subject_match("sub.pub", "pub"));
+    assert!(!subject_match("sub.pub", "sub.*.pub"));
 }
 
 #[test]


### PR DESCRIPTION
Subject matching function in test server was only taking into account the number of tokens in message subject.

This caused false matches when a message's subject was a prefix of longer subscription pattern