### PR TITLE
Fix lame duck mode tests race

### DIFF
--- a/tests/lame_duck_mode.rs
+++ b/tests/lame_duck_mode.rs
@@ -15,7 +15,7 @@ fn lame_duck_mode() {
         .connect(s.client_url().as_str())
         .expect("could not connect to the server");
     let _sub = nc.subscribe("foo").unwrap();
-    set_lame_duck_mode();
+    set_lame_duck_mode(&s);
     let r = lrx.recv_timeout(Duration::from_millis(500));
     assert!(r.is_ok(), "expected lame duck response, got nothing");
 }


### PR DESCRIPTION
Lame duck mode tests were sometimes failing because of the fact that they were not targeting specific PID.
With each test in parallel, risk of race happening was increasing.

This allows func that calls lame_duck_mode to refer specific PID.