### PR TITLE
Make subscribe not require `blocking` by using `flume` instead of `crossbeam-channel`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ split-debuginfo = "unpacked"
 base64 = "0.13.0"
 base64-url = "1.4.10"
 blocking = "1.1.0"
-crossbeam-channel = "0.5.1"
 fastrand = "1.5.0"
 itoa = "1.0.1"
 json = "0.12.4"
@@ -57,6 +56,7 @@ serde_repr = "0.1.7"
 memchr = "2.4.0"
 url = "2.2.2"
 time = { version = "0.3.6", features = ["parsing", "formatting", "serde", "serde-well-known"] }
+flume = "0.10.12"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.98"

--- a/src/client.rs
+++ b/src/client.rs
@@ -189,11 +189,10 @@ impl Client {
 
         channel::select::Selector::new()
             .recv(&run_receiver, |res| {
-                res.unwrap().expect("client thread has panicked");
-                unreachable!()
+                res.expect("client thread has panicked")
             })
-            .recv(&pong_receiver, |_| {})
-            .wait();
+            .recv(&pong_receiver, |_| Ok(()))
+            .wait()?;
 
         // Spawn a thread that periodically flushes buffered messages.
         let handle = thread::spawn({

--- a/src/jetstream/pull_subscription.rs
+++ b/src/jetstream/pull_subscription.rs
@@ -19,7 +19,7 @@ use crate::jetstream::{ConsumerInfo, ConsumerOwnership, JetStream};
 use crate::Message;
 
 use super::{AckPolicy, BatchOptions};
-use crossbeam_channel as channel;
+use flume as channel;
 
 #[derive(Debug)]
 pub(crate) struct Inner {

--- a/src/jetstream/push_subscription.rs
+++ b/src/jetstream/push_subscription.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel as channel;
+use flume as channel;
 
 use crate::jetstream::{AckPolicy, ConsumerInfo, ConsumerOwnership, JetStream};
 use crate::message::Message;

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel as channel;
+use flume as channel;
 
 use crate::client::Client;
 use crate::message::Message;

--- a/tests/async_errors.rs
+++ b/tests/async_errors.rs
@@ -13,7 +13,7 @@
 
 use std::time::Duration;
 
-use crossbeam_channel::bounded;
+use flume::bounded;
 
 mod util;
 pub use util::*;

--- a/tests/lame_duck_mode.rs
+++ b/tests/lame_duck_mode.rs
@@ -14,7 +14,7 @@
 mod util;
 use std::time::Duration;
 
-use crossbeam_channel::bounded;
+use flume::bounded;
 pub use util::*;
 
 #[test]


### PR DESCRIPTION
Hi. This is a pretty big architectural change, and it's more of a suggestion than something I think should be merged in its current form.

As discussed (for instance in #210), using `blocking` in subscriptions means that there is a thread started for every subscription. This is non-optimal for codebases which are based on being async.

The reason for this is that `next()` for a subscriptions uses `crossbeam-channels`, which is blocking. However there is a competitor to `crossbeam-channels`, called [flume](https://crates.io/crates/flume). They have both a sync and async API for the same receiver. My idea is to change from the one to the other.

`flume` and `crossbeam-channels` have mostly the same API, so most of this PR is just changing from the one to the other. The only difference is how `select` is done.

I have changed subscriptions to use the async-api for `flume`, everything else is exactly as it was with `crossbeam`.

All tests are green, and my testing shows it works as good as using crossbeam. I have not done any benchmarks.

Note that nats is exposing the crossbeam channel in `receiver()`, which means that we either need to create a adapter from flume to crossbeam, or this will be a breaking change.

Hope you think this is interesting. Please let me know if you want to merge this, I will gladly make changes to make this more "mergeable". If you're not interested, let me know so that we can maintain our own fork.