### PR TITLE
Remove ClusterInfo from Config

### DIFF
--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -282,10 +282,6 @@ pub struct Config {
     /// Number of consumer replucas
     #[serde(default, skip_serializing_if = "is_default")]
     pub num_replicas: usize,
-
-    /// Information about cluster and replication for the Consumer
-    #[serde(default)]
-    pub cluster: ClusterInfo,
 }
 
 impl From<&Config> for Config {

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -18,7 +18,7 @@ use std::{task::Poll, time::Duration};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    jetstream::{self, stream::ClusterInfo, Context},
+    jetstream::{self, Context},
     Error, StatusCode, Subscriber,
 };
 
@@ -1291,9 +1291,6 @@ pub struct Config {
     /// Number of consumer replucas
     #[serde(default, skip_serializing_if = "is_default")]
     pub num_replicas: usize,
-    /// Information about cluster and replication for the Consumer
-    #[serde(default)]
-    pub cluster: ClusterInfo,
 }
 
 impl IntoConsumerConfig for &Config {
@@ -1326,7 +1323,6 @@ impl IntoConsumerConfig for Config {
             max_expires: self.max_expires,
             inactive_threshold: self.inactive_threshold,
             num_replicas: self.num_replicas,
-            cluster: self.cluster,
         }
     }
 }
@@ -1356,7 +1352,6 @@ impl FromConsumer for Config {
             max_expires: config.max_expires,
             inactive_threshold: config.inactive_threshold,
             num_replicas: config.num_replicas,
-            cluster: config.cluster,
         })
     }
 }

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -13,7 +13,7 @@
 
 use super::{AckPolicy, Consumer, DeliverPolicy, FromConsumer, IntoConsumerConfig, ReplayPolicy};
 use crate::{
-    jetstream::{self, stream::ClusterInfo, Context, Message},
+    jetstream::{self, Context, Message},
     Error, StatusCode, Subscriber,
 };
 
@@ -191,8 +191,6 @@ pub struct Config {
     /// Number of consumer replucas
     #[serde(default, skip_serializing_if = "is_default")]
     pub num_replicas: usize,
-    /// Information about cluster and replication for the Consumer
-    pub cluster: ClusterInfo,
 }
 
 impl FromConsumer for Config {
@@ -223,7 +221,6 @@ impl FromConsumer for Config {
             flow_control: config.flow_control,
             idle_heartbeat: config.idle_heartbeat,
             num_replicas: config.num_replicas,
-            cluster: config.cluster,
         })
     }
 }
@@ -252,7 +249,6 @@ impl IntoConsumerConfig for Config {
             max_expires: Duration::default(),
             inactive_threshold: Duration::default(),
             num_replicas: self.num_replicas,
-            cluster: self.cluster,
         }
     }
 }


### PR DESCRIPTION
Unnecessary cluster info found. Removed.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>