### PR TITLE
Add convinience methods to Consumer management

### DIFF
--- a/async-nats/src/jetstream/consumer.rs
+++ b/async-nats/src/jetstream/consumer.rs
@@ -289,6 +289,11 @@ impl IntoConsumerConfig for PushConsumerConfig {
         }
     }
 }
+impl IntoConsumerConfig for &PushConsumerConfig {
+    fn into_consumer_config(self) -> ConsumerConfig {
+        self.clone().into_consumer_config()
+    }
+}
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct PullConsumerConfig {
@@ -380,6 +385,12 @@ impl IntoConsumerConfig for PullConsumerConfig {
             max_expires: self.max_expires,
             inactive_threshold: self.inactive_threshold,
         }
+    }
+}
+
+impl IntoConsumerConfig for &PullConsumerConfig {
+    fn into_consumer_config(self) -> ConsumerConfig {
+        self.clone().into_consumer_config()
     }
 }
 
@@ -506,6 +517,26 @@ impl From<&str> for ConsumerConfig {
             durable_name: Some(s.to_string()),
             ..Default::default()
         }
+    }
+}
+
+impl IntoConsumerConfig for ConsumerConfig {
+    fn into_consumer_config(self) -> ConsumerConfig {
+        self
+    }
+}
+impl IntoConsumerConfig for &ConsumerConfig {
+    fn into_consumer_config(self) -> ConsumerConfig {
+        self.clone()
+    }
+}
+
+impl FromConsumer for ConsumerConfig {
+    fn try_from_consumer_config(config: ConsumerConfig) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(config)
     }
 }
 

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -33,11 +33,11 @@ pub struct Stream {
 }
 
 impl Stream {
-    pub async fn create_consumer<C: Into<ConsumerConfig>>(
+    pub async fn create_consumer<C: IntoConsumerConfig>(
         &self,
         config: C,
     ) -> Result<ConsumerInfo, Error> {
-        let config = config.into();
+        let config = config.into_consumer_config();
         let subject = if let Some(ref durable_name) = config.durable_name {
             format!(
                 "{}.CONSUMER.DURABLE.CREATE.{}.{}",

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -26,7 +26,7 @@ mod jetstream {
     use super::*;
     use async_nats::header::HeaderMap;
     use async_nats::jetstream::consumer::{
-        Consumer, ConsumerConfig, DeliverPolicy, PullConsumer, PullConsumerConfig, PushConsumer,
+        ConsumerConfig, DeliverPolicy, PullConsumer, PullConsumerConfig, PushConsumer,
         PushConsumerConfig,
     };
     use async_nats::jetstream::response::Response;
@@ -39,7 +39,7 @@ mod jetstream {
         let client = async_nats::connect(server.client_url()).await.unwrap();
         let context = async_nats::jetstream::new(client);
 
-        let stream = context
+        let _stream = context
             .create_stream(StreamConfig {
                 name: "TEST".to_string(),
                 subjects: vec!["foo".into(), "bar".into(), "baz".into()],
@@ -236,7 +236,7 @@ mod jetstream {
             .get_or_create_stream("events")
             .await
             .unwrap()
-            .create_consumer(&ConsumerConfig {
+            .create_consumer(ConsumerConfig {
                 durable_name: Some("durable".to_string()),
                 deliver_policy: DeliverPolicy::ByStartSequence { start_sequence: 10 },
                 ..Default::default()
@@ -252,6 +252,17 @@ mod jetstream {
                 deliver_policy: DeliverPolicy::ByStartTime {
                     start_time: OffsetDateTime::now_utc(),
                 },
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        context
+            .get_or_create_stream("events")
+            .await
+            .unwrap()
+            .create_consumer(&PullConsumerConfig {
+                durable_name: Some("pull_explicit".to_string()),
                 ..Default::default()
             })
             .await
@@ -286,14 +297,14 @@ mod jetstream {
 
         let stream = context.get_or_create_stream("stream").await.unwrap();
         stream
-            .create_consumer(&ConsumerConfig {
+            .create_consumer(ConsumerConfig {
                 durable_name: Some("pull".to_string()),
                 ..Default::default()
             })
             .await
             .unwrap();
         stream
-            .create_consumer(&ConsumerConfig {
+            .create_consumer(&PushConsumerConfig {
                 durable_name: Some("push".to_string()),
                 deliver_subject: Some("subject".to_string()),
                 ..Default::default()
@@ -320,7 +331,7 @@ mod jetstream {
         let stream = context.get_or_create_stream("stream").await.unwrap();
 
         // this creates the consumer
-        stream
+        let _consumer: PullConsumer = stream
             .get_or_create_consumer::<PullConsumerConfig>(
                 "consumer",
                 PullConsumerConfig {


### PR DESCRIPTION
This PR allows passing `PullConsumerConfig` or `PushConsumer` config while calling `create()`.
