### PR TITLE
Removed attempt to connect to server info host when TLS is enabled

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -401,14 +401,21 @@ impl Connector {
                     )
                 })?;
 
-            let domain = rustls::ServerName::try_from(info.host.as_str())
-                .or_else(|_| rustls::ServerName::try_from(tls_host))
-                .map_err(|_| {
-                    io::Error::new(
-                        ErrorKind::InvalidInput,
-                        "cannot determine hostname for TLS connection",
-                    )
-                })?;
+            // Use the server-advertised hostname to validate if given as a hostname, not an IP address
+            let domain = if let Ok(server_hostname @ rustls::ServerName::DnsName(_)) =
+                rustls::ServerName::try_from(info.host.as_str())
+            {
+                server_hostname
+            } else if let Ok(tls_hostname @ rustls::ServerName::DnsName(_)) =
+                rustls::ServerName::try_from(tls_host)
+            {
+                tls_hostname
+            } else {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidInput,
+                    "cannot determine hostname for TLS connection",
+                ));
+            };
 
             connection = Connection {
                 stream: Box::new(tls_connector.connect(domain, connection.stream).await?),

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -269,9 +269,18 @@ mod client {
     }
 
     #[tokio::test]
-    #[ignore] // temporarily ignored due to DNS issues on github actions
     async fn connect_domain() {
         assert!(async_nats::connect("demo.nats.io").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn connect_invalid_tls_over_ip() {
+        let server = nats_server::run_basic_server();
+        assert!(async_nats::ConnectOptions::new()
+            .require_tls(true)
+            .connect(server.client_url())
+            .await
+            .is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
After some back and forth with @Jarema , I was having some trouble connecting to `connect.ngs.global` with the nats client. I was getting an error for `UnsupportedNameType`, which I tracked down in [rustls](https://github.com/rustls/rustls/blob/main/rustls/src/verify.rs#L330). When I took a look at this function, it seems that attempting to connect to NGS always resulted in the `info.host` variable filled in as an IP address, which as you can see in the above function creates an error.

Simply removing this fixes the issue _for me_ but I wanted to open this PR for discussion. I'm not entirely sure if connecting to an IP address with TLS is a totally valid use case, or if ignoring the `info.host` value here is the proper solution. What also worked for me is reordering the connections to try creating a server name from `tls_host` first, but that's not really solving much more than just removing the option.

Anyways, looking forward to discussing this. If we wanted to make this a bit more robust, I can create a `ServerName` from both values and match to ensure that the value is a `ServerName::DnsName` rather than just taking `tls_host`