### PR TITLE
Generalize handling of terminal status codes

### DIFF
--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -110,10 +110,12 @@ impl Context {
             .request(format!("{}.{}", self.prefix, subject), request)
             .await?;
 
-        if message.status == Some(StatusCode::NO_RESPONDERS) {
+        let status = message.status.unwrap_or(StatusCode::OK);
+        if status.is_server_error() {
+            // TODO(caspervonb) return jetstream::Error with a status code when that type lands.
             return Err(Box::new(std::io::Error::new(
-                ErrorKind::NotFound,
-                "nats: no responders",
+                ErrorKind::Other,
+                format!("nats: request failed with status code {:?}", status),
             )));
         }
 

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -809,15 +809,7 @@ impl Client {
         self.publish_with_reply(subject, inbox, payload).await?;
         self.flush().await?;
         match sub.next().await {
-            Some(message) => {
-                if message.status == Some(StatusCode::NO_RESPONDERS) {
-                    return Err(Box::new(std::io::Error::new(
-                        ErrorKind::NotFound,
-                        "nats: no responders",
-                    )));
-                }
-                Ok(message)
-            }
+            Some(message) => Ok(message),
             None => Err(Box::new(io::Error::new(
                 ErrorKind::BrokenPipe,
                 "did not receive any message",


### PR DESCRIPTION
- In `Client::request`, you get access to the message and can easily check the status of it so this is no longer an error.
- The implicit handling is moved to `Context::request` instead, and is applied to all status codes representing server errors.