### PR TITLE
Fix all clippy warnings

### DIFF
--- a/async-nats/examples/pub.rs
+++ b/async-nats/examples/pub.rs
@@ -1,5 +1,4 @@
 use bytes::Bytes;
-use futures_util::StreamExt;
 use std::error::Error;
 use std::time::Instant;
 

--- a/async-nats/src/connection.rs
+++ b/async-nats/src/connection.rs
@@ -7,12 +7,7 @@ use bytes::{Buf, BytesMut};
 use tokio::io;
 
 use crate::header::{HeaderMap, HeaderName, HeaderValue};
-use crate::ClientOp;
-use crate::ConnectInfo;
-use crate::Protocol;
-use crate::ServerError;
-use crate::ServerInfo;
-use crate::ServerOp;
+use crate::{ClientOp, ServerError, ServerOp};
 
 /// Supertrait enabling trait object for containing both TLS and non TLS `TcpStream` connection.
 pub(crate) trait AsyncReadWrite: AsyncWrite + AsyncRead + Send + Unpin {}
@@ -384,7 +379,8 @@ impl Connection {
 
 #[cfg(test)]
 mod read_op {
-    use super::{Connection, HeaderMap, ServerError, ServerInfo, ServerOp};
+    use super::Connection;
+    use crate::{HeaderMap, ServerError, ServerInfo, ServerOp};
     use bytes::BytesMut;
     use tokio::io::{self, AsyncWriteExt};
 
@@ -558,7 +554,8 @@ mod read_op {
 
 #[cfg(test)]
 mod write_op {
-    use super::{ClientOp, ConnectInfo, Connection, HeaderMap, Protocol};
+    use super::Connection;
+    use crate::{ClientOp, ConnectInfo, HeaderMap, Protocol};
     use bytes::BytesMut;
     use tokio::io::{self, AsyncBufReadExt, BufReader};
 

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -14,12 +14,10 @@
 mod nats_server;
 
 mod client {
-
-    use std::{collections::HashMap, time::Duration};
-
     use super::nats_server;
     use bytes::Bytes;
     use futures_util::{future::join_all, StreamExt};
+    use std::time::Duration;
 
     #[tokio::test]
     async fn basic_pub_sub() {
@@ -73,7 +71,7 @@ mod client {
         for mut subscriber in subscribers.into_iter() {
             results.push(tokio::spawn(async move {
                 let mut count = 0u32;
-                while let Ok(Some(item)) = tokio::time::timeout(
+                while let Ok(Some(_)) = tokio::time::timeout(
                     tokio::time::Duration::from_millis(1000),
                     subscriber.next(),
                 )

--- a/async-nats/tests/nats_server/mod.rs
+++ b/async-nats/tests/nats_server/mod.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
 use std::io::{BufRead, BufReader};
 use std::net::TcpStream;
 use std::path::PathBuf;

--- a/nats/examples/nats-box/main.rs
+++ b/nats/examples/nats-box/main.rs
@@ -1,4 +1,3 @@
-use nats;
 use quicli::prelude::*;
 use structopt::{clap::ArgGroup, StructOpt};
 

--- a/nats/examples/nats_bench.rs
+++ b/nats/examples/nats_bench.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use historian::Histo;
-use nats;
 use structopt::StructOpt;
 
 lazy_static::lazy_static! {

--- a/nats/examples/serde-json/main.rs
+++ b/nats/examples/serde-json/main.rs
@@ -1,4 +1,3 @@
-use nats;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/nats/tests/util/mod.rs
+++ b/nats/tests/util/mod.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
 use std::io::{BufRead, BufReader};
 use std::net::TcpStream;
 use std::path::PathBuf;
@@ -131,7 +132,7 @@ pub fn run_server(cfg: &str) -> Server {
         .arg("-P")
         .arg(pidfile.as_os_str());
 
-    if cfg != "" {
+    if !cfg.is_empty() {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         cmd.arg("-c").arg(path.join(cfg));
     }


### PR DESCRIPTION
Fixed all linter warnings reported with:

```
cargo clippy --examples --tests --all-features -- --deny clippy::all 
```