### PR TITLE
Bump MSRV to 1.52.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,5 +202,5 @@ jobs:
         run: |
           set -eo pipefail
           echo "msrv check"
-          rustup install 1.51.0
-          cargo +1.51.0 check
+          rustup install 1.52.0
+          cargo +1.52.0 check

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ let response = rsub.iter().take(1);
 
 ## Minimum Supported Rust Version (MSRV)
 
-The minimum supported Rust version is 1.51.0.
+The minimum supported Rust version is 1.52.0.
 
 ## Sync vs Async
 


### PR DESCRIPTION
This bumpos the minimum supported rust version to 1.52.0 which is required for `str::split_once`.
