### PR TITLE
Rename `Process` stream to `Sequence`

### DIFF
--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -73,7 +73,7 @@ impl Consumer<Config> {
         .await
     }
 
-    pub fn process(&self, batch: usize) -> Result<Process, Error> {
+    pub fn sequence(&self, batch: usize) -> Result<Sequence, Error> {
         let context = self.context.clone();
         let subject = format!(
             "{}.CONSUMER.MSG.NEXT.{}.{}",
@@ -86,7 +86,7 @@ impl Consumer<Config> {
         })
         .map(Bytes::from)?;
 
-        Ok(Process {
+        Ok(Sequence {
             context,
             subject,
             request,
@@ -147,7 +147,7 @@ impl Stream for Batch {
     }
 }
 
-pub struct Process<'a> {
+pub struct Sequence<'a> {
     context: Context,
     subject: String,
     request: Bytes,
@@ -155,7 +155,7 @@ pub struct Process<'a> {
     next: Option<BoxFuture<'a, Result<Batch, Error>>>,
 }
 
-impl<'a> Stream for Process<'a> {
+impl<'a> Stream for Sequence<'a> {
     type Item = Result<Batch, Error>;
 
     fn poll_next(

--- a/async-nats/src/jetstream/mod.rs
+++ b/async-nats/src/jetstream/mod.rs
@@ -41,7 +41,7 @@
 //!     ..Default::default()
 //! }).await?;
 //!
-//! let mut batches = consumer.process(50)?.take(10);
+//! let mut batches = consumer.sequence(50)?.take(10);
 //! while let Ok(Some(mut batch)) = batches.try_next().await {
 //!     while let Some(Ok(message)) = batch.next().await {
 //!         println!("message receiver: {:?}", message);

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -380,7 +380,7 @@ mod jetstream {
     }
 
     #[tokio::test]
-    async fn pull_process() {
+    async fn pull_sequence() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = async_nats::connect(server.client_url()).await.unwrap();
         let context = async_nats::jetstream::new(client);
@@ -411,7 +411,7 @@ mod jetstream {
                 .unwrap();
         }
 
-        let mut iter = consumer.process(50).unwrap().take(10);
+        let mut iter = consumer.sequence(50).unwrap().take(10);
         while let Ok(Some(mut batch)) = iter.try_next().await {
             while let Ok(Some(message)) = batch.try_next().await {
                 assert_eq!(message.payload, Bytes::from(b"dat".as_ref()));


### PR DESCRIPTION
Alternative names include but are not limited to series, serial, linear, etc.