### PR TITLE
Release v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.18.1
+## Overview
+A patch release fixing long durations until `close()` returned. It was introduced in the graceful shutdown of client connection threads in v0.18.0.
+
+Dropping NATS connection was not affected.
+
+## Fixed
+* Fix slow connection closing by @Jarema in https://github.com/nats-io/nats.rs/pull/319
+* Fix close() hang after js.subscribe() is called by @Jarema https://github.com/nats-io/nats.rs/pull/321
+* Fix close() hang after Push Consumer subsription edge case by @Jarema https://github.com/nats-io/nats.rs/pull/323
+
+## Minor
+* Replace custom Into trait with From by @Jarema in https://github.com/nats-io/nats.rs/pull/315
+
+**Full Changelog**: https://github.com/nats-io/nats.rs/compare/v0.18.0...v0.18.1
+
 # 0.18.0
 ## Overview
 This release focuses mainly around fixes of large changes introduces in 0.17.0, but also improves adds slow consumers support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nats"
-version = "0.18.0"
+version = "0.18.1"
 description = "A Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"


### PR DESCRIPTION
# 0.18.1
## Overview
A patch release fixing long durations until `close()` returned. It was introduced in the graceful shutdown of client connection threads in v0.18.0.

Dropping NATS connection was not affected.
