### PR TITLE
Add cluster to streaminfo/consumerInfo struct 

### DIFF
--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -722,7 +722,7 @@ pub struct ClusterInfo {
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
-struct ClusterReplicas {
+pub struct ClusterReplicas {
     /// The server's name, which is on this cluster (out of the leader)
     pub name: String,
     pub current: bool,

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -390,6 +390,8 @@ pub struct StreamInfo {
     pub created: DateTime,
     /// Various metrics associated with this stream
     pub state: StreamState,
+    /// Information about the stream's cluster
+    pub cluster: ClusterInfo,
 }
 
 /// Information about a received message
@@ -708,11 +710,23 @@ pub struct ConsumerInfo {
     pub push_bound: bool,
 }
 
-/// Information about the consumer's associated `JetStream` cluster
+/// Information about the stream's, consumer's associated `JetStream` cluster
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ClusterInfo {
+    /// The name of cluster
+    pub name: String,
     /// The leader of the cluster
     pub leader: String,
+    /// The replica state of cluster
+    pub replicas: Vec<ClusterReplicas>
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+struct ClusterReplicas {
+    /// The server's name, which is on this cluster (out of the leader)
+    pub name: String,
+    pub current: bool,
+    pub active: usize
 }
 
 /// Information about a consumer and the stream it is consuming


### PR DESCRIPTION
Add cluster information on ConsumerInfo && StreamInfo,
Follow the structure of ```nats``` CLI Tool within ```trace``` Mode.

- Jetstream Stream API Trace
> nats str report --trace
```
{"type":"io.nats.jetstream.api.v1.stream_list_response","total":1,"offset":0,"limit":256,"streams":[{"config":{"name":"test","subjects":["test"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":3,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2022-06-24T11:04:21.564710722Z","state":{"messages":10,"bytes":531,"first_seq":1,"first_ts":"2022-06-24T11:04:36.593164161Z","last_seq":10,"last_ts":"2022-06-24T11:04:36.599477736Z","num_subjects":1,"consumer_count":1},"cluster":{"name":"nats-server-1","leader":"nats-server-4-0","replicas":[{"name":"nats-server-5-0","current":true,"active":472214464},{"name":"nats-server-6-0","current":true,"active":472212927}]}}]}

╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                           Stream Report                                                           │
├────────┬─────────┬───────────┬───────────┬──────────┬───────┬──────┬─────────┬────────────────────────────────────────────────────┤
│ Stream │ Storage │ Placement │ Consumers │ Messages │ Bytes │ Lost │ Deleted │ Replicas                                           │
├────────┼─────────┼───────────┼───────────┼──────────┼───────┼──────┼─────────┼────────────────────────────────────────────────────┤
│ test   │ File    │           │ 1         │ 10       │ 531 B │ 0    │ 0       │ nats-server-4-0*, nats-server-5-0, nats-server-6-0 │
╰────────┴─────────┴───────────┴───────────┴──────────┴───────┴──────┴─────────┴────────────────────────────────────────────────────╯
```

- Jetstream Consumer API Trace
> nats con report <Stream_Name> --trace
```
{"type":"io.nats.jetstream.api.v1.consumer_info_response","stream_name":"test","name":"test","created":"2022-06-24T11:04:28.904421826Z","config":{"durable_name":"test","deliver_policy":"all","ack_policy":"explicit","ack_wait":30000000000,"max_deliver":-1,"replay_policy":"instant","max_waiting":512,"max_ack_pending":1000},"delivered":{"consumer_seq":1,"stream_seq":1,"last_active":"2022-06-24T11:04:41.465820627Z"},"ack_floor":{"consumer_seq":1,"stream_seq":1,"last_active":"2022-06-24T11:04:41.468118541Z"},"num_ack_pending":0,"num_redelivered":0,"num_waiting":0,"num_pending":9,"cluster":{"name":"nats-server-1","leader":"nats-server-4-0","replicas":[{"name":"nats-server-5-0","current":true,"active":416324845},{"name":"nats-server-6-0","current":true,"active":416451641}]}}

╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                     Consumer report for test with 1 consumers                                                      │
├──────────┬──────┬────────────┬──────────┬─────────────┬─────────────┬─────────────┬───────────┬────────────────────────────────────────────────────┤
│ Consumer │ Mode │ Ack Policy │ Ack Wait │ Ack Pending │ Redelivered │ Unprocessed │ Ack Floor │ Cluster                                            │
├──────────┼──────┼────────────┼──────────┼─────────────┼─────────────┼─────────────┼───────────┼────────────────────────────────────────────────────┤
│ test     │ Pull │ Explicit   │ 30.00s   │ 0           │ 0           │ 9 / 90%     │ 1         │ nats-server-4-0*, nats-server-5-0, nats-server-6-0 │
╰──────────┴──────┴────────────┴──────────┴─────────────┴─────────────┴─────────────┴───────────┴────────────────────────────────────────────────────╯
```