### PR TITLE
Support sending and receiving messages with headers

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -20,6 +20,7 @@ futures-util = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] } 
 serde_json = "1.0.79"
 serde_repr = "0.1.7"
+http = "0.2.7"
 tokio = { version = "1.16.1", features = ["full"] }
 tokio-util = { version = "0.7.0", features = ["codec"] }
 itoa = "1"

--- a/async-nats/src/header.rs
+++ b/async-nats/src/header.rs
@@ -1,0 +1,1 @@
+pub use http::header::{HeaderMap, HeaderName, HeaderValue};

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -141,8 +141,12 @@ const LANG: &str = "rust";
 /// must be provided using `Options::tls_client_config`.
 pub use tokio_rustls::rustls;
 
+use header::HeaderName;
+pub use header::{HeaderMap, HeaderValue};
+
 mod options;
 pub use options::ConnectOptions;
+pub mod header;
 mod tls;
 
 /// Information sent by the server back to this client
@@ -213,6 +217,7 @@ pub(crate) enum ServerOp {
         subject: String,
         reply: Option<String>,
         payload: Bytes,
+        headers: Option<HeaderMap>,
     },
 }
 
@@ -222,6 +227,7 @@ pub enum Command {
         subject: String,
         payload: Bytes,
         respond: Option<String>,
+        headers: Option<HeaderMap>,
     },
     Subscribe {
         sid: u64,
@@ -247,6 +253,7 @@ pub enum ClientOp {
         subject: String,
         payload: Bytes,
         respond: Option<String>,
+        headers: Option<HeaderMap>,
     },
     Subscribe {
         sid: u64,
@@ -363,7 +370,126 @@ impl Connection {
                     return Ok(Some(ServerOp::Message {
                         sid,
                         reply: reply_to,
+                        headers: None,
                         subject,
+                        payload,
+                    }));
+                }
+            }
+
+            return Ok(None);
+        }
+
+        if self.buffer.starts_with(b"HMSG ") {
+            if let Some(len) = self.buffer.find(b"\r\n") {
+                // Extract whitespace-delimited arguments that come after "HMSG".
+                let line = std::str::from_utf8(&self.buffer[5..len]).unwrap();
+                let args = line.split_whitespace().filter(|s| !s.is_empty());
+                let args = args.collect::<Vec<_>>();
+
+                // <subject> <sid> [reply-to] <# header bytes><# total bytes>
+                let (subject, sid, reply_to, num_header_bytes, num_bytes) = match args[..] {
+                    [subject, sid, num_header_bytes, num_bytes] => {
+                        (subject, sid, None, num_header_bytes, num_bytes)
+                    }
+                    [subject, sid, reply_to, num_header_bytes, num_bytes] => {
+                        (subject, sid, Some(reply_to), num_header_bytes, num_bytes)
+                    }
+                    _ => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "invalid number of arguments after HMSG",
+                        ));
+                    }
+                };
+
+                // Convert the slice into an owned string.
+                let subject = subject.to_string();
+
+                // Parse the subject ID.
+                let sid = u64::from_str(sid).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "cannot parse sid argument after HMSG",
+                    )
+                })?;
+
+                // Convert the slice into an owned string.
+                let reply_to = reply_to.map(ToString::to_string);
+
+                // Parse the number of payload bytes.
+                let num_header_bytes = usize::from_str(num_header_bytes).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "cannot parse the number of header bytes argument after \
+                     HMSG",
+                    )
+                })?;
+
+                // Parse the number of payload bytes.
+                let num_bytes = usize::from_str(num_bytes).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "cannot parse the number of bytes argument after HMSG",
+                    )
+                })?;
+
+                if num_bytes < num_header_bytes {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "number of header bytes was greater than or equal to the \
+                 total number of bytes after HMSG",
+                    ));
+                }
+
+                // Only advance if there is enough data for the entire operation and payload remaining.
+                if len + num_bytes + 4 <= self.buffer.remaining() {
+                    self.buffer.advance(len + 2);
+                    let buffer = self.buffer.split_to(num_header_bytes).freeze();
+                    let payload = self.buffer.split_to(num_bytes - num_header_bytes).freeze();
+
+                    let mut lines = std::str::from_utf8(&buffer).unwrap().lines().peekable();
+
+                    let version_line = lines.next().ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidInput, "no header version line found")
+                    })?;
+
+                    if !version_line.starts_with("NATS/1.0") {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "header version line does not begin with nats/1.0",
+                        ));
+                    }
+
+                    let mut headers = HeaderMap::new();
+                    while let Some(line) = lines.next() {
+                        if line.is_empty() {
+                            continue;
+                        }
+
+                        let (key, value) = line.split_once(':').ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidInput,
+                                "no header version line found",
+                            )
+                        })?;
+
+                        let mut value = String::from_str(value).unwrap();
+                        while let Some(v) = lines.next_if(|s| s.starts_with(char::is_whitespace)) {
+                            value.push_str(v);
+                        }
+
+                        headers.append(
+                            HeaderName::from_str(key).unwrap(),
+                            HeaderValue::from_str(&value).unwrap(),
+                        );
+                    }
+
+                    return Ok(Some(ServerOp::Message {
+                        sid,
+                        reply: reply_to,
+                        subject,
+                        headers: Some(headers),
                         payload,
                     }));
                 }
@@ -405,19 +531,60 @@ impl Connection {
                 subject,
                 payload,
                 respond,
+                headers,
             } => {
-                let mut bufi = itoa::Buffer::new();
-                self.stream.write_all(b"PUB ").await?;
+                if headers.is_some() {
+                    self.stream.write_all(b"HPUB ").await?;
+                } else {
+                    self.stream.write_all(b"PUB ").await?;
+                }
+
                 self.stream.write_all(subject.as_bytes()).await?;
                 self.stream.write_all(b" ").await?;
+
                 if let Some(respond) = respond {
                     self.stream.write_all(respond.as_bytes()).await?;
                     self.stream.write_all(b" ").await?;
                 }
-                self.stream
-                    .write_all(bufi.format(payload.len()).as_bytes())
-                    .await?;
-                self.stream.write_all(b"\r\n").await?;
+
+                if let Some(headers) = headers {
+                    let mut header = Vec::new();
+                    header.extend_from_slice(b"NATS/1.0\r\n");
+                    for (key, value) in headers.iter() {
+                        header.extend_from_slice(key.as_ref());
+                        header.push(b':');
+                        header.extend_from_slice(value.as_ref());
+                        header.extend_from_slice(b"\r\n");
+                    }
+
+                    header.extend_from_slice(b"\r\n");
+
+                    let mut header_len_buf = itoa::Buffer::new();
+                    self.stream
+                        .write_all(header_len_buf.format(header.len()).as_bytes())
+                        .await?;
+
+                    self.stream.write_all(b" ").await?;
+
+                    let mut total_len_buf = itoa::Buffer::new();
+                    self.stream
+                        .write_all(
+                            total_len_buf
+                                .format(header.len() + payload.len())
+                                .as_bytes(),
+                        )
+                        .await?;
+
+                    self.stream.write_all(b"\r\n").await?;
+                    self.stream.write_all(&header).await?;
+                } else {
+                    let mut len_buf = itoa::Buffer::new();
+                    self.stream
+                        .write_all(len_buf.format(payload.len()).as_bytes())
+                        .await?;
+                    self.stream.write_all(b"\r\n").await?;
+                }
+
                 self.stream.write_all(&payload).await?;
                 self.stream.write_all(b"\r\n").await?;
             }
@@ -691,6 +858,7 @@ impl ConnectionHandler {
                 subject,
                 reply,
                 payload,
+                headers,
             } => {
                 let mut context = self.subscription_context.lock().await;
 
@@ -699,6 +867,7 @@ impl ConnectionHandler {
                         subject,
                         reply,
                         payload,
+                        headers,
                     };
 
                     // if the channel for subscription was dropped, remove the
@@ -816,6 +985,7 @@ impl ConnectionHandler {
                 subject,
                 payload,
                 respond,
+                headers,
             } => {
                 while let Err(err) = self
                     .connection
@@ -823,6 +993,7 @@ impl ConnectionHandler {
                         subject: subject.clone(),
                         payload: payload.clone(),
                         respond: respond.clone(),
+                        headers: headers.clone(),
                     })
                     .await
                 {
@@ -890,6 +1061,24 @@ impl Client {
                 subject,
                 payload,
                 respond: None,
+                headers: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn publish_with_headers(
+        &mut self,
+        subject: String,
+        headers: HeaderMap,
+        payload: Bytes,
+    ) -> Result<(), Error> {
+        self.sender
+            .send(Command::Publish {
+                subject,
+                payload,
+                respond: None,
+                headers: Some(headers),
             })
             .await?;
         Ok(())
@@ -906,6 +1095,25 @@ impl Client {
                 subject,
                 payload,
                 respond: Some(reply),
+                headers: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn publish_with_reply_and_headers(
+        &mut self,
+        subject: String,
+        reply: String,
+        headers: HeaderMap,
+        payload: Bytes,
+    ) -> Result<(), Error> {
+        self.sender
+            .send(Command::Publish {
+                subject,
+                payload,
+                respond: Some(reply),
+                headers: Some(headers),
             })
             .await?;
         Ok(())
@@ -1107,6 +1315,7 @@ pub struct Message {
     pub subject: String,
     pub reply: Option<String>,
     pub payload: Bytes,
+    pub headers: Option<HeaderMap>,
 }
 
 /// Retrieves messages from given `subscription` created by [Client::subscribe].

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -122,6 +122,27 @@ mod client {
     }
 
     #[tokio::test]
+    async fn publish_with_headers() {
+        let server = nats_server::run_basic_server();
+        let mut client = async_nats::connect(server.client_url()).await.unwrap();
+
+        let mut subscriber = client.subscribe("test".into()).await.unwrap();
+
+        let mut headers = async_nats::HeaderMap::new();
+        headers.append("X-Test", b"Test".as_ref().try_into().unwrap());
+
+        client
+            .publish_with_headers("test".into(), headers.clone(), b"".as_ref().into())
+            .await
+            .unwrap();
+
+        client.flush().await.unwrap();
+
+        let message = subscriber.next().await.unwrap();
+        assert_eq!(message.headers.unwrap(), headers);
+    }
+
+    #[tokio::test]
     async fn publish_request() {
         let server = nats_server::run_basic_server();
         let mut client = async_nats::connect(server.client_url()).await.unwrap();


### PR DESCRIPTION
Header support for incoming and outgoing messages.
This time we're re-using the header types from the http crate.