### PR TITLE
Allow tokens in connection strings and add tests

### DIFF
--- a/nats-server/src/lib.rs
+++ b/nats-server/src/lib.rs
@@ -85,6 +85,14 @@ impl Server {
         url.as_str().to_string()
     }
 
+    // Allow token override.
+    pub fn client_url_with_token(&self, token: &str) -> String {
+        use url::Url;
+        let mut url = Url::parse(&self.client_url()).expect("could not parse");
+        url.set_username(token).ok();
+        url.as_str().to_string()
+    }
+
     // Grab client addr from logs.
     fn client_addr(&self) -> String {
         // We may need to wait for log to be present.

--- a/nats/src/connector.rs
+++ b/nats/src/connector.rs
@@ -604,12 +604,17 @@ impl ServerAddress {
         self.0.scheme() == "tls"
     }
 
+    /// Returns if the server url had embedded username and password.
+    pub fn has_user_pass(&self) -> bool {
+        self.0.username() != ""
+    }
+
     pub(crate) fn auth(&self) -> AuthStyle {
         if let Some(password) = self.0.password() {
-            if self.0.username() != "" {
-                AuthStyle::UserPass(self.0.username().to_string(), password.to_string())
-            } else {
+            if self.0.username() == "" {
                 AuthStyle::NoAuth
+            } else {
+                AuthStyle::UserPass(self.0.username().to_string(), password.to_string())
             }
         } else if "" != self.0.username() {
             AuthStyle::Token(self.0.username().to_string())
@@ -722,6 +727,8 @@ mod tests {
     #[test]
     fn server_address_user_auth() {
         let address = ServerAddress::from_str("nats://myuser:mypass@localhost").unwrap();
-        assert!(matches!(address.auth(), AuthStyle::UserPass(username, password) if &username == "myuser" && &password == "mypass"));
+        assert!(
+            matches!(address.auth(), AuthStyle::UserPass(username, password) if &username == "myuser" && &password == "mypass")
+        );
     }
 }

--- a/nats/src/connector.rs
+++ b/nats/src/connector.rs
@@ -285,8 +285,15 @@ impl Connector {
             no_responders: true,
         };
 
+        let server_auth = server.auth();
+        let auth = if let AuthStyle::NoAuth = server_auth {
+            &self.options.auth
+        } else {
+            &server_auth
+        };
+
         // Fill in the info that authenticates the client.
-        match &self.options.auth {
+        match auth {
             AuthStyle::NoAuth => {}
             AuthStyle::UserPass(user, pass) => {
                 connect_info.user = Some(SecureString::from(user.to_string()));
@@ -307,12 +314,6 @@ impl Connector {
                 connect_info.nkey = Some(nkey);
                 connect_info.signature = Some(sig);
             }
-        }
-
-        // If our server url had embedded username, check that here.
-        if server.has_user_pass() {
-            connect_info.user = server.username();
-            connect_info.pass = server.password();
         }
 
         // Send CONNECT and PING messages.
@@ -603,9 +604,18 @@ impl ServerAddress {
         self.0.scheme() == "tls"
     }
 
-    /// Returns if the server url had embedded username and password.
-    pub fn has_user_pass(&self) -> bool {
-        self.0.username() != ""
+    pub(crate) fn auth(&self) -> AuthStyle {
+        if let Some(password) = self.0.password() {
+            if self.0.username() != "" {
+                AuthStyle::UserPass(self.0.username().to_string(), password.to_string())
+            } else {
+                AuthStyle::NoAuth
+            }
+        } else if "" != self.0.username() {
+            AuthStyle::Token(self.0.username().to_string())
+        } else {
+            AuthStyle::NoAuth
+        }
     }
 
     /// Returns the host.
@@ -690,5 +700,28 @@ impl IntoServerList for Vec<ServerAddress> {
 impl IntoServerList for io::Result<Vec<ServerAddress>> {
     fn into_server_list(self) -> io::Result<Vec<ServerAddress>> {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_address_no_auth() {
+        let address = ServerAddress::from_str("nats://localhost").unwrap();
+        assert!(matches!(address.auth(), AuthStyle::NoAuth));
+    }
+
+    #[test]
+    fn server_address_token_auth() {
+        let address = ServerAddress::from_str("nats://mytoken@localhost").unwrap();
+        assert!(matches!(address.auth(), AuthStyle::Token(token) if &token == "mytoken"));
+    }
+
+    #[test]
+    fn server_address_user_auth() {
+        let address = ServerAddress::from_str("nats://myuser:mypass@localhost").unwrap();
+        assert!(matches!(address.auth(), AuthStyle::UserPass(username, password) if &username == "myuser" && &password == "mypass"));
     }
 }

--- a/nats/tests/auth_token.rs
+++ b/nats/tests/auth_token.rs
@@ -1,0 +1,30 @@
+// Copyright 2020-2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn token_auth() {
+    let s = nats_server::run_server("tests/configs/token_auth.conf");
+
+    assert!(nats::connect(&s.client_url()).is_err());
+
+    assert!(nats::Options::with_token("some-auth-token")
+        .connect(&s.client_url())
+        .is_ok());
+
+    assert!(nats::connect(&s.client_url_with_token("some-auth-token")).is_ok());
+
+    // Check override.
+    assert!(nats::Options::with_token("bad-auth-token")
+        .connect(&s.client_url_with_token("some-auth-token"))
+        .is_ok());
+}

--- a/nats/tests/configs/token_auth.conf
+++ b/nats/tests/configs/token_auth.conf
@@ -1,0 +1,5 @@
+
+authorization {
+  token: "some-auth-token"
+  timeout:  "2s"
+}


### PR DESCRIPTION
Many NATS clients allow for token authentication to be specified in a connection URL by passing a username without a password. This enables that approach, and adds some tests.

If this looks good, I'm happy to make a similar change on the `async_nats` side, either in this PR or in a follow-up as appropriate.