### PR TITLE
Use a concurrency group to prevent action backlog

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Adds a concurrency group to prevent force pushes and similar events on the same pull request to fill up the backlog for hours (benchmark takes quite some time once it starts filling up).