### PR TITLE
fix: publicly export handler struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ use regex::Regex;
 pub use jetstream::JetStreamOptions;
 pub use message::Message;
 pub use options::Options;
-pub use subscription::Subscription;
+pub use subscription::{Handler, Subscription};
 
 /// A re-export of the `rustls` crate used in this crate,
 /// for use in cases where manual client configurations


### PR DESCRIPTION
Currently the `Handler` struct returned from `Subscription#with_handler` is public but not exported as part of the library. This exports it so the handler can be used as a return type etc.