### PR TITLE
fix: add read and write timeouts to the tcp stream

### DIFF
--- a/src/asynk.rs
+++ b/src/asynk.rs
@@ -856,4 +856,43 @@ impl Options {
             inner: self.inner.add_root_certificate(path),
         }
     }
+
+    /// Sets the tcp read timeout to the timeout specified
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # smol::block_on(async {
+    /// let nc = nats::asynk::Options::new()
+    ///     .tcp_read_timeout(std::time::Duration::from_secs(5))
+    ///     .connect("tls://demo.nats.io:4443")
+    ///     .await?;
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    pub fn tcp_read_timeout<T: Into<Option<Duration>>>(
+        self,
+        timeout: T,
+    ) -> Options {
+        Options {
+            inner: self.inner.tcp_read_timeout(timeout),
+        }
+    }
+    /// Sets the tcp write timeout to the timeout specified
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # smol::block_on(async {
+    /// let nc = nats::asynk::Options::new()
+    ///     .tcp_write_timeout(std::time::Duration::from_secs(5))
+    ///     .connect("tls://demo.nats.io:4443")
+    ///     .await?;
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    pub fn tcp_write_timeout<T: Into<Option<Duration>>>(
+        self,
+        timeout: T,
+    ) -> Options {
+        Options {
+            inner: self.inner.tcp_write_timeout(timeout),
+        }
+    }
 }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -233,6 +233,13 @@ impl Connector {
         // Connect to the remote socket.
         let mut stream = TcpStream::connect(addr)?;
         stream.set_nodelay(true)?;
+        // set read and write timeouts, if they were specified
+        if let Some(timeout) = self.options.tcp_read_timeout {
+            stream.set_read_timeout(timeout)?;
+        }
+        if let Some(timeout) = self.options.tcp_write_timeout {
+            stream.set_write_timeout(timeout)?;
+        }
 
         // Expect an INFO message.
         let mut line = crate::SecureVec::with_capacity(512);

--- a/src/options.rs
+++ b/src/options.rs
@@ -28,6 +28,9 @@ pub struct Options {
     pub(crate) reconnect_delay_callback: ReconnectDelayCallback,
     pub(crate) close_callback: Callback,
     pub(crate) jetstream_prefix: String,
+
+    pub(crate) tcp_read_timeout: Option<Option<Duration>>,
+    pub(crate) tcp_write_timeout: Option<Option<Duration>>,
 }
 
 impl fmt::Debug for Options {
@@ -47,6 +50,8 @@ impl fmt::Debug for Options {
             .entry(&"reconnect_callback", &self.reconnect_callback)
             .entry(&"reconnect_delay_callback", &"set")
             .entry(&"close_callback", &self.close_callback)
+            .entry(&"tcp_read_timeout", &self.tcp_read_timeout)
+            .entry(&"tcp_write_timeout", &self.tcp_write_timeout)
             .finish()
     }
 }
@@ -69,6 +74,8 @@ impl Default for Options {
             close_callback: Callback(None),
             jetstream_prefix: "$JS.API.".to_string(),
             tls_client_config: crate::rustls::ClientConfig::default(),
+            tcp_read_timeout: None,
+            tcp_write_timeout: None,
         }
     }
 }
@@ -387,7 +394,7 @@ impl Options {
     /// If no servers remain that are under this threshold,
     /// then no further reconnect shall be attempted.
     /// The reconnect attempt for a server is reset upon
-    /// successfull connection.
+    /// successful connection.
     /// If None then there is no maximum number of attempts.
     ///
     /// # Example
@@ -620,6 +627,45 @@ impl Options {
     /// ```
     pub fn add_root_certificate(mut self, path: impl AsRef<Path>) -> Options {
         self.certificates.push(path.as_ref().to_owned());
+        self
+    }
+
+    /// Sets the tcp read timeout to the timeout specified
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> {
+    ///
+    /// let nc = nats::Options::new()
+    ///     .tcp_read_timeout(std::time::Duration::from_secs(5))
+    ///     .connect("tls://demo.nats.io:4443")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn tcp_read_timeout<T: Into<Option<Duration>>>(
+        mut self,
+        timeout: T,
+    ) -> Options {
+        self.tcp_read_timeout = Some(timeout.into());
+        self
+    }
+    /// Sets the tcp write timeout to the timeout specified
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> {
+    ///
+    /// let nc = nats::Options::new()
+    ///     .tcp_write_timeout(std::time::Duration::from_secs(5))
+    ///     .connect("tls://demo.nats.io:4443")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn tcp_write_timeout<T: Into<Option<Duration>>>(
+        mut self,
+        timeout: T,
+    ) -> Options {
+        self.tcp_write_timeout = Some(timeout.into());
         self
     }
 }


### PR DESCRIPTION
The tcp stream to the nats-server can get stuck if the server is not
shutdown gracefully. Even the connection lost callback does not get
triggered because the stream is somehow stuck.

Adding the timeouts seems to resolve this issue, at least on my test
environment.

By default the timeouts are not set so the existing behavior is kept
but they can be set to a Duration value or None which is then set on
the tcp stream.