### PR TITLE
Bump nuid dependency to `0.3.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ json = "0.12.4"
 lazy_static = "1.4.0"
 log = "0.4.14"
 nkeys = "0.1.0"
-nuid = "0.3.0"
+nuid = "0.3.1"
 once_cell = "1.8.0"
 parking_lot = "0.11.1"
 regex = { version = "1.5.4", default-features = false, features = ["std", "unicode-perl"] }


### PR DESCRIPTION
This is necessary as `0.3.0` was depending on `rand = "0"` thus it is possible for it to switch back to `0.7` or older, which just happened with `nuid` coming in transitively from our dependency on nats. The only change between `nuid 0.3.0` and `0.3.1` is the refinement of the `rand` version constraint. So I bet this is safe.