### PR TITLE
Add cluster to streaminfo/consumerinfo struct

### DIFF
--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -722,7 +722,7 @@ pub struct ClusterInfo {
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
-struct ClusterReplicas {
+pub struct ClusterReplicas {
     /// The server's name, which is on this cluster (out of the leader)
     pub name: String,
     pub current: bool,

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -733,7 +733,7 @@ pub struct PeerInfo {
     /// Indicates the node is considered offline by the group.
     #[serde(default)]
     pub offline: bool,
-    //// How many uncommitted operations this peer is behind the leader.
+    /// How many uncommitted operations this peer is behind the leader.
     pub lag: Option<i64>,
 }
 

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -718,7 +718,7 @@ pub struct ClusterInfo {
     /// The server name of the RAFT leader.
     pub leader: String,
     /// The members of the RAFT cluster.
-    pub replicas: option<Vec<PeerInfo>>,
+    pub replicas: Option<Vec<PeerInfo>>,
 }
 
 /// The members of the RAFT cluster

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -727,13 +727,13 @@ pub struct PeerInfo {
     /// The server name of the peer.
     pub name: String,
     /// Indicates if the server is up to date and synchronised.
-    pub current: Option<bool>,
+    pub current: bool,
     /// Nanoseconds since this peer was last seen.
     pub active: usize,
     /// Indicates the node is considered offline by the group.
     pub offline: Option<bool>,
     //// How many uncommitted operations this peer is behind the leader.
-    pub lag: i64,
+    pub lag: Option<i64>,
 }
 
 /// Information about a consumer and the stream it is consuming

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -734,12 +734,13 @@ pub struct PeerInfo {
     /// Indicates if the server is up to date and synchronised.
     pub current: bool,
     /// Nanoseconds since this peer was last seen.
-    pub active: usize,
+    #[serde(with = "serde_nanos")]
+    pub active: Duration,
     /// Indicates the node is considered offline by the group.
     #[serde(default)]
     pub offline: bool,
     /// How many uncommitted operations this peer is behind the leader.
-    pub lag: Option<i64>,
+    pub lag: Option<u64>,
 }
 
 /// Information about a consumer and the stream it is consuming

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -731,7 +731,8 @@ pub struct PeerInfo {
     /// Nanoseconds since this peer was last seen.
     pub active: usize,
     /// Indicates the node is considered offline by the group.
-    pub offline: Option<bool>,
+    #[serde(default)]
+    pub offline: bool,
     //// How many uncommitted operations this peer is behind the leader.
     pub lag: Option<i64>,
 }

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -726,7 +726,7 @@ pub struct ClusterReplicas {
     /// The server's name, which is on this cluster (out of the leader)
     pub name: String,
     pub current: bool,
-    pub active: usize
+    pub active: usize,
 }
 
 /// Information about a consumer and the stream it is consuming

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -721,11 +721,14 @@ pub struct ClusterInfo {
     pub replicas: Vec<ClusterReplicas>
 }
 
+/// The replica state of cluster (without leader node), and show the replicate state.
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ClusterReplicas {
-    /// The server's name, which is on this cluster (out of the leader)
+    /// The server's name, which is on this cluster (out of the leader).
     pub name: String,
+    /// The replica node on `current state` or not.
     pub current: bool,
+    /// The replica node seen `nano_sec` ago 
     pub active: usize,
 }
 

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -390,6 +390,8 @@ pub struct StreamInfo {
     pub created: DateTime,
     /// Various metrics associated with this stream
     pub state: StreamState,
+    /// Information about the stream's cluster
+    pub cluster: ClusterInfo,
 }
 
 /// Information about a received message
@@ -708,11 +710,23 @@ pub struct ConsumerInfo {
     pub push_bound: bool,
 }
 
-/// Information about the consumer's associated `JetStream` cluster
+/// Information about the stream's, consumer's associated `JetStream` cluster
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ClusterInfo {
+    /// The name of cluster
+    pub name: String,
     /// The leader of the cluster
     pub leader: String,
+    /// The replica state of cluster
+    pub replicas: Vec<ClusterReplicas>
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+struct ClusterReplicas {
+    /// The server's name, which is on this cluster (out of the leader)
+    pub name: String,
+    pub current: bool,
+    pub active: usize
 }
 
 /// Information about a consumer and the stream it is consuming

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -718,7 +718,7 @@ pub struct ClusterInfo {
     /// The server name of the RAFT leader.
     pub leader: String,
     /// The members of the RAFT cluster.
-    pub replicas: Vec<PeerInfo>,
+    pub replicas: option<Vec<PeerInfo>>,
 }
 
 /// The members of the RAFT cluster

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -391,6 +391,7 @@ pub struct StreamInfo {
     /// Various metrics associated with this stream
     pub state: StreamState,
     /// Information about the stream's cluster
+    #[serde(default)]
     pub cluster: ClusterInfo,
 }
 
@@ -704,6 +705,7 @@ pub struct ConsumerInfo {
     /// The number of pending
     pub num_pending: u64,
     /// Information about the consumer's cluster
+    #[serde(default)]
     pub cluster: ClusterInfo,
     /// Indicates if any client is connected and receiving messages from a push consumer
     #[serde(default)]
@@ -714,11 +716,14 @@ pub struct ConsumerInfo {
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ClusterInfo {
     /// The cluster name.
-    pub name: String,
+    #[serde(default)]
+    pub name: Option<String>,
     /// The server name of the RAFT leader.
-    pub leader: String,
+    #[serde(default)]
+    pub leader: Option<String>,
     /// The members of the RAFT cluster.
-    pub replicas: Option<Vec<PeerInfo>>,
+    #[serde(default)]
+    pub replicas: Vec<PeerInfo>,
 }
 
 /// The members of the RAFT cluster

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -713,23 +713,27 @@ pub struct ConsumerInfo {
 /// Information about the stream's, consumer's associated `JetStream` cluster
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ClusterInfo {
-    /// The name of cluster
+    /// The cluster name.
     pub name: String,
-    /// The leader of the cluster
+    /// The server name of the RAFT leader.
     pub leader: String,
-    /// The replica state of cluster
-    pub replicas: Vec<ClusterReplicas>
+    /// The members of the RAFT cluster.
+    pub replicas: Vec<PeerInfo>
 }
 
-/// The replica state of cluster (without leader node), and show the replicate state.
+/// The members of the RAFT cluster
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct ClusterReplicas {
-    /// The server's name, which is on this cluster (out of the leader).
+pub struct PeerInfo {
+    /// The server name of the peer.
     pub name: String,
-    /// The replica node on `current state` or not.
-    pub current: bool,
-    /// The replica node seen `nano_sec` ago 
+    /// Indicates if the server is up to date and synchronised.
+    pub current: Option<bool>,
+    /// Nanoseconds since this peer was last seen.
     pub active: usize,
+    /// Indicates the node is considered offline by the group.
+    pub offline: Option<bool>,
+    //// How many uncommitted operations this peer is behind the leader.
+    pub lag: i64,
 }
 
 /// Information about a consumer and the stream it is consuming

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -718,7 +718,7 @@ pub struct ClusterInfo {
     /// The server name of the RAFT leader.
     pub leader: String,
     /// The members of the RAFT cluster.
-    pub replicas: Vec<PeerInfo>
+    pub replicas: Vec<PeerInfo>,
 }
 
 /// The members of the RAFT cluster


### PR DESCRIPTION
Add cluster information on ConsumerInfo && StreamInfo,
Follow the structure of ```nats``` CLI Tool within ```trace``` Mode.

- Jetstream Stream API Trace
> nats str report --trace
```
{"type":"io.nats.jetstream.api.v1.stream_list_response","total":1,"offset":0,"limit":256,"streams":[{"config":{"name":"test","subjects":["test"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":3,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2022-06-24T11:04:21.564710722Z","state":{"messages":10,"bytes":531,"first_seq":1,"first_ts":"2022-06-24T11:04:36.593164161Z","last_seq":10,"last_ts":"2022-06-24T11:04:36.599477736Z","num_subjects":1,"consumer_count":1},"cluster":{"name":"nats-server-1","leader":"nats-server-4-0","replicas":[{"name":"nats-server-5-0","current":true,"active":472214464},{"name":"nats-server-6-0","current":true,"active":472212927}]}}]}

╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                           Stream Report                                                           │
├────────┬─────────┬───────────┬───────────┬──────────┬───────┬──────┬─────────┬────────────────────────────────────────────────────┤
│ Stream │ Storage │ Placement │ Consumers │ Messages │ Bytes │ Lost │ Deleted │ Replicas                                           │
├────────┼─────────┼───────────┼───────────┼──────────┼───────┼──────┼─────────┼────────────────────────────────────────────────────┤
│ test   │ File    │           │ 1         │ 10       │ 531 B │ 0    │ 0       │ nats-server-4-0*, nats-server-5-0, nats-server-6-0 │
╰────────┴─────────┴───────────┴───────────┴──────────┴───────┴──────┴─────────┴────────────────────────────────────────────────────╯
```

- Jetstream Consumer API Trace
> nats con report <Stream_Name> --trace
```
{"type":"io.nats.jetstream.api.v1.consumer_info_response","stream_name":"test","name":"test","created":"2022-06-24T11:04:28.904421826Z","config":{"durable_name":"test","deliver_policy":"all","ack_policy":"explicit","ack_wait":30000000000,"max_deliver":-1,"replay_policy":"instant","max_waiting":512,"max_ack_pending":1000},"delivered":{"consumer_seq":1,"stream_seq":1,"last_active":"2022-06-24T11:04:41.465820627Z"},"ack_floor":{"consumer_seq":1,"stream_seq":1,"last_active":"2022-06-24T11:04:41.468118541Z"},"num_ack_pending":0,"num_redelivered":0,"num_waiting":0,"num_pending":9,"cluster":{"name":"nats-server-1","leader":"nats-server-4-0","replicas":[{"name":"nats-server-5-0","current":true,"active":416324845},{"name":"nats-server-6-0","current":true,"active":416451641}]}}

╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                     Consumer report for test with 1 consumers                                                      │
├──────────┬──────┬────────────┬──────────┬─────────────┬─────────────┬─────────────┬───────────┬────────────────────────────────────────────────────┤
│ Consumer │ Mode │ Ack Policy │ Ack Wait │ Ack Pending │ Redelivered │ Unprocessed │ Ack Floor │ Cluster                                            │
├──────────┼──────┼────────────┼──────────┼─────────────┼─────────────┼─────────────┼───────────┼────────────────────────────────────────────────────┤
│ test     │ Pull │ Explicit   │ 30.00s   │ 0           │ 0           │ 9 / 90%     │ 1         │ nats-server-4-0*, nats-server-5-0, nats-server-6-0 │
╰──────────┴──────┴────────────┴──────────┴─────────────┴─────────────┴─────────────┴───────────┴────────────────────────────────────────────────────╯
```