### PR TITLE
Add Nak backoff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,13 +50,15 @@ rustls = "0.19.1"
 rustls-native-certs = "0.5.0"
 rustls-pemfile = "0.2.1"
 webpki = "0.21.0"
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.64"
-serde_nanos = "0.1.1"
+# serde_nanos = { path = "../serde_nanos" }
+serde_nanos = "0.1"
 serde_repr = "0.1.7"
 memchr = "2.4.0"
 url = "2.2.2"
 time = { version = "0.3.6", features = ["parsing", "formatting", "serde", "serde-well-known"] }
+format-bytes = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.98"

--- a/src/jetstream/types.rs
+++ b/src/jetstream/types.rs
@@ -217,7 +217,7 @@ pub struct ConsumerConfig {
     pub max_deliver: i64,
     // Array of durations representing backoff directive that is used for delivery retries
     #[serde(default, skip_serializing_if = "is_default")]
-    pub backoff: DurationVec,
+    pub backoff: Vec<Duration>,
     /// When consuming from a Stream with many subjects, or wildcards, this selects only specific incoming subjects. Supports wildcards.
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subject: String,
@@ -255,12 +255,6 @@ pub struct ConsumerConfig {
     /// Threshold for ephemeral consumer intactivity
     #[serde(default, with = "serde_nanos", skip_serializing_if = "is_default")]
     pub inactive_threshold: Duration,
-}
-
-#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone, Debug)]
-#[serde(transparent)]
-pub struct DurationVec {
-    pub inner: Vec<Duration>,
 }
 
 pub(crate) enum ConsumerKind {

--- a/src/message.rs
+++ b/src/message.rs
@@ -199,7 +199,7 @@ impl Message {
     ///
     /// Does not check whether this message has already been double-acked.
     pub fn ack_kind(&self, ack_kind: crate::jetstream::AckKind) -> io::Result<()> {
-        self.respond(ack_kind)
+        self.respond(ack_kind.to_bytes())
     }
 
     /// Acknowledge a `JetStream` message and wait for acknowledgement from the server
@@ -241,7 +241,8 @@ impl Message {
             let sub =
                 crate::Subscription::new(sid, ack_reply.to_string(), receiver, client.clone());
 
-            let pub_ret = client.publish(original_reply, Some(&ack_reply), None, ack_kind.as_ref());
+            let pub_ret =
+                client.publish(original_reply, Some(&ack_reply), None, &ack_kind.to_bytes());
             if pub_ret.is_err() {
                 std::thread::sleep(std::time::Duration::from_millis(100));
                 continue;

--- a/tests/jetstream.rs
+++ b/tests/jetstream.rs
@@ -792,9 +792,9 @@ fn jetstream_pull_subscribe_bad_stream() {
 }
 
 #[test]
-fn add_consumer() {
+fn jetstream_nak_backoff() {
     let s = util::run_server("tests/configs/jetstream.conf");
-    let con = nats::connect("localhost:4222").unwrap();
+    let con = nats::connect(s.client_url()).unwrap();
 
     let js = nats::jetstream::new(con);
 


### PR DESCRIPTION
This is blocked until `serde-nanos` supports serialization/deserialization for `Vec<std::time::Duration>`.

Addresses https://github.com/nats-io/nats-architecture-and-design/issues/89