### PR TITLE
Fix jetstream PagedIterator infinite loop

### DIFF
--- a/nats/src/jetstream/mod.rs
+++ b/nats/src/jetstream/mod.rs
@@ -513,7 +513,7 @@ where
     type Item = io::Result<T>;
 
     fn next(&mut self) -> Option<io::Result<T>> {
-        if self.done {
+        if self.done && self.items.is_empty() {
             return None;
         }
         if !self.items.is_empty() {
@@ -537,6 +537,10 @@ where
         if page.items.is_none() {
             self.done = true;
             return None;
+        }
+
+        if page.total <= page.limit + page.offset {
+            self.done = true;
         }
 
         let items = page.items.take().unwrap();


### PR DESCRIPTION
On current nats server version (2.8) when a paged request is made to jetstream (e.g. to list the stream names), the page will never be empty, making the last page being repeated over and over and hanging if callingcollect() on it.

This fix implements the same fix as [jsm.go(5a418c) manager.go +236](https://github.com/nats-io/jsm.go/blob/5a418c85744e080d40ae7c127abdbced9afa5eed/manager.go#L236) by stopping when detecting it's the last page.