### PR TITLE
Jarema/add slow consumers

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -256,6 +256,57 @@ impl Subscription {
         Handler { sub: self }
     }
 
+    /// Sets limit of how many messages can wait in internal queue.
+    /// If limit will be reached, `error_callback` will be fired with information
+    /// which subscription is affected
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> std::io::Result<()> {
+    /// # let nc = nats::connect("demo.nats.io")?;
+    /// let sub =  nc.subscribe("bar")?;
+    /// sub.set_message_limits(1000);
+    /// # Ok(())
+    /// # }
+    /// ```
+
+    pub fn set_message_limits(&self, limit: usize) {
+        self.0
+            .client
+            .state
+            .read
+            .lock()
+            .subscriptions
+            .entry(self.0.sid)
+            .and_modify(|sub| sub.pending_messages_limit = Some(limit));
+    }
+
+    /// Returns number of dropped messages for this Subscription.
+    /// Dropped messages occur when `set_message_limits` is set and threashold is reached,
+    /// triggering `slow consumer` error.
+    ///
+    /// # Example:
+    /// ```
+    /// # fn main() -> std::io::Result<()> {
+    /// # let nc = nats::connect("demo.nats.io")?;
+    /// let sub =  nc.subscribe("bar")?;
+    /// sub.set_message_limits(1000);
+    /// println!("dropped messages: {}", sub.dropped_messages()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn dropped_messages(&self) -> io::Result<usize> {
+        self.0
+            .client
+            .state
+            .read
+            .lock()
+            .subscriptions
+            .get(&self.0.sid)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "subscription not found"))
+            .map(|subscription| subscription.dropped_messages)
+    }
+
     /// Unsubscribe a subscription immediately without draining.
     /// Use `drain` instead if you want any pending messages
     /// to be processed by a handler, if one is configured.

--- a/tests/slow_consumer.rs
+++ b/tests/slow_consumer.rs
@@ -1,0 +1,66 @@
+// Copyright 2020-2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod util;
+use std::{
+    sync::{atomic::AtomicUsize, Arc},
+    thread,
+    time::Duration,
+};
+pub use util::*;
+
+#[test]
+fn slow_consumers() {
+    let dropped_messages = Arc::new(AtomicUsize::new(0));
+    let s = util::run_basic_server();
+    let nc = nats::Options::with_user_pass("derek", "s3cr3t!")
+        .error_callback({
+            let dropped_messages = dropped_messages.clone();
+            move |err| {
+                if err.to_string()
+                    == *"slow consumer detected for subscription on subject data. dropping messages"
+                {
+                    dropped_messages.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+        })
+        .connect(s.client_url())
+        .expect("could not connect");
+
+    let sub = nc.subscribe("data").unwrap();
+
+    // set limits for number of messages
+    sub.set_message_limits(100);
+
+    // send messages
+    for _ in 0..140 {
+        nc.publish("data", b"test message").unwrap();
+    }
+
+    // wait a while to trigger slow consumers
+    thread::sleep(Duration::from_millis(200));
+    let mut i = 0;
+    while i < 100 {
+        sub.next();
+        i += 1;
+    }
+
+    // check if numbers align between callback and registered dropped messages
+    assert_eq!(
+        sub.dropped_messages().unwrap(),
+        dropped_messages.load(std::sync::atomic::Ordering::SeqCst)
+    );
+
+    // check if expected number of messages were dropped
+    assert_eq!(sub.dropped_messages().unwrap(), 40);
+}


### PR DESCRIPTION
Added handling to slow consumers.

I really don't like the outcome.
Adding the method to return dropped messages (and count them in the first place) forces making some fields of `State` `pub(crate)` to be able to reach them from `Subscription`.

Will make a rework using the preprocessor.

closes #299 