### PR TITLE
Release async-nats/v0.16.0 & nats/v0.22.0

### DIFF
--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -1,3 +1,38 @@
+# 0.16.0
+
+This release features a lot of improvements and additions to `JetStream` API and adds `Push Consumer`.
+
+## Added
+* Add `query_account` to `jetstream::Context` by @caspervonb in https://github.com/nats-io/nats.rs/pull/528
+* Add streams to push consumers by @caspervonb in https://github.com/nats-io/nats.rs/pull/527
+* Add no_echo option by @Jarema in https://github.com/nats-io/nats.rs/pull/560
+* Add `jetstream::Stream::get_raw_message` by @caspervonb in https://github.com/nats-io/nats.rs/pull/484
+* Add Pull Consumer builder by @Jarema in https://github.com/nats-io/nats.rs/pull/541
+
+## Changed
+* Allow unknown directives to be skipped when parsing by @caspervonb in https://github.com/nats-io/nats.rs/pull/514
+* Narrow error type returned from client publishing by @caspervonb in https://github.com/nats-io/nats.rs/pull/525
+* Change `create_consumer` to return `Consumer` by @Jarema in https://github.com/nats-io/nats.rs/pull/544
+* Switch webpki to rustls-native-certs by @Jarema in https://github.com/nats-io/nats.rs/pull/558
+* Normalize error type used in subscribe methods by @caspervonb in https://github.com/nats-io/nats.rs/pull/524
+* Optimize `jetstream::consumer::pull::Consumer::stream` method. by @Jarema in https://github.com/nats-io/nats.rs/pull/529
+* Make `deliver_subject` required for `push::Config` by @caspervonb in https://github.com/nats-io/nats.rs/pull/531
+
+## Fixed
+* Handle missing error cases in Stream by @Jarema in https://github.com/nats-io/nats.rs/pull/542
+* Handle connecting to ipv6 addresses correctly by @jszwedko in https://github.com/nats-io/nats.rs/pull/386
+
+## Other
+* Move `Client` into its own source file by @caspervonb in https://github.com/nats-io/nats.rs/pull/523
+* Extract `jetstream::Message` into its own module by @caspervonb in https://github.com/nats-io/nats.rs/pull/534
+* Normalize introduction example by @caspervonb in https://github.com/nats-io/nats.rs/pull/540
+* Fix documentation links by @Jarema in https://github.com/nats-io/nats.rs/pull/547
+* Add more documentation to Pull Consumer by @Jarema in https://github.com/nats-io/nats.rs/pull/546
+* Add Push Consumer stream docs by @Jarema in https://github.com/nats-io/nats.rs/pull/559
+* Fix ack test race by @Jarema in https://github.com/nats-io/nats.rs/pull/555
+* Add Message and Headers docs by @Jarema in https://github.com/nats-io/nats.rs/pull/548
+* Remove trace and debug from nats-server wrapper by @Jarema in https://github.com/nats-io/nats.rs/pull/550
+
 # 0.15.0
 
 This release is the first `JetStream` 🍾  feature set for `async-nats`!

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "A async Rust NATS client"
 license = "Apache-2.0"

--- a/nats/CHANGELOG.md
+++ b/nats/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.22.0
+## Overview
+This is a minor release for the `nats` client with one fix and several documentation improvements.
+
+## What's changed
+* Handle connecting to ipv6 addresses correctly by @jszwedko in https://github.com/nats-io/nats.rs/pull/386
+* Use correct flush_timeout operation in doc test by @krady21 in https://github.com/nats-io/nats.rs/pull/556
+* Fix typo in jetstream/pull_subscription.rs by @bbigras in https://github.com/nats-io/nats.rs/pull/521
+
 # 0.21.0
 ## Added
 * Allow tokens in connection strings and add tests by @paulgb in https://github.com/nats-io/nats.rs/pull/506

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nats"
-version = "0.21.0"
+version = "0.22.0"
 description = "A Rust NATS client"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"


### PR DESCRIPTION
## async-nats. v0.16.0

This release features a lot of improvements and additions to `JetStream` API and adds `Push Consumer`.

### Added
* Add `query_account` to `jetstream::Context` by @caspervonb in https://github.com/nats-io/nats.rs/pull/528
* Add streams to push consumers by @caspervonb in https://github.com/nats-io/nats.rs/pull/527
* Add no_echo option by @Jarema in https://github.com/nats-io/nats.rs/pull/560
* Add `jetstream::Stream::get_raw_message` by @caspervonb in https://github.com/nats-io/nats.rs/pull/484
* Add Pull Consumer builder by @Jarema in https://github.com/nats-io/nats.rs/pull/541

### Changed
* Allow unknown directives to be skipped when parsing by @caspervonb in https://github.com/nats-io/nats.rs/pull/514
* Narrow error type returned from client publishing by @caspervonb in https://github.com/nats-io/nats.rs/pull/525
* Change `create_consumer` to return `Consumer` by @Jarema in https://github.com/nats-io/nats.rs/pull/544
* Switch webpki to rustls-native-certs by @Jarema in https://github.com/nats-io/nats.rs/pull/558
* Normalize error type used in subscribe methods by @caspervonb in https://github.com/nats-io/nats.rs/pull/524
* Optimize `jetstream::consumer::pull::Consumer::stream` method. by @Jarema in https://github.com/nats-io/nats.rs/pull/529
* Make `deliver_subject` required for `push::Config` by @caspervonb in https://github.com/nats-io/nats.rs/pull/531

### Fixed
* Handle missing error cases in Stream by @Jarema in https://github.com/nats-io/nats.rs/pull/542
* Handle connecting to ipv6 addresses correctly by @jszwedko in https://github.com/nats-io/nats.rs/pull/386

### Other
* Move `Client` into its own source file by @caspervonb in https://github.com/nats-io/nats.rs/pull/523
* Extract `jetstream::Message` into its own module by @caspervonb in https://github.com/nats-io/nats.rs/pull/534
* Normalize introduction example by @caspervonb in https://github.com/nats-io/nats.rs/pull/540
* Fix documentation links by @Jarema in https://github.com/nats-io/nats.rs/pull/547
* Add more documentation to Pull Consumer by @Jarema in https://github.com/nats-io/nats.rs/pull/546
* Add Push Consumer stream docs by @Jarema in https://github.com/nats-io/nats.rs/pull/559
* Fix ack test race by @Jarema in https://github.com/nats-io/nats.rs/pull/555
* Add Message and Headers docs by @Jarema in https://github.com/nats-io/nats.rs/pull/548
* Remove trace and debug from nats-server wrapper by @Jarema in https://github.com/nats-io/nats.rs/pull/550

## nats v0.22.0

This is a minor release for the `nats` client with one fix and several documentation improvements.

## What's changed
* Handle connecting to ipv6 addresses correctly by @jszwedko in https://github.com/nats-io/nats.rs/pull/386
* Use correct flush_timeout operation in doc test by @krady21 in https://github.com/nats-io/nats.rs/pull/556
* Fix typo in jetstream/pull_subscription.rs by @bbigras in https://github.com/nats-io/nats.rs/pull/521

## New Contributors
* @bbigras made their first contribution in https://github.com/nats-io/nats.rs/pull/521
* @jszwedko made their first contribution in https://github.com/nats-io/nats.rs/pull/386
* @krady21 made their first contribution in https://github.com/nats-io/nats.rs/pull/556

Huge thanks to all contributors. Your help, feedback and insights allows us to drive this library with confidence and speed!

**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.15.0...async-nats/v0.16.0

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>