### PR TITLE
Normalize the examples heading

### DIFF
--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -50,7 +50,7 @@ impl<T: IntoConsumerConfig> Consumer<T> {
     /// Retrieves `info` about [Consumer] from the server, updates the cached `info` inside
     /// [Consumer] and returns it.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -89,7 +89,7 @@ impl<T: IntoConsumerConfig> Consumer<T> {
     /// Cache is either from initial creation/retrival of the [Consumer] or last call to
     /// [Consumer::info].
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -60,7 +60,7 @@ impl Context {
     ///
     /// If the stream does not exist, `no responders` error will be returned.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -94,7 +94,7 @@ impl Context {
     ///
     /// If the stream does not exist, `no responders` error will be returned.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -136,7 +136,7 @@ impl Context {
     /// Create a JetStream [Stream] with given config and return a handle to it.
     /// That handle can be used to manage and use [Consumer][crate::jetstream::consumer::Consumer].
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -187,7 +187,7 @@ impl Context {
     /// Checks for [Stream] existence on the server and returns handle to it.
     /// That handle can be used to manage and use [Consumer][crate::jetstream::consumer::Consumer].
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -229,7 +229,7 @@ impl Context {
     ///
     /// Note: This does not validate if the Stream on the server is compatible with the configuration passed in.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -272,7 +272,7 @@ impl Context {
 
     /// Deletes a [Stream] with a given name.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -309,7 +309,7 @@ impl Context {
     /// Updates a [Stream] with a given config. If specific field cannot be updated,
     /// error is returned.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -351,7 +351,7 @@ impl Context {
     /// This is a low level API used mostly internally, that should be used only in
     /// specific cases when this crate API on [Consumer][crate::jetstream::consumer::Consumer] or [Stream] does not provide needed functionality.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # use async_nats::jetstream::stream::Info;

--- a/async-nats/src/jetstream/mod.rs
+++ b/async-nats/src/jetstream/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! To start, create a new [Context] which is an entrypoint to `JetStream` API.
 //!
-//! # Examples:
+//! # Examples
 //!
 //! ```no_run
 //! # #[tokio::main]
@@ -64,7 +64,7 @@ pub use context::Context;
 /// Creates a new JetStream [Context] that provides JetStream API for managming and using [Streams][crate::jetstream::stream::Stream],
 /// [Consumers][crate::jetstream::consumer::Consumer], key value and object store.
 ///
-/// # Examples:
+/// # Examples
 ///
 /// ```no_run
 /// # #[tokio::main]
@@ -83,7 +83,7 @@ pub fn new(client: Client) -> Context {
 
 /// Creates a new JetStream [Context] with given JetStteam domain.
 ///
-/// # Examples:
+/// # Examples
 ///
 /// ```no_run
 /// # #[tokio::main]
@@ -102,7 +102,7 @@ pub fn with_domain<T: AsRef<str>>(client: Client, domain: T) -> Context {
 
 /// Creates a new JetStream [Context] with given JetStream prefix.
 /// By default it is `$JS.API`.
-/// # Examples:
+/// # Examples
 ///
 /// ```no_run
 /// # #[tokio::main]

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -39,7 +39,7 @@ impl Stream {
     /// Create a new `Durable` or `Ephemeral` Consumer (if `durable_name` was not provided) and
     /// returns the info from the server about created [Consumer][Consumer]
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -91,7 +91,7 @@ impl Stream {
 
     /// Retrieve [Info] about [Consumer] from the server.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -125,7 +125,7 @@ impl Stream {
     /// Get [Consumer] from the the server. [Consumer] iterators can be used to retrieve
     /// [Messages][crate::jetstream::JetStreamMessage] for a given [Consumer].
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -157,7 +157,7 @@ impl Stream {
     ///
     /// Note: This does not validate if the [Consumer] on the server is compatible with the configuration passed in except Push/Pull compatibility.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -210,7 +210,7 @@ impl Stream {
 
     /// Delete a [Consumer] from the server.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]


### PR DESCRIPTION
For consistency without trailing colon ala std lib as it is rendered with a heading tag in rustdoc.