### PR TITLE
Add support for JetStream publishing

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -26,6 +26,12 @@ const HEADER_LINE_LEN: usize = HEADER_LINE.len();
 pub const STATUS_HEADER: &str = "Status";
 pub const DESCRIPTION_HEADER: &str = "Description";
 
+pub const NATS_MSG_ID: &str = "Nats-Msg-Id";
+pub const NATS_EXPECTED_STREAM: &str = "Nats-Expected-Stream";
+pub const NATS_EXPECTED_LAST_MSG_ID: &str = "Nats-Expected-Last-Msg-Id";
+pub const NATS_EXPECTED_LAST_SEQUENCE: &str = "Nats-Expected-Last-Sequence";
+pub const NATS_EXPECTED_LAST_SUBJECT_SEQUENCE: &str = "Nats-Expected-Last-Subject-Sequence";
+
 /// A multi-map from header name to a set of values for that header
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Headers {

--- a/src/jetstream.rs
+++ b/src/jetstream.rs
@@ -257,6 +257,11 @@ impl JetStreamOptions {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 enum ApiResponse<T> {
+    // Note:
+    // Serde will try to match the data against each variant in order and the first one that
+    // deserializes successfully is the one returned.
+    //
+    // Therefore the error case must come first, otherwise it can be ignored.
     Err { r#type: String, error: Error },
     Ok(T),
 }

--- a/src/jetstream.rs
+++ b/src/jetstream.rs
@@ -262,7 +262,7 @@ enum ApiResponse<T> {
     // deserializes successfully is the one returned.
     //
     // Therefore the error case must come first, otherwise it can be ignored.
-    Err { r#type: String, error: Error },
+    Err { error: Error },
     Ok(T),
 }
 

--- a/src/jetstream_types.rs
+++ b/src/jetstream_types.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -435,14 +435,20 @@ pub(crate) struct AccountStats {
     pub limits: AccountLimits,
 }
 
+/// `PublishAck` is an acknowledgement received after successfully publishing a message.
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub(crate) struct PubAck {
+pub struct PublishAck {
+    /// Name of stream the message was published to.
     pub stream: String,
-    pub seq: u64,
+    /// Sequence number the message was published in.
+    #[serde(rename = "seq")]
+    pub sequence: u64,
+    /// Domain the message was published to
     // TODO(caspervonb) using String::is_empty as default for String is still unstable.
     // Use `is_default` once that is no longer gated for strings.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub domain: String,
+    /// True if the published message was determined to be a duplicate, false otherwise.
     #[serde(default, skip_serializing_if = "is_default")]
     pub duplicate: bool,
 }
@@ -565,15 +571,19 @@ pub(crate) struct SubOpts {
 
 /// Options for publishing
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub(crate) struct PubOpts {
-    pub ttl: i64,
-    pub id: String,
-    // Expected last msgId
-    pub lid: String,
-    // Expected stream name
-    pub str: String,
-    // Expected last sequence
-    pub seq: u64,
+pub struct PublishOptions {
+    /// Duration to wait before timing out
+    pub timeout: Option<Duration>,
+    /// Message id
+    pub id: Option<String>,
+    /// Expected last message id
+    pub expected_last_msg_id: Option<String>,
+    /// Expected stream name
+    pub expected_stream: Option<String>,
+    /// Expected last sequence
+    pub expected_last_sequence: Option<u64>,
+    /// Expected last subject sequence
+    pub expected_last_subject_sequence: Option<u64>,
 }
 
 /// contains info about the `JetStream` usage from the current account.


### PR DESCRIPTION
This adds adds support for `JetStream` publishing.
A few tangental fixes were made along the way.

Supercedes #218 
Closes #215