### PR TITLE
Fix ordered consumer after discard policy hit

### DIFF
--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -407,6 +407,7 @@ impl<'a> futures::Stream for Ordered<'a> {
                     Some(subscriber) => match subscriber.as_mut().poll(cx) {
                         Poll::Ready(subscriber) => {
                             self.subscriber_future = None;
+                            self.consumer_sequence = 0;
                             self.subscriber = Some(subscriber?);
                         }
                         Poll::Pending => {

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -642,16 +642,16 @@ mod jetstream {
 
         for i in 0..1000 {
             context
-                .publish("events".to_string(), "dat".into())
+                .publish("events".to_string(), format!("{}", i).into())
                 .await
                 .unwrap();
         }
 
-        let mut messages = consumer.messages().await.unwrap().take(500);
-        while let Some(message) = messages.next().await {
+        let mut messages = consumer.messages().await.unwrap().take(500).enumerate();
+        while let Some((i, message)) = messages.next().await {
             let message = message.unwrap();
             assert_eq!(message.status, None);
-            assert_eq!(message.payload.as_ref(), b"dat");
+            assert_eq!(message.payload, bytes::Bytes::from(format!("{}", i + 500)));
         }
     }
 


### PR DESCRIPTION
We didn't account properly for stream/consumer sequence if some messages were discarded.