### PR TITLE
Introduce a `JetStream` type

### DIFF
--- a/src/jetstream.rs
+++ b/src/jetstream.rs
@@ -20,7 +20,7 @@
 //! ```no_run
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let nc = nats::connect("my_server::4222")?;
-//! let js = nats::jetstream::JetStream::new(nc, nats::jetstream::JetStreamOptions::default());
+//! let js = nats::jetstream::new(nc);
 //!
 //! // create_stream converts a str into a
 //! // default `StreamConfig`.
@@ -36,7 +36,7 @@
 //! use nats::jetstream::{StreamConfig, StorageType};
 //!
 //! let nc = nats::connect("my_server::4222")?;
-//! let js = nats::jetstream::JetStream::new(nc, nats::jetstream::JetStreamOptions::default());
+//! let js = nats::jetstream::new(nc);
 //!
 //! js.create_stream(StreamConfig {
 //!     name: "my_memory_stream".to_string(),
@@ -53,7 +53,7 @@
 //! ```no_run
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let nc = nats::connect("my_server::4222")?;
-//! let js = nats::jetstream::JetStream::new(nc, nats::jetstream::JetStreamOptions::default());
+//! let js = nats::jetstream::new(nc);
 //!
 //! js.create_stream("my_stream")?;
 //!
@@ -69,7 +69,7 @@
 //! use nats::jetstream::{AckPolicy, ConsumerConfig};
 //!
 //! let nc = nats::connect("my_server::4222")?;
-//! let js = nats::jetstream::JetStream::new(nc, nats::jetstream::JetStreamOptions::default());
+//! let js = nats::jetstream::new(nc);
 //!
 //! js.create_stream("my_stream")?;
 //!
@@ -91,7 +91,7 @@
 //! use nats::jetstream::{AckPolicy, Consumer, ConsumerConfig};
 //!
 //! let nc = nats::connect("my_server::4222")?;
-//! let js = nats::jetstream::JetStream::new(nc, nats::jetstream::JetStreamOptions::default());
+//! let js = nats::jetstream::new(nc);
 //!
 //! let consumer_res = Consumer::existing(js.clone(), "my_stream", "non-existent_consumer");
 //!
@@ -110,7 +110,7 @@
 //! use nats::jetstream::{AckPolicy, Consumer, ConsumerConfig};
 //!
 //! let nc = nats::connect("my_server::4222")?;
-//! let js = nats::jetstream::JetStream::new(nc, nats::jetstream::JetStreamOptions::default());
+//! let js = nats::jetstream::new(nc);
 //!
 //! // this will create the consumer if it does not exist already.
 //! let mut consumer = Consumer::create_or_open(js, "my_stream", "existing_or_created_consumer")?;
@@ -1182,4 +1182,10 @@ impl Consumer {
         let req = serde_json::ser::to_vec(&next_request).unwrap();
         self.js.nc.request_multi(&subject, &req)
     }
+}
+
+/// Creates a new `JetStream` context using the given `Connection` and default options.
+///
+pub fn new(nc: Connection) -> JetStream {
+    JetStream::new(nc, JetStreamOptions::default())
 }

--- a/src/jetstream.rs
+++ b/src/jetstream.rs
@@ -179,6 +179,73 @@ pub use crate::jetstream_types::*;
 
 use crate::{Connection as NatsClient, Message};
 
+/// `JetStream` options
+pub struct JetStreamOptions {
+    pub(crate) api_prefix: String,
+}
+
+impl Debug for JetStreamOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_map()
+            .entry(&"api_prefix", &self.api_prefix)
+            .finish()
+    }
+}
+
+impl Default for JetStreamOptions {
+    fn default() -> JetStreamOptions {
+        JetStreamOptions {
+            api_prefix: "$JS.API.".to_string(),
+        }
+    }
+}
+
+impl JetStreamOptions {
+    /// `Options` for `JetStream` operations.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let options = nats::JetStreamOptions::new();
+    /// ```
+    pub fn new() -> JetStreamOptions {
+        JetStreamOptions::default()
+    }
+
+    /// Set a custom `JetStream` API prefix.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let options = nats::JetStreamOptions::new()
+    ///     .api_prefix("some_exported_prefix".to_string());
+    /// ```
+    pub fn api_prefix(mut self, mut api_prefix: String) -> Self {
+        if !api_prefix.ends_with('.') {
+            api_prefix.push('.');
+        }
+
+        self.api_prefix = api_prefix;
+        self
+    }
+
+    /// Set a custom `JetStream` API prefix from a domain.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let options = nats::JetStreamOptions::new()
+    ///   .domain("some_domain");
+    /// ```
+    pub fn domain(self, domain: &str) -> Self {
+        if domain.is_empty() {
+            self.api_prefix("".to_string())
+        } else {
+            self.api_prefix(format!("$JS.{}.API", domain))
+        }
+    }
+}
+
 /// `ApiResponse` is a standard response from the `JetStream` JSON Api
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,8 +234,8 @@ use std::{
 };
 
 pub use headers::Headers;
+pub use jetstream::JetStreamOptions;
 pub use message::Message;
-pub use options::JetStreamOptions;
 pub use options::Options;
 pub use subscription::Subscription;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::auth_utils;
-use crate::jetstream::JetStreamOptions;
 use crate::secure_wipe::SecureString;
 use crate::Connection;
 
@@ -41,7 +40,6 @@ pub struct Options {
     pub(crate) reconnect_callback: Callback,
     pub(crate) reconnect_delay_callback: ReconnectDelayCallback,
     pub(crate) close_callback: Callback,
-    pub(crate) jetstream: JetStreamOptions,
 }
 
 impl fmt::Debug for Options {
@@ -81,7 +79,6 @@ impl Default for Options {
             reconnect_callback: Callback(None),
             reconnect_delay_callback: ReconnectDelayCallback(Box::new(backoff)),
             close_callback: Callback(None),
-            jetstream: JetStreamOptions::default(),
             tls_client_config: crate::rustls::ClientConfig::default(),
         }
     }
@@ -499,25 +496,6 @@ impl Options {
         F: Fn() + Send + Sync + 'static,
     {
         self.reconnect_callback = Callback(Some(Box::new(cb)));
-        self
-    }
-
-    /// Set `JetStream` options
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # fn main() -> std::io::Result<()> {
-    /// let nc = nats::Options::new()
-    ///     .jetstream(nats::JetStreamOptions::new()
-    ///         .api_prefix("some_exported_prefix".to_string())
-    ///     )
-    ///     .connect("demo.nats.io")?;
-    /// nc.drain().unwrap();
-    /// # Ok(())
-    /// # }
-    pub fn jetstream(mut self, jetstream: JetStreamOptions) -> Self {
-        self.jetstream = jetstream;
         self
     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -20,76 +20,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::auth_utils;
+use crate::jetstream::JetStreamOptions;
 use crate::secure_wipe::SecureString;
 use crate::Connection;
-
-/// `JetStream` options
-#[allow(clippy::module_name_repetitions)]
-pub struct JetStreamOptions {
-    pub(crate) api_prefix: String,
-}
-
-impl fmt::Debug for JetStreamOptions {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_map()
-            .entry(&"api_prefix", &self.api_prefix)
-            .finish()
-    }
-}
-
-impl Default for JetStreamOptions {
-    fn default() -> JetStreamOptions {
-        JetStreamOptions {
-            api_prefix: "$JS.API.".to_string(),
-        }
-    }
-}
-
-impl JetStreamOptions {
-    /// `Options` for `JetStream` operations.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let options = nats::JetStreamOptions::new();
-    /// ```
-    pub fn new() -> JetStreamOptions {
-        JetStreamOptions::default()
-    }
-
-    /// Set a custom `JetStream` API prefix.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let options = nats::JetStreamOptions::new()
-    ///     .api_prefix("some_exported_prefix".to_string());
-    /// ```
-    pub fn api_prefix(mut self, mut api_prefix: String) -> Self {
-        if !api_prefix.ends_with('.') {
-            api_prefix.push('.');
-        }
-
-        self.api_prefix = api_prefix;
-        self
-    }
-
-    /// Set a custom `JetStream` API prefix from a domain.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let options = nats::JetStreamOptions::new()
-    ///   .domain("some_domain");
-    /// ```
-    pub fn domain(self, domain: &str) -> Self {
-        if domain.is_empty() {
-            self.api_prefix("".to_string())
-        } else {
-            self.api_prefix(format!("$JS.{}.API", domain))
-        }
-    }
-}
 
 /// Connect options.
 pub struct Options {

--- a/tests/jetstream.rs
+++ b/tests/jetstream.rs
@@ -10,7 +10,7 @@ pub use util::*;
 fn jetstream_not_enabled() {
     let s = util::run_basic_server();
     let nc = nats::connect(&s.client_url()).unwrap();
-    let js = JetStream::new(nc, JetStreamOptions::default());
+    let js = nats::jetstream::new(nc);
 
     let err = js.account_info().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Other);
@@ -29,7 +29,7 @@ fn jetstream_not_enabled() {
 fn jetstream_account_not_enabled() {
     let s = util::run_server("tests/configs/jetstream_account_not_enabled.conf");
     let nc = nats::connect(&s.client_url()).unwrap();
-    let js = JetStream::new(nc, JetStreamOptions::default());
+    let js = nats::jetstream::new(nc);
 
     let err = js.account_info().unwrap_err();
     println!("{:?}", err);

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -6,6 +6,7 @@ use std::{env, fs};
 use std::{thread, time::Duration};
 
 use lazy_static::lazy_static;
+use nats::jetstream::{JetStream, JetStreamOptions};
 use nats::Connection;
 use regex::Regex;
 
@@ -113,8 +114,10 @@ pub fn run_basic_server() -> Server {
 }
 
 // Helper function to return server and client.
-pub fn run_basic_jetstream() -> (Server, Connection) {
+pub fn run_basic_jetstream() -> (Server, Connection, JetStream) {
     let s = run_server("tests/configs/jetstream.conf");
     let nc = nats::connect(&s.client_url()).unwrap();
-    (s, nc)
+    let js = JetStream::new(nc.clone(), JetStreamOptions::default());
+
+    (s, nc, js)
 }


### PR DESCRIPTION
First pass at separating JetStream from `Connection`.

- Moves JetStreamOptions into the `jetstream` module.
- Introduces a `jetstream::JetStream` type that will be the home of `publish` with acks and other ops ala the Go and JavaScript clients.
- Adds a short-hand for instantiating these `JetStream` contexts via `nats::jetstream::new(nc)`.

Was considering `jetstream::Connection`, `jetstream::Client` and `jetstream::Context` and in the end just went with `jetstream::JetStream` but is bike-shreddable.

Easiest to review on a commit by commit basis.