### PR TITLE
Lame duck mode support

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -53,11 +53,7 @@ pub struct ConnectInfo {
     /// Sending 1 indicates that the client supports dynamic reconfiguration
     /// of cluster topology changes by asynchronously receiving INFO messages
     /// with known servers it can reconnect to.
-<<<<<<< HEAD
     pub protocol: Protocol,
-=======
-    pub protocol: u8,
->>>>>>> d829084 (Add missing protocol field in CONNECT)
 
     /// Indicates whether the client requires an SSL connection.
     pub tls_required: bool,
@@ -95,11 +91,7 @@ impl ConnectInfo {
             echo: self.echo,
             lang: self.lang.clone(),
             version: self.version.clone(),
-<<<<<<< HEAD
             protocol: self.protocol as u8,
-=======
-            protocol: self.protocol,
->>>>>>> d829084 (Add missing protocol field in CONNECT)
             tls_required: self.tls_required,
             headers: self.headers,
             no_responders: self.no_responders,

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -53,7 +53,11 @@ pub struct ConnectInfo {
     /// Sending 1 indicates that the client supports dynamic reconfiguration
     /// of cluster topology changes by asynchronously receiving INFO messages
     /// with known servers it can reconnect to.
+<<<<<<< HEAD
     pub protocol: Protocol,
+=======
+    pub protocol: u8,
+>>>>>>> d829084 (Add missing protocol field in CONNECT)
 
     /// Indicates whether the client requires an SSL connection.
     pub tls_required: bool,
@@ -91,7 +95,11 @@ impl ConnectInfo {
             echo: self.echo,
             lang: self.lang.clone(),
             version: self.version.clone(),
+<<<<<<< HEAD
             protocol: self.protocol as u8,
+=======
+            protocol: self.protocol,
+>>>>>>> d829084 (Add missing protocol field in CONNECT)
             tls_required: self.tls_required,
             headers: self.headers,
             no_responders: self.no_responders,

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -49,6 +49,12 @@ pub struct ConnectInfo {
     /// The version of the client.
     pub version: String,
 
+    /// Sending 0 (or absent) indicates client supports original protocol.
+    /// Sending 1 indicates that the client supports dynamic reconfiguration
+    /// of cluster topology changes by asynchronously receiving INFO messages
+    /// with known servers it can reconnect to.
+    pub protocol: Protocol,
+
     /// Indicates whether the client requires an SSL connection.
     pub tls_required: bool,
 
@@ -68,6 +74,15 @@ pub struct ConnectInfo {
     pub no_responders: bool,
 }
 
+/// Protocol version used by the client.
+#[derive(Clone, Copy, Debug)]
+pub enum Protocol {
+    /// Original protocol.
+    Original = 0,
+    /// Protocol with dynamic reconfiguration of cluster and lame duck mode functionality.
+    Dynamic = 1,
+}
+
 impl ConnectInfo {
     pub(crate) fn dump(&self) -> Option<String> {
         let mut obj = json::object! {
@@ -76,9 +91,10 @@ impl ConnectInfo {
             echo: self.echo,
             lang: self.lang.clone(),
             version: self.version.clone(),
+            protocol: self.protocol as u8,
             tls_required: self.tls_required,
             headers: self.headers,
-        no_responders: self.no_responders,
+            no_responders: self.no_responders,
         };
         if let Some(s) = &self.user_jwt {
             obj.insert("jwt", s.to_string()).ok()?;

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -286,11 +286,7 @@ impl Connector {
             verbose: false,
             lang: crate::LANG.to_string(),
             version: crate::VERSION.to_string(),
-<<<<<<< HEAD
             protocol: crate::connect::Protocol::Dynamic,
-=======
-            protocol: 1,
->>>>>>> d829084 (Add missing protocol field in CONNECT)
             user: None,
             pass: None,
             auth_token: None,

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -286,7 +286,11 @@ impl Connector {
             verbose: false,
             lang: crate::LANG.to_string(),
             version: crate::VERSION.to_string(),
+<<<<<<< HEAD
             protocol: crate::connect::Protocol::Dynamic,
+=======
+            protocol: 1,
+>>>>>>> d829084 (Add missing protocol field in CONNECT)
             user: None,
             pass: None,
             auth_token: None,

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -286,6 +286,7 @@ impl Connector {
             verbose: false,
             lang: crate::LANG.to_string(),
             version: crate::VERSION.to_string(),
+            protocol: crate::connect::Protocol::Dynamic,
             user: None,
             pass: None,
             auth_token: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,8 @@ pub struct ServerInfo {
     pub client_ip: String,
     /// Whether the server supports headers.
     pub headers: bool,
+    /// Whether server goes into lame duck mode.
+    pub lame_duck_mode: bool,
 }
 
 impl ServerInfo {
@@ -321,6 +323,7 @@ impl ServerInfo {
                 .collect(),
             client_ip: obj["client_ip"].take_string().unwrap_or_default(),
             headers: obj["headers"].as_bool().unwrap_or(false),
+            lame_duck_mode: obj["ldm"].as_bool().unwrap_or(false),
         })
     }
 }

--- a/tests/duck_mode.rs
+++ b/tests/duck_mode.rs
@@ -1,0 +1,20 @@
+mod util;
+use std::time::Duration;
+
+use crossbeam_channel::bounded;
+pub use util::*;
+
+#[test]
+fn lame_duck_mode() {
+    let (ltx, lrx) = bounded(1);
+
+    let s = util::run_basic_server();
+    let nc = nats::Options::new()
+        .lame_duck_callback(move || ltx.send(true).unwrap())
+        .connect(s.client_url().as_str())
+        .expect("could not connect to the server");
+    let _sub = nc.subscribe("foo").unwrap();
+    set_lame_duck_mode();
+    let r = lrx.recv_timeout(Duration::from_millis(500));
+    assert!(r.is_ok(), "expected lame duck response, got nothing");
+}

--- a/tests/lame_duck_mode.rs
+++ b/tests/lame_duck_mode.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::bounded;
 pub use util::*;
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)]
 fn lame_duck_mode() {
     let (ltx, lrx) = bounded(1);
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -83,6 +83,11 @@ impl Server {
     }
 }
 
+pub fn set_lame_duck_mode() {
+    let mut cmd = Command::new("nats-server");
+    cmd.arg("--signal").arg("ldm").spawn().unwrap();
+}
+
 /// Starts a local NATS server with the given config that gets stopped and cleaned up on drop.
 pub fn run_server(cfg: &str) -> Server {
     let id = nuid::next();


### PR DESCRIPTION
Realized that we should probably do more when new info arrives, hence used `process_info` instead of more specific name for lame duck tape mode.