### PR TITLE
Add header module

### DIFF
--- a/src/asynk.rs
+++ b/src/asynk.rs
@@ -98,7 +98,7 @@ use std::time::Duration;
 use blocking::unblock;
 use crossbeam_channel::{Receiver, Sender};
 
-use crate::Headers;
+use crate::header::HeaderMap;
 
 /// Connect to a NATS server at the given url.
 ///
@@ -275,7 +275,7 @@ impl Connection {
         &self,
         subject: &str,
         reply: Option<&str>,
-        headers: Option<&Headers>,
+        headers: Option<&HeaderMap>,
         msg: impl AsRef<[u8]>,
     ) -> io::Result<()> {
         if let Some(res) = self
@@ -286,7 +286,7 @@ impl Connection {
         }
         let subject = subject.to_string();
         let reply = reply.map(str::to_owned);
-        let headers = headers.map(Headers::clone);
+        let headers = headers.map(HeaderMap::clone);
         let msg = msg.as_ref().to_vec();
         let inner = self.inner.clone();
         unblock(move || {
@@ -376,7 +376,7 @@ pub struct Message {
     pub data: Vec<u8>,
 
     /// Optional headers associated with this `Message`.
-    pub headers: Option<Headers>,
+    pub headers: Option<HeaderMap>,
 
     /// Client for publishing on the reply subject.
     #[doc(hidden)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ use parking_lot::Mutex;
 use crate::connector::{Connector, NatsStream};
 use crate::message::Message;
 use crate::proto::{self, ClientOp, ServerOp};
-use crate::{inject_delay, inject_io_failure, Headers, Options, ServerInfo};
+use crate::{header::HeaderMap, inject_delay, inject_io_failure, Options, ServerInfo};
 
 const BUF_CAPACITY: usize = 32 * 1024;
 
@@ -440,7 +440,7 @@ impl Client {
         &self,
         subject: &str,
         reply_to: Option<&str>,
-        headers: Option<&Headers>,
+        headers: Option<&HeaderMap>,
         msg: &[u8],
     ) -> io::Result<()> {
         // Inject random delays when testing.
@@ -514,7 +514,7 @@ impl Client {
         &self,
         subject: &str,
         reply_to: Option<&str>,
-        headers: Option<&Headers>,
+        headers: Option<&HeaderMap>,
         msg: &[u8],
     ) -> Option<io::Result<()>> {
         // Check if the client is closed.

--- a/src/jetstream.rs
+++ b/src/jetstream.rs
@@ -183,7 +183,10 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 pub use crate::jetstream_types::*;
 
-use crate::{headers, headers::Headers, Connection, Message};
+use crate::{
+    header::{self, HeaderMap},
+    Connection, Message,
+};
 
 /// `JetStream` options
 #[derive(Clone)]
@@ -652,16 +655,16 @@ impl JetStream {
         &self,
         subject: &str,
         maybe_options: Option<&PublishOptions>,
-        maybe_headers: Option<&Headers>,
+        maybe_headers: Option<&HeaderMap>,
         msg: impl AsRef<[u8]>,
     ) -> io::Result<PublishAck> {
         let maybe_headers = if let Some(options) = maybe_options {
-            let mut headers = maybe_headers.map_or_else(Headers::default, Headers::clone);
+            let mut headers = maybe_headers.map_or_else(HeaderMap::default, HeaderMap::clone);
 
             if let Some(v) = options.id.as_ref() {
                 let entry = headers
                     .inner
-                    .entry(headers::NATS_MSG_ID.to_string())
+                    .entry(header::NATS_MSG_ID.to_string())
                     .or_insert_with(HashSet::default);
 
                 entry.insert(v.to_string());
@@ -670,7 +673,7 @@ impl JetStream {
             if let Some(v) = options.expected_last_msg_id.as_ref() {
                 let entry = headers
                     .inner
-                    .entry(headers::NATS_EXPECTED_LAST_MSG_ID.to_string())
+                    .entry(header::NATS_EXPECTED_LAST_MSG_ID.to_string())
                     .or_insert_with(HashSet::default);
 
                 entry.insert(v.to_string());
@@ -679,7 +682,7 @@ impl JetStream {
             if let Some(v) = options.expected_stream.as_ref() {
                 let entry = headers
                     .inner
-                    .entry(headers::NATS_EXPECTED_STREAM.to_string())
+                    .entry(header::NATS_EXPECTED_STREAM.to_string())
                     .or_insert_with(HashSet::default);
 
                 entry.insert(v.to_string());
@@ -688,7 +691,7 @@ impl JetStream {
             if let Some(v) = options.expected_last_sequence.as_ref() {
                 let entry = headers
                     .inner
-                    .entry(headers::NATS_EXPECTED_LAST_SEQUENCE.to_string())
+                    .entry(header::NATS_EXPECTED_LAST_SEQUENCE.to_string())
                     .or_insert_with(HashSet::default);
 
                 entry.insert(v.to_string());
@@ -697,7 +700,7 @@ impl JetStream {
             if let Some(v) = options.expected_last_subject_sequence.as_ref() {
                 let entry = headers
                     .inner
-                    .entry(headers::NATS_EXPECTED_LAST_SUBJECT_SEQUENCE.to_string())
+                    .entry(header::NATS_EXPECTED_LAST_SUBJECT_SEQUENCE.to_string())
                     .or_insert_with(HashSet::default);
 
                 entry.insert(v.to_string());

--- a/src/message.rs
+++ b/src/message.rs
@@ -19,7 +19,10 @@ use std::{
     },
 };
 
-use crate::{client::Client, Headers};
+use crate::{
+    client::Client,
+    header::{self, HeaderMap},
+};
 
 /// A message received on a subject.
 #[derive(Clone)]
@@ -35,7 +38,7 @@ pub struct Message {
     pub data: Vec<u8>,
 
     /// Optional headers associated with this `Message`.
-    pub headers: Option<Headers>,
+    pub headers: Option<HeaderMap>,
 
     /// Client for publishing on the reply subject.
     #[doc(hidden)]
@@ -74,12 +77,11 @@ impl Message {
 
     /// Determine if the message is a no responders response from the server.
     pub fn is_no_responders(&self) -> bool {
-        use crate::headers::STATUS_HEADER;
         if !self.data.is_empty() {
             return false;
         }
         if let Some(hdrs) = &self.headers {
-            if let Some(set) = hdrs.get(STATUS_HEADER) {
+            if let Some(set) = hdrs.get(header::STATUS) {
                 if set.get("503").is_some() {
                     return true;
                 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -17,7 +17,7 @@ use std::io::{self, Error, ErrorKind};
 use std::str::{self, FromStr};
 
 use crate::connect::ConnectInfo;
-use crate::{inject_io_failure, Headers, ServerInfo};
+use crate::{header::HeaderMap, inject_io_failure, ServerInfo};
 
 /// A protocol operation sent by the server.
 #[derive(Debug)]
@@ -37,7 +37,7 @@ pub(crate) enum ServerOp {
     /// bytes>\r\n<version line>\r\n[headers]\r\n\r\n[payload]\r\n`
     Hmsg {
         subject: String,
-        headers: Headers,
+        headers: HeaderMap,
         sid: u64,
         reply_to: Option<String>,
         payload: Vec<u8>,
@@ -264,7 +264,7 @@ pub(crate) fn decode(mut stream: impl BufRead) -> io::Result<Option<ServerOp>> {
         header_payload.resize(num_header_bytes as usize, 0_u8);
         stream.read_exact(&mut header_payload[..])?;
 
-        let headers = Headers::try_from(&*header_payload)?;
+        let headers = HeaderMap::try_from(&*header_payload)?;
 
         // Read the payload.
         let mut payload = Vec::new();
@@ -309,7 +309,7 @@ pub(crate) enum ClientOp<'a> {
     Hpub {
         subject: &'a str,
         reply_to: Option<&'a str>,
-        headers: &'a Headers,
+        headers: &'a HeaderMap,
         payload: &'a [u8],
     },
 


### PR DESCRIPTION
This makes the header module public which contains the header map type and constants for various known headers (taking a little inspiration from the [http crate](https://docs.rs/http/0.2.5/http/header/index.html) here).

The top level `Headers` type still exists, but has been aliased to the new name and the alias is marked as deprecated.