### PR TITLE
Handle `TryFlush` as a command

### DIFF
--- a/async-nats/src/connection.rs
+++ b/async-nats/src/connection.rs
@@ -369,9 +369,6 @@ impl Connection {
                 self.stream.write_all(b"PONG\r\n").await?;
                 self.stream.flush().await?;
             }
-            ClientOp::TryFlush => {
-                self.stream.flush().await?;
-            }
         }
 
         Ok(())

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -270,7 +270,6 @@ pub enum ClientOp {
     },
     Ping,
     Pong,
-    TryFlush,
     Connect(ConnectInfo),
 }
 
@@ -604,9 +603,7 @@ impl ConnectionHandler {
                 }
             }
             Command::TryFlush => {
-                if let Err(err) = self.connection.write_op(ClientOp::TryFlush).await {
-                    println!("Sending TryFlush failed with {:?}", err);
-                }
+                self.connection.flush().await?;
             }
             Command::Subscribe {
                 sid,


### PR DESCRIPTION
This inlines Command::TryFlush in the command handler, rather than doing it during operation encoding.