### PR TITLE
Fix flaky connection callback test

### DIFF
--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -331,6 +331,7 @@ mod client {
     #[tokio::test]
     async fn connection_callbacks() {
         use async_nats::ServerAddr;
+        use std::time::Duration;
 
         let mut servers = vec![
             nats_server::run_basic_server(),
@@ -340,6 +341,7 @@ mod client {
         let (tx, mut rx) = tokio::sync::mpsc::channel(128);
         let (dc_tx, mut dc_rx) = tokio::sync::mpsc::channel(128);
         let mut nc = async_nats::ConnectOptions::new()
+            .ping_interval(Duration::from_millis(100))
             .reconnect_callback(move || {
                 let tx = tx.clone();
                 async move {

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -366,9 +366,9 @@ mod client {
             .await
             .unwrap();
         println!("conncted");
+        drop(servers.remove(0));
         nc.subscribe("test".to_string()).await.unwrap();
         nc.flush().await.unwrap();
-        drop(servers.remove(0));
         tokio::time::sleep(Duration::from_secs(3)).await;
         println!("dropped server");
         tokio::time::timeout(Duration::from_secs(15), dc_rx.recv())


### PR DESCRIPTION
Edit: this wasn't it, the server just doesn't get killed *sometimes*.