### PR TITLE
Use temporary directories for storage

### DIFF
--- a/tests/configs/jetstream.conf
+++ b/tests/configs/jetstream.conf
@@ -1,6 +1,4 @@
-
 jetstream: {
   max_mem_store:  8MiB,
   max_file_store: 10GiB
-  store_dir:      "$SD"
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -87,12 +87,13 @@ impl Server {
 pub fn run_server(cfg: &str) -> Server {
     let id = nuid::next();
     let logfile = env::temp_dir().join(format!("nats-server-{}.log", id));
-    let sd = env::temp_dir().join(format!("store-dir-{}", id));
+    let store_dir = env::temp_dir().join(format!("store-dir-{}", id));
 
     // Always use dynamic ports so tests can run in parallel.
     // Create env for a storage directory for jetstream.
     let mut cmd = Command::new("nats-server");
-    cmd.env("SD", sd)
+    cmd.arg("--store_dir")
+        .arg(store_dir.as_path().to_str().unwrap())
         .arg("-p")
         .arg("-1")
         .arg("-l")


### PR DESCRIPTION
Quotes were resulting in a directory named `./$SD` directory to be created and used on Unix for storage, which leads to racing between the tests and frequent failures.

This makes use of the `--store_dir` cli option instead.