### PR TITLE
Export subscription modules

### DIFF
--- a/src/jetstream/mod.rs
+++ b/src/jetstream/mod.rs
@@ -113,19 +113,24 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 const ORDERED_IDLE_HEARTBEAT: Duration = Duration::from_nanos(5_000_000_000);
 
-mod pull_subscription;
-mod push_subscription;
+/// Pull subscriptions
+pub mod pull_subscription;
+
+/// Pull subscriptions
+pub mod push_subscription;
+
 mod types;
 
-pub use push_subscription::PushSubscription;
+// We use a fully qualified crate path so these are documented as re-exports.
+pub use crate::jetstream::pull_subscription::PullSubscription;
+pub use crate::jetstream::push_subscription::PushSubscription;
+
 pub use types::*;
 
 use crate::{
     header::{self, HeaderMap},
     Connection, Message,
 };
-
-use self::pull_subscription::PullSubscription;
 
 /// `JetStream` options
 #[derive(Clone)]

--- a/src/jetstream/mod.rs
+++ b/src/jetstream/mod.rs
@@ -116,7 +116,7 @@ const ORDERED_IDLE_HEARTBEAT: Duration = Duration::from_nanos(5_000_000_000);
 /// Pull subscriptions
 pub mod pull_subscription;
 
-/// Pull subscriptions
+/// Push subscriptions
 pub mod push_subscription;
 
 mod types;

--- a/src/jetstream/mod.rs
+++ b/src/jetstream/mod.rs
@@ -121,7 +121,6 @@ pub mod push_subscription;
 
 mod types;
 
-
 // We use a fully qualified crate path so these are documented as re-exports.
 pub use crate::jetstream::pull_subscription::PullSubscription;
 pub use crate::jetstream::push_subscription::PushSubscription;

--- a/src/jetstream/pull_subscription.rs
+++ b/src/jetstream/pull_subscription.rs
@@ -362,7 +362,6 @@ impl PullSubscription {
     /// # Ok(())
     /// # }
     /// ```
-
     pub fn fetch_with_handler<F, I>(&self, batch: I, mut handler: F) -> io::Result<()>
     where
         F: FnMut(&Message) -> io::Result<()>,
@@ -388,6 +387,7 @@ impl PullSubscription {
         Ok(())
     }
 
+    /// Returns an iterator that will wait endlessly for messages.
     pub fn iter(&self) -> Iter<'_> {
         Iter { subscription: self }
     }
@@ -499,6 +499,7 @@ impl<'a> Iterator for TimeoutBatchIter<'a> {
 /// Trait that allows to set `BatchOptions` in different ways. Currently implemented for `usize`
 /// which allows passing just a message batch number instead of a whole struct.
 pub trait IntoFetchOptions {
+    ///  Converts self into `BatchOptions`
     fn into_fetch_opts(self) -> BatchOptions;
 }
 


### PR DESCRIPTION
A few types like `nats::jetstream::push_subscription::Handler` were voldemort types.

This exports the `push_subscription` and `pull_subscription` modules to
avoid that scenario.