### PR TITLE
Do not flush in write calls

### DIFF
--- a/async-nats/src/connection.rs
+++ b/async-nats/src/connection.rs
@@ -392,7 +392,6 @@ impl Connection {
                 self.stream
                     .write_all(format!(" {}\r\n", sid).as_bytes())
                     .await?;
-                self.stream.flush().await?;
             }
 
             ClientOp::Unsubscribe { sid, max } => {
@@ -411,7 +410,6 @@ impl Connection {
             }
             ClientOp::Pong => {
                 self.stream.write_all(b"PONG\r\n").await?;
-                self.stream.flush().await?;
             }
         }
 

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -503,6 +503,7 @@ impl ConnectionHandler {
         match server_op {
             ServerOp::Ping => {
                 self.connection.write_op(ClientOp::Pong).await?;
+                self.connection.flush().await?;
             }
             ServerOp::Pong => {
                 self.pending_pings -= 1;
@@ -606,6 +607,8 @@ impl ConnectionHandler {
                 if let Err(_err) = self.connection.write_op(ClientOp::Ping).await {
                     self.handle_disconnect().await?;
                 }
+
+                self.connection.flush().await?;
             }
             Command::Flush { result } => {
                 if let Err(_err) = self.connection.flush().await {


### PR DESCRIPTION
We should flush when dealing with commands, rather than in the writer.