### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: ci
 
 on:
   push:
@@ -7,51 +7,16 @@ on:
   pull_request:
 
 jobs:
-  fmt_check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
-
-  clippy_check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Rust
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-rust
-        with:
-          path: target
-          key: ${{ runner.os }}-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          override: true
-      - uses: actions-rs/clippy-check@v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
-
-  default:
-    name: Cargo Test on ${{ matrix.os }}
+  test_matrix:
+    name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+
     steps:
-      - name: Cache Rust
+      - name: Cache rust
         uses: actions/cache@v1
         env:
           cache-name: cache-rust
@@ -60,7 +25,8 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}
           restore-keys: |
             ${{ runner.os }}-
-      - name: Cache Go
+
+      - name: Cache go
         uses: actions/cache@v2
         with:
           path: |
@@ -71,24 +37,30 @@ jobs:
           key: ${{ runner.os }}-go-${{ env.cache-name }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up go
+        uses: actions/setup-go@v2
         with:
           go-version: '1.16'
-      - name: install nats-server
+
+      - name: Install nats-server
         run: go get github.com/nats-io/nats-server/v2
-      - name: cargo test
+
+      - name: Run tests
         env:
           RUST_BACKTRACE: 1
         run: |
           rustup update
           cargo test
 
-  fault-injection:
-    name: Fault Injection
+  test_fault-injection:
+    name: test (fault-injection)
     runs-on: ubuntu-latest
     steps:
-      - name: Cache Rust
+      - name: Cache rust
         uses: actions/cache@v1
         env:
           cache-name: cache-rust-fault-injection
@@ -97,19 +69,22 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: actions/checkout@v2
-      - name: fault injection test
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Run tests with fault injection
         env:
           RUST_LOG: trace
         run: |
           rustup update
           cargo test reconnect_test --features=fault_injection -- --ignored
 
-  doctests:
-    name: doctests
+  test_documentation:
+    name: test (documentation)
     runs-on: ubuntu-latest
     steps:
-      - name: Cache Rust
+      - name: Cache rust
         uses: actions/cache@v1
         env:
           cache-name: cache-rust
@@ -118,50 +93,49 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up go
+        uses: actions/setup-go@v2
         with:
           go-version: '1.16'
+
       - name: install nats-server
         run: go get github.com/nats-io/nats-server/v2
-      - name: JetStream test
+
+      - name: Run documentation tests
         env:
           RUST_LOG: trace
         run: |
           rustup update
           cargo test --doc
 
-  examples:
-    name: examples
+  check_format:
+    name: check (format)
     runs-on: ubuntu-latest
     steps:
-      - name: Cache Rust
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-rust
-        with:
-          path: target
-          key: ${{ runner.os }}-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16'
-      - name: install nats-server
-        run: go get github.com/nats-io/nats-server/v2
-      - name: JetStream test
-        env:
-          RUST_LOG: trace
-        run: |
-          rustup update
-          cargo check --examples
+      - name: Check out repository
+        uses: actions/checkout@v2
 
-  msrv:
-    name: MSRV
+      - name: Set up rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Check format
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+  check_lint:
+    name: check (lint)
     runs-on: ubuntu-latest
     steps:
-      - name: Cache Rust
+      - name: Cache rust
         uses: actions/cache@v1
         env:
           cache-name: cache-rust
@@ -170,10 +144,74 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: actions/checkout@v1
-      - name: MSRV check
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+
+      - name: Check lint
+        uses: actions-rs/clippy-check@v1.0.7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
+  check_msrv:
+    name: check (msrv)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache rust
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-rust
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ env.cache-name }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Check minimum supported rust Version
         run: |
           set -eo pipefail
           echo "msrv check"
           rustup install 1.52.0
           cargo +1.52.0 check
+
+  check_examples:
+    name: check (examples)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache rust
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-rust
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ env.cache-name }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - name: Install nats-server
+        run: go get github.com/nats-io/nats-server/v2
+      - name: Check examples
+        env:
+          RUST_LOG: trace
+        run: |
+          rustup update
+          cargo check --examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,32 +158,6 @@ jobs:
           rustup update
           cargo check --examples
 
-  jetstream:
-    name: JetStream
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Rust
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-rust-jetstream
-        with:
-          path: target
-          key: ${{ runner.os }}-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16'
-      - name: install nats-server
-        run: go get github.com/nats-io/nats-server/v2
-      - name: JetStream test
-        env:
-          RUST_LOG: trace
-        run: |
-          rustup update
-          cargo test jetstream
-
   msrv:
     name: MSRV
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
           toolchain: stable
           components: clippy
           override: true
-      - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1.0.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Remove jetstream job
- Don't use rustup to re-install clippy
- Normalises jobs and step naming splitting them into two groups: tests and checks.