### PR TITLE
Link to asynk module instead of async-nats

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,12 @@
 //! system for cloud native applications, `IoT` messaging, and microservices
 //! architectures.
 //!
-//! For async API refer to the [`async-nats`] crate.
+//! For async API refer to the [`asynk`] module.
 //!
 //! For more information see [https://nats.io/].
 //!
 //! [https://nats.io/]: https://nats.io/
-//! [`async-nats`]: https://docs.rs/async-nats
+//! [`async`]: crate::async
 //!
 //! ## Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! For more information see [https://nats.io/].
 //!
 //! [https://nats.io/]: https://nats.io/
-//! [`async`]: crate::async
 //!
 //! ## Examples
 //!


### PR DESCRIPTION
I was confused about the difference between `async-nats` and `asynk` but eventually came across #192. Hopefully this will help clarify things for new users.