### PR TITLE
Make `jetstream::Context::create_stream` return `Stream`

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -214,7 +214,7 @@ mod jetstream {
         let client = async_nats::connect(server.client_url()).await.unwrap();
         let context = async_nats::jetstream::new(client);
 
-        let info2 = context.create_stream("events").await.unwrap();
+        let _stream = context.create_stream("events").await.unwrap();
         let info = context
             .update_stream(&stream::Config {
                 name: "events".to_string(),
@@ -224,7 +224,7 @@ mod jetstream {
             })
             .await
             .unwrap();
-        context.update_stream(&info2.config).await.unwrap();
+        context.update_stream(&info.config).await.unwrap();
         assert_eq!(info.config.max_messages, 1000);
         assert_eq!(info.config.max_messages_per_subject, 100);
     }


### PR DESCRIPTION
The two paths of get_or_create_stream returns different types, which is fairly unexpected.

This changes `jetstream::Context::create_stream` to return a `Stream`. If we need a non-binding variant we can add `insert_stream` which returns `stream::Info` rather than `Stream`.