### PR TITLE
Add a public convenience interface to header maps

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -18,6 +18,9 @@ use std::{
     ops::Deref,
 };
 
+use std::collections::hash_set;
+use std::iter::Iterator;
+
 use log::trace;
 
 const HEADER_LINE: &str = "NATS/1.0";
@@ -54,7 +57,7 @@ pub const NATS_CONSUMER_STALLED: &str = "Nats-Consumer-Stalled";
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct HeaderMap {
     /// A multi-map from header name to a set of values for that header
-    pub inner: HashMap<String, HashSet<String>>,
+    inner: HashMap<String, HashSet<String>>,
 }
 
 impl FromIterator<(String, String)> for HeaderMap {
@@ -229,6 +232,178 @@ impl Deref for HeaderMap {
 }
 
 impl HeaderMap {
+    /// Creates a new header map
+    ///
+    pub fn new() -> HeaderMap {
+        HeaderMap::default()
+    }
+
+    /// Clears the map, removing all key-value pairs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use nats::HeaderMap;
+    /// # use nats::header::STATUS;
+    /// let mut map = HeaderMap::new();
+    /// map.insert(STATUS, "200".to_string());
+    ///
+    /// map.clear();
+    /// assert!(map.is_empty());
+    /// ```
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    /// Returns true if the map contains no elements.
+    ///
+    ///  # Examples
+    ///
+    /// ```
+    /// # use nats::HeaderMap;
+    /// # use nats::header::STATUS;
+    /// let mut map = HeaderMap::new();
+    ///
+    /// assert!(map.is_empty());
+    ///
+    /// map.insert(STATUS, "200".to_string());
+    ///
+    /// assert!(!map.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns `true` if the map contains a value for the specified key.
+    ///
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.inner.contains_key(key)
+    }
+}
+
+impl HeaderMap {
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the map did not previously have this key present, then `None` is
+    /// returned.
+    ///
+    /// If the map did have this key present, the new value is associated with
+    /// the key and all previous values are removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::HashSet;
+    /// # use std::iter::FromIterator;
+    /// # use nats::HeaderMap;
+    /// # use nats::header::STATUS;
+    /// let mut map = HeaderMap::new();
+    /// map.insert(STATUS, "200");
+    /// assert!(!map.is_empty());
+    ///
+    /// let mut previous_set = map.insert(STATUS, "302").unwrap();
+    /// assert_eq!(HashSet::from_iter(["200".to_string()]), previous_set);
+    /// ```
+    pub fn insert<K, V>(&mut self, key: K, value: V) -> Option<HashSet<String>>
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let mut value_set = HashSet::new();
+        value_set.insert(value.into());
+
+        self.inner.insert(key.into(), value_set)
+    }
+
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the map did not previously have this key present, then false is returned.
+    ///
+    /// If the map did have this key present, the new value is inserted to the end of the set of values currently associated with the key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use nats::HeaderMap;
+    /// # use nats::header::STATUS;
+    /// let mut map = HeaderMap::new();
+    /// map.append(STATUS, "200");
+    /// assert!(!map.is_empty());
+    ///
+    /// ```
+    pub fn append<K, V>(&mut self, key: K, value: V) -> bool
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.inner
+            .entry(key.into())
+            .or_insert_with(HashSet::default)
+            .insert(value.into())
+    }
+
+    /// Returns a reference to the value associated with the key.
+    ///
+    /// If there are multiple values associated with the key, then the first one
+    /// is returned. Use `get_all` to get all values associated with a given
+    /// key. Returns `None` if there are no values associated with the key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use nats::HeaderMap;
+    /// # use nats::header::STATUS;
+    /// let mut map = HeaderMap::new();
+    /// assert!(map.get(STATUS).is_none());
+    ///
+    /// map.insert(STATUS, "200".to_string());
+    /// assert_eq!(map.get(STATUS).unwrap(), &"200");
+    /// ```
+    pub fn get<K: ?Sized>(&self, key: &K) -> Option<&String>
+    where
+        K: ToString,
+    {
+        self.inner
+            .get(&key.to_string())
+            .and_then(|values| values.iter().next())
+    }
+
+    /// Returns a view of all values associated with a key.
+    ///
+    /// The returned view does not incur any allocations and allows iterating
+    /// the values associated with the key.  See [`GetAll`] for more details.
+    /// Returns `None` if there are no values associated with the key.
+    ///
+    /// [`GetAll`]: struct.GetAll.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use nats::HeaderMap;
+    /// # use nats::header::STATUS;
+    /// let mut map = HeaderMap::new();
+    ///
+    /// map.insert(STATUS, "hello");
+    /// map.append(STATUS, "goodbye");
+    ///
+    /// let values = map.get_all(STATUS);
+    ///
+    /// // Will print in an arbitrary order.
+    /// for x in values {
+    ///   println!("{}", x);
+    /// }
+    /// ```
+    ///
+    pub fn get_all<K: ?Sized>(&self, key: &K) -> GetAll<'_>
+    where
+        K: ToString,
+    {
+        GetAll {
+            map: self,
+            key: key.to_string(),
+        }
+    }
+
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         // `<version line>\r\n[headers]\r\n\r\n[payload]\r\n`
         let mut buf = vec![];
@@ -243,6 +418,74 @@ impl HeaderMap {
         }
         buf.extend_from_slice(b"\r\n");
         buf
+    }
+}
+
+/// A view to all values stored in a single entry.
+///
+/// This struct is returned by `HeaderMap::get_all`.
+#[derive(Debug)]
+pub struct GetAll<'a> {
+    map: &'a HeaderMap,
+    key: String,
+}
+
+impl<'a> GetAll<'a> {
+    /// Returns an iterator visiting all values associated with the entry.
+    ///
+    /// The values are iterated on in an arbitrary but deterministic order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use nats::HeaderMap;
+    /// # use nats::header::STATUS;
+    /// let mut map = HeaderMap::new();
+    /// map.insert(STATUS, "hello");
+    /// map.append(STATUS, "goodbye");
+    ///
+    /// let values = map.get_all(STATUS);
+    ///
+    /// // Will print in an arbitrary order.
+    /// for x in values {
+    ///   println!("{}", x);
+    /// }
+    /// ```
+    pub fn iter(&self) -> ValueIter<'a> {
+        // This creates a new GetAll struct so that the lifetime
+        // isn't bound to &self.
+        GetAll {
+            map: self.map,
+            key: self.key.to_owned(),
+        }
+        .into_iter()
+    }
+}
+
+impl<'a> IntoIterator for GetAll<'a> {
+    type Item = &'a String;
+    type IntoIter = ValueIter<'a>;
+
+    fn into_iter(self) -> ValueIter<'a> {
+        ValueIter {
+            maybe_inner: self.map.inner.get(&self.key).map(|values| values.iter()),
+        }
+    }
+}
+
+/// Iterator for iterating over values.
+pub struct ValueIter<'a> {
+    maybe_inner: Option<hash_set::Iter<'a, String>>,
+}
+
+impl<'a> Iterator for ValueIter<'a> {
+    type Item = &'a String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.maybe_inner {
+            Some(inner) => inner.next(),
+            None => None,
+        }
     }
 }
 

--- a/src/jetstream/mod.rs
+++ b/src/jetstream/mod.rs
@@ -95,7 +95,7 @@
 //! internally managed consumer resource that gets destroyed when the subscription is dropped.
 //!
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::VecDeque,
     convert::TryFrom,
     error, fmt,
     fmt::Debug,
@@ -608,48 +608,23 @@ impl JetStream {
             let mut headers = maybe_headers.map_or_else(HeaderMap::default, HeaderMap::clone);
 
             if let Some(v) = options.id.as_ref() {
-                let entry = headers
-                    .inner
-                    .entry(header::NATS_MSG_ID.to_string())
-                    .or_insert_with(HashSet::default);
-
-                entry.insert(v.to_string());
+                headers.insert(header::NATS_MSG_ID, v.to_string());
             }
 
             if let Some(v) = options.expected_last_msg_id.as_ref() {
-                let entry = headers
-                    .inner
-                    .entry(header::NATS_EXPECTED_LAST_MSG_ID.to_string())
-                    .or_insert_with(HashSet::default);
-
-                entry.insert(v.to_string());
+                headers.insert(header::NATS_EXPECTED_LAST_MSG_ID, v.to_string());
             }
 
             if let Some(v) = options.expected_stream.as_ref() {
-                let entry = headers
-                    .inner
-                    .entry(header::NATS_EXPECTED_STREAM.to_string())
-                    .or_insert_with(HashSet::default);
-
-                entry.insert(v.to_string());
+                headers.insert(header::NATS_EXPECTED_STREAM, v.to_string());
             }
 
             if let Some(v) = options.expected_last_sequence.as_ref() {
-                let entry = headers
-                    .inner
-                    .entry(header::NATS_EXPECTED_LAST_SEQUENCE.to_string())
-                    .or_insert_with(HashSet::default);
-
-                entry.insert(v.to_string());
+                headers.insert(header::NATS_EXPECTED_LAST_SEQUENCE, v.to_string());
             }
 
             if let Some(v) = options.expected_last_subject_sequence.as_ref() {
-                let entry = headers
-                    .inner
-                    .entry(header::NATS_EXPECTED_LAST_SUBJECT_SEQUENCE.to_string())
-                    .or_insert_with(HashSet::default);
-
-                entry.insert(v.to_string());
+                headers.insert(header::NATS_EXPECTED_LAST_SUBJECT_SEQUENCE, v.to_string());
             }
 
             Some(headers)
@@ -1330,16 +1305,11 @@ impl JetStream {
                     let maybe_consumer_stalled = message
                         .headers
                         .as_ref()
-                        .and_then(|headers| {
-                            headers
-                                .get(header::NATS_CONSUMER_STALLED)
-                                .map(|set| set.iter().cloned().next())
-                        })
-                        .flatten();
+                        .and_then(|headers| headers.get(header::NATS_CONSUMER_STALLED));
 
                     if let Some(consumer_stalled) = maybe_consumer_stalled {
                         context.connection.try_publish_with_reply_or_headers(
-                            &consumer_stalled,
+                            consumer_stalled,
                             None,
                             None,
                             b"",
@@ -1349,12 +1319,7 @@ impl JetStream {
                     let maybe_consumer_seq = message
                         .headers
                         .as_ref()
-                        .and_then(|headers| {
-                            headers
-                                .get(header::NATS_LAST_CONSUMER)
-                                .map(|set| set.iter().cloned().next())
-                        })
-                        .flatten();
+                        .and_then(|headers| headers.get(header::NATS_LAST_CONSUMER));
 
                     if let Some(consumer_seq) = maybe_consumer_seq {
                         let consumer_seq = consumer_seq.parse::<u64>().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,8 @@ pub type ConnectionOptions = Options;
 #[deprecated(since = "0.17.0", note = "this has been moved to `header::HeaderMap`.")]
 pub type Headers = HeaderMap;
 
+pub use header::HeaderMap;
+
 use std::{
     io::{self, Error, ErrorKind},
     sync::Arc,
@@ -267,7 +269,6 @@ pub use rustls;
 pub use connect::ConnectInfo;
 
 use client::Client;
-use header::HeaderMap;
 use options::AuthStyle;
 use secure_wipe::{SecureString, SecureVec};
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -105,35 +105,32 @@ impl Message {
         if !self.data.is_empty() {
             return false;
         }
-        if let Some(hdrs) = &self.headers {
-            if let Some(set) = hdrs.get(header::STATUS) {
-                if set.get("503").is_some() {
-                    return true;
-                }
+
+        if let Some(headers) = &self.headers {
+            if headers.get(header::STATUS) == Some(&"503".to_string()) {
+                return true;
             }
         }
+
         false
     }
 
     /// Determine if a message is `404 No Messages`.
     pub(crate) fn is_no_messages(&self) -> bool {
-        if let Some(hdrs) = &self.headers {
-            if let Some(set) = hdrs.get(header::STATUS) {
-                if set.get("404").is_some() {
-                    return true;
-                }
+        if let Some(headers) = &self.headers {
+            if headers.get(header::STATUS) == Some(&"404".to_string()) {
+                return true;
             }
         }
+
         false
     }
 
     // Determine if a message is `408 Request Timeout`.
     pub(crate) fn is_request_timeout(&self) -> bool {
-        if let Some(hdrs) = &self.headers {
-            if let Some(set) = hdrs.get(header::STATUS) {
-                if set.get("408").is_some() {
-                    return true;
-                }
+        if let Some(headers) = &self.headers {
+            if headers.get(header::STATUS) == Some(&"408".to_string()) {
+                return true;
             }
         }
         false
@@ -146,20 +143,16 @@ impl Message {
         }
 
         if let Some(headers) = &self.headers {
-            if let Some(set) = headers.get(header::STATUS) {
-                if set.get("100").is_none() {
-                    return false;
-                }
+            if headers.get(header::STATUS) != Some(&"100".to_string()) {
+                return false;
             }
 
-            if let Some(set) = headers.get(header::DESCRIPTION) {
-                if set.get("Flow Control").is_some() {
-                    return true;
-                }
+            if headers.get(header::DESCRIPTION) == Some(&"Flow Control".to_string()) {
+                return true;
+            }
 
-                if set.get("FlowControl Request").is_some() {
-                    return true;
-                }
+            if headers.get(header::DESCRIPTION) == Some(&"FlowControl Request".to_string()) {
+                return true;
             }
         }
 
@@ -173,16 +166,12 @@ impl Message {
         }
 
         if let Some(headers) = &self.headers {
-            if let Some(set) = headers.get(header::STATUS) {
-                if set.get("100").is_none() {
-                    return false;
-                }
+            if headers.get(header::STATUS) != Some(&"100".to_string()) {
+                return false;
             }
 
-            if let Some(set) = headers.get(header::DESCRIPTION) {
-                if set.get("Idle Heartbeat").is_some() {
-                    return true;
-                }
+            if headers.get(header::DESCRIPTION) == Some(&"Idle Heartbeat".to_string()) {
+                return true;
             }
         }
 

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -25,7 +25,6 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::cmp;
-use std::collections::HashSet;
 use std::io;
 use std::time::Duration;
 
@@ -455,12 +454,7 @@ impl ObjectStore {
 
         let data = serde_json::to_vec(&object_info)?;
         let mut headers = HeaderMap::default();
-        let entry = headers
-            .inner
-            .entry(NATS_ROLLUP.to_string())
-            .or_insert_with(HashSet::default);
-
-        entry.insert(ROLLUP_SUBJECT.to_string());
+        headers.insert(NATS_ROLLUP, ROLLUP_SUBJECT.to_string());
 
         let message = Message::new(&subject, None, data, Some(headers));
 
@@ -558,12 +552,7 @@ impl ObjectStore {
         let data = serde_json::to_vec(&object_info)?;
 
         let mut headers = HeaderMap::default();
-        let entry = headers
-            .inner
-            .entry(NATS_ROLLUP.to_string())
-            .or_insert_with(HashSet::default);
-
-        entry.insert(ROLLUP_SUBJECT.to_string());
+        headers.insert(NATS_ROLLUP, ROLLUP_SUBJECT.to_string());
 
         let subject = format!("$O.{}.M.{}", &self.name, &object_name);
         let message = Message::new(&subject, None, data, Some(headers));

--- a/tests/jetstream.rs
+++ b/tests/jetstream.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashSet, io, iter::FromIterator, time::Duration};
+use std::{io, time::Duration};
 
 mod util;
 use nats::jetstream;
@@ -247,10 +247,8 @@ fn jetstream_publish() {
     assert_eq!(
         msg.headers
             .unwrap()
-            .inner
-            .get("Nats-Expected-Last-Subject-Sequence")
-            .unwrap(),
-        &HashSet::from_iter(vec!["1".to_string()])
+            .get("Nats-Expected-Last-Subject-Sequence"),
+        Some(&"1".to_string())
     );
 }
 


### PR DESCRIPTION
This adds an actual API for headers instead of exposing `inner` publicly.

- [x] Add methods for `append`, `insert` and `get`.
- [x] Make inner private, remove all uses of inner internally.
- [x] Lint (ToString is a bit bad here, probably use where Key is `Into<String>` instead)
- [x] Implement `get_all(key: K)`

This is a breaking change.