### PR TITLE
Use stable toolchain for clippy checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           components: clippy
           override: true
       - run: rustup component add clippy


### PR DESCRIPTION
Switches the toolchain from nightly to stable to avoid any unexpected surprises.
