### PR TITLE
Use local server for documentation tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
           go-version: '1.16'
 
       - name: install nats-server
-        run: go get github.com/nats-io/nats-server/v2
+        run: go get github.com/nats-io/nats-server/v2@v2.7.4
 
       - name: Start nats-server
         run: nats-server --jetstream &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,12 @@ jobs:
       - name: install nats-server
         run: go get github.com/nats-io/nats-server/v2
 
+      - name: Start nats-server
+        run: nats-server --jetstream &
+
+      - name: Configure nats-server
+        run: echo 'localhost:4444 demo.nats.io' | sudo tee -a /etc/hosts
+
       - name: Run documentation tests
         env:
           RUST_LOG: trace


### PR DESCRIPTION
We run doctests in an isolated task, should be fine to grab port 4222 and run a local server on that redirecting demo.nats.io to it.