### PR TITLE
Bind to nats-server 2.7.4 and fixed deadlocked tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           go-version: '1.16'
 
       - name: Install nats-server
-        run: go get github.com/nats-io/nats-server/v2
+        run: go get github.com/nats-io/nats-server/v2@v2.7.4
 
       - name: Run tests
         env:

--- a/nats/src/jetstream/pull_subscription.rs
+++ b/nats/src/jetstream/pull_subscription.rs
@@ -397,9 +397,12 @@ impl PullSubscription {
     /// # use nats::jetstream::BatchOptions;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
-    /// # let context = nats::jetstream::new(client);
+    /// # let context = nats::jetstream::new(client.clone());
     /// #
     /// # context.add_stream("next")?;
+    /// # for i in 0..20 {
+    /// # client.publish("next", b"data")?;
+    /// # }
     ///
     /// let consumer = context.pull_subscribe("next")?;
     /// // request specific number of messages.
@@ -414,6 +417,7 @@ impl PullSubscription {
     /// for (i, message) in consumer.iter().enumerate() {
     ///     println!("recieved message: {:?}", message);
     ///     message.ack()?;
+    /// #   break;
     /// }
     /// # Ok(())
     /// # }

--- a/nats/src/subscription.rs
+++ b/nats/src/subscription.rs
@@ -228,6 +228,7 @@ impl Subscription {
     /// ```
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
+    /// # nc.publish("bar", b"data")?;
     /// nc.subscribe("bar")?.with_handler(move |msg| {
     ///     println!("Received {}", &msg);
     ///     Ok(())


### PR DESCRIPTION
This is a workaround until we find reason why few test fails
with the new version of the server.

Also fixes doc examples that were relying on `demo.nats.io` having streams with messages.