### PR TITLE
Remove fault injection run from workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,30 +80,6 @@ jobs:
           nats-server --jetstream --port=4222 &
           cargo test --features=unstable -- --nocapture
 
-  test_fault-injection:
-    name: test (fault-injection)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache rust
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-rust-fault-injection
-        with:
-          path: target
-          key: ${{ runner.os }}-${{ env.cache-name }}
-          restore-keys: |
-            ${{ runner.os }}-
-
-      - name: Check out repository
-        uses: actions/checkout@v2
-
-      - name: Run tests with fault injection
-        env:
-          RUST_LOG: trace
-        run: |
-          rustup update
-          cargo test reconnect_test --features=fault_injection -- --ignored
-
   check_format:
     name: check (format)
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't make much use of this in async, takes up runner time.