### PR TITLE
Use correct flush_timeout operation in doc test

### DIFF
--- a/nats/src/lib.rs
+++ b/nats/src/lib.rs
@@ -663,9 +663,10 @@ impl Connection {
     ///
     /// # Example
     /// ```
+    /// # use std::time::Duration;
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
-    /// nc.flush()?;
+    /// nc.flush_timeout(Duration::from_secs(5))?;
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
Hi. I've been going through the code as I've been looking to contribute and I noticed the wrong function being used in one of the doc tests. 