### PR TITLE
support RSA private keys #277

### DIFF
--- a/src/auth_utils.rs
+++ b/src/auth_utils.rs
@@ -163,10 +163,20 @@ pub(crate) fn load_key(path: &Path) -> io::Result<PrivateKey> {
         &PrivateKey,
     )?;
     if keys.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "no keys found in the client key file",
-        ));
+        let mut keys = extract(
+            path,
+            "-----BEGIN RSA PRIVATE KEY-----",
+            "-----END RSA PRIVATE KEY-----",
+            &PrivateKey,
+        )?;
+        
+        if keys.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no keys found in the client key file",
+            ));
+        }
+        Ok(keys.remove(0))
     }
     Ok(keys.remove(0))
 }

--- a/src/auth_utils.rs
+++ b/src/auth_utils.rs
@@ -175,8 +175,9 @@ pub(crate) fn load_key(path: &Path) -> io::Result<PrivateKey> {
                 io::ErrorKind::InvalidData,
                 "no keys found in the client key file",
             ));
+        } else {
+            return Ok(keys.remove(0));
         }
-        Ok(keys.remove(0))
     }
     Ok(keys.remove(0))
 }


### PR DESCRIPTION
Retries parsing of private key PEM file with an RSA signature if the ordinary PRIVATE KEY signature does not succeed.

Experimentally fixes #277