### PR TITLE
Jarema/fix unsub

### DIFF
--- a/src/jetstream/push_subscription.rs
+++ b/src/jetstream/push_subscription.rs
@@ -511,14 +511,6 @@ impl PushSubscription {
     /// # }
     /// ```
     pub fn unsubscribe(self) -> io::Result<()> {
-        // Drain
-        self.0
-            .context
-            .connection
-            .0
-            .client
-            .flush(DEFAULT_FLUSH_TIMEOUT)?;
-
         self.0
             .context
             .connection
@@ -561,9 +553,9 @@ impl PushSubscription {
         self.unsubscribe()
     }
 
-    /// Send an unsubscription then flush the connection,
+    /// Send an unsubscription and flush the connection,
     /// allowing any unprocessed messages to be handled
-    /// by a handler function if one is configured.
+    /// by a `Subscription`
     ///
     /// After the flush returns, we know that a round-trip
     /// to the server has happened after it received our
@@ -593,7 +585,7 @@ impl PushSubscription {
     ///
     /// subscription.drain()?;
     ///
-    /// assert!(subscription.next().is_none());
+    /// assert!(subscription.next().is_some());
     ///
     /// # Ok(())
     /// # }
@@ -613,9 +605,6 @@ impl PushSubscription {
             .0
             .client
             .unsubscribe(self.0.sid.load(Ordering::Relaxed))?;
-
-        // Discard all queued messages.
-        while self.0.messages.try_recv().is_ok() {}
 
         // Delete the consumer, if we own it.
         if self.0.consumer_ownership == ConsumerOwnership::Yes {
@@ -668,7 +657,7 @@ impl Handler {
     /// # }
     /// ```
     pub fn unsubscribe(self) -> io::Result<()> {
-        self.subscription.drain()
+        self.subscription.unsubscribe()
     }
 }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -270,7 +270,7 @@ impl Subscription {
     /// # }
     /// ```
     pub fn unsubscribe(self) -> io::Result<()> {
-        self.drain()?;
+        self.0.client.unsubscribe(self.0.sid)?;
         // Discard all queued messages.
         while self.0.messages.try_recv().is_ok() {}
         Ok(())

--- a/tests/drain.rs
+++ b/tests/drain.rs
@@ -1,0 +1,41 @@
+// Copyright 2020-2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod util;
+pub use util::*;
+
+#[test]
+fn drain() {
+    let s = run_basic_server();
+    let nc = nats::connect(s.client_url()).unwrap();
+
+    let sub = nc.subscribe("test").unwrap();
+
+    for _ in 0..10000 {
+        nc.publish("test", b"foo").unwrap();
+    }
+    let mut i = 0;
+    // first drain
+    sub.drain().unwrap();
+    // then read messages
+    for _msg in sub.iter() {
+        i += 1;
+    }
+    assert_eq!(10000, i);
+
+    // check if we do not get further messages when publishing to drained subscription.
+    nc.publish("test", b"ipsum").unwrap();
+    assert!(sub.next().is_none());
+
+    sub.unsubscribe().unwrap();
+}

--- a/tests/jetstream.rs
+++ b/tests/jetstream.rs
@@ -293,6 +293,16 @@ fn jetstream_subscribe() {
     assert_eq!(info.config.ack_policy, AckPolicy::Explicit);
     assert_eq!(info.delivered.consumer_seq, 10);
     assert_eq!(info.ack_floor.consumer_seq, 10);
+
+    // publish one more message to check drain behaviour
+    js.publish("foo", payload).unwrap();
+    // check if we still get messages from drain
+    sub.drain().unwrap();
+    assert!(sub.next().is_some());
+
+    // check if we are really unsubscribed and cannot get further messages
+    js.publish("foo", payload).unwrap();
+    assert!(sub.next().is_none());
 }
 
 #[test]


### PR DESCRIPTION
All unsubscribe methods were actually draining.
Also, some `drain`s discarded messages, which should not happen.
Added tests.

fixes #297