### PR TITLE
Bump rustls to `0.20.4`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ nuid = "0.3.1"
 once_cell = "1.8.0"
 parking_lot = "0.11.1"
 regex = { version = "1.5.4", default-features = false, features = ["std", "unicode-perl"] }
-rustls = "0.19.1"
+rustls = "0.20.4"
 rustls-native-certs = "0.5.0"
 rustls-pemfile = "0.2.1"
 webpki = "0.21.0"


### PR DESCRIPTION
This allows building `nats` on Apple M1 devices, because `rustlts` v0.19 depends on `ring` v0.16.12, which build failed on M1.
Issue: https://github.com/briansmith/ring/issues/1163