### PR TITLE
Release async-nats/v0.18.0

### DIFF
--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 0.18.0
+## Overview
+This release focuses on fixes and improvements, with addition of ordered Push Consumer.
+
+## Added
+* Add `get_last_raw_message_by_subject` to `Stream` by @caspervonb in https://github.com/nats-io/nats.rs/pull/584
+* Add cluster to streaminfo/consumerinfo struct by @j13tw in https://github.com/nats-io/nats.rs/pull/537
+* Add `ClusterInfo` and `PeerInfo` by @Jarema in https://github.com/nats-io/nats.rs/pull/572
+* Add ordered  push consumer by @Jarema in https://github.com/nats-io/nats.rs/pull/574
+* Add concurrent example by @Jarema in https://github.com/nats-io/nats.rs/pull/580
+* Add delete message from stream by @Jarema in https://github.com/nats-io/nats.rs/pull/588
+
+## Fixed
+* Fix ordered consumer after discard policy hit by @Jarema in https://github.com/nats-io/nats.rs/pull/585
+* Fix pull consumer stream method when batch is set to 1 by @Jarema in https://github.com/nats-io/nats.rs/pull/590
+* Fix reconnect auth deadlock by @caspervonb in https://github.com/nats-io/nats.rs/pull/578
+
+## New Contributors
+* @j13tw made their first contribution in https://github.com/nats-io/nats.rs/pull/537
+
+**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.17.0...async-nats/v0.18.0
+
+
 # 0.17.0
 ## Overview
 This release focuses on two main things:

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "A async Rust NATS client"
 license = "Apache-2.0"


### PR DESCRIPTION
# 0.18.0
## Overview
This release focuses on fixes and improvements, with addition of ordered Push Consumer.

## Added
* Add cluster to streaminfo/consumerinfo struct by @j13tw in https://github.com/nats-io/nats.rs/pull/537
* Add `ClusterInfo` and `PeerInfo` by @Jarema in https://github.com/nats-io/nats.rs/pull/572
* Add ordered  push consumer by @Jarema in https://github.com/nats-io/nats.rs/pull/574
* Add concurrent example by @Jarema in https://github.com/nats-io/nats.rs/pull/580
* Add delete message from stream by @Jarema in https://github.com/nats-io/nats.rs/pull/588

## Fixed
* Fix ordered consumer after discard policy hit by @Jarema in https://github.com/nats-io/nats.rs/pull/585
* Fix pull consumer stream method when batch is set to 1 by @Jarema in https://github.com/nats-io/nats.rs/pull/590
* Fix reconnect auth deadlock by @caspervonb in https://github.com/nats-io/nats.rs/pull/578

## New Contributors
* @j13tw made their first contribution in https://github.com/nats-io/nats.rs/pull/537

**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.17.0...async-nats/v0.18.0


Signed-off-by: Tomasz Pietrek <tomasz@nats.io>