### PR TITLE
Proposed update to enable reconnect on first attempt

### DIFF
--- a/src/asynk.rs
+++ b/src/asynk.rs
@@ -636,6 +636,28 @@ impl Options {
         }
     }
 
+    /// Select option to enable reconnect with backoff
+    /// on first failed connection attempt.
+    /// The reconnect logic with `max_reconnects` and the
+    /// `reconnect_delay_callback` will be specified the same
+    /// as before but will be invoked on the first failed
+    /// connection attempt.
+    ///
+    /// # Example
+    /// ```
+    /// # smol::block_on(async {
+    /// let nc = nats::asynk::Options::new()
+    ///     .retry_on_failed_connect()
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    pub fn retry_on_failed_connect(self) -> Options {
+        Options {
+            inner: self.inner.retry_on_failed_connect(),
+        }
+    }
+
     /// Set the maximum number of reconnect attempts.
     /// If no servers remain that are under this threshold,
     /// then no further reconnect shall be attempted.

--- a/src/client.rs
+++ b/src/client.rs
@@ -519,8 +519,9 @@ impl Client {
         let mut first_connect = true;
 
         loop {
-            // Don't use backoff on first connect.
-            let use_backoff = !first_connect;
+            //  Don't use backoff on first connect unless retry_on_failed_connect is set to true.
+            let use_backoff = self.options.retry_on_failed_connect || !first_connect;
+
             // Make a connection to the server.
             let (server_info, stream) = connector.connect(use_backoff)?;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -15,6 +15,7 @@ pub struct Options {
     pub(crate) auth: AuthStyle,
     pub(crate) name: Option<String>,
     pub(crate) no_echo: bool,
+    pub(crate) retry_on_failed_connect: bool,
     pub(crate) max_reconnects: Option<usize>,
     pub(crate) reconnect_buffer_size: usize,
     pub(crate) tls_required: bool,
@@ -36,6 +37,7 @@ impl fmt::Debug for Options {
             .entry(&"auth", &self.auth)
             .entry(&"name", &self.name)
             .entry(&"no_echo", &self.no_echo)
+            .entry(&"retry_on_failed_connect", &self.retry_on_failed_connect)
             .entry(&"reconnect_buffer_size", &self.reconnect_buffer_size)
             .entry(&"max_reconnects", &self.max_reconnects)
             .entry(&"tls_required", &self.tls_required)
@@ -57,6 +59,7 @@ impl Default for Options {
             auth: AuthStyle::NoAuth,
             name: None,
             no_echo: false,
+            retry_on_failed_connect: false,
             reconnect_buffer_size: 8 * 1024 * 1024,
             max_reconnects: Some(60),
             tls_required: false,
@@ -380,6 +383,27 @@ impl Options {
     /// ```
     pub fn no_echo(mut self) -> Options {
         self.no_echo = true;
+        self
+    }
+
+    /// Select option to enable reconnect with backoff
+    /// on first failed connection attempt.
+    /// The reconnect logic with `max_reconnects` and the
+    /// `reconnect_delay_callback` will be specified the same
+    /// as before but will be invoked on the first failed
+    /// connection attempt.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> std::io::Result<()> {
+    /// let nc = nats::Options::new()
+    ///     .retry_on_failed_connect()
+    ///     .connect("demo.nats.io")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn retry_on_failed_connect(mut self) -> Options {
+        self.retry_on_failed_connect = true;
         self
     }
 


### PR DESCRIPTION
We have had issues connecting on the first attempt, similar to issue brought up in the past:
https://github.com/nats-io/nats.rs/issues/99

We modified the nats.rs to enable us to enter the retry loop on the first connection attempt.  Our application behavior is such that we do not require the NatsServer be up and running when we start.  This change allows for that behavior.