### PR TITLE
Only retain non-closed subscriptions on reconnect

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -697,6 +697,9 @@ impl ConnectionHandler {
         let (_, connection) = self.connector.connect().await?;
         self.connection = connection;
 
+        self.subscriptions
+            .retain(|_, subscription| !subscription.sender.is_closed());
+
         for (sid, subscription) in &self.subscriptions {
             self.connection
                 .write_op(ClientOp::Subscribe {


### PR DESCRIPTION
If a subscriber is dropped during reconnect, it likely it never fired the unsubscribe command. But we know it closed so we can just not ever re-create the subscription.