### PR TITLE
Add last_active to SequenceInfo and rename SequencePair to SequenceInfo

### DIFF
--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -156,9 +156,9 @@ pub struct Info {
     /// The consumer's configuration
     pub config: Config,
     /// Statistics for delivered messages
-    pub delivered: SequencePair,
+    pub delivered: SequenceInfo,
     /// Statistics for acknowleged messages
-    pub ack_floor: SequencePair,
+    pub ack_floor: SequenceInfo,
     /// The difference between delivered and acknowledged messages
     pub num_ack_pending: usize,
     /// The number of messages re-sent after acknowledgement was not received within the configured
@@ -176,14 +176,17 @@ pub struct Info {
 }
 
 /// Information about a consumer and the stream it is consuming
-#[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
-pub struct SequencePair {
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub struct SequenceInfo {
     /// How far along the consumer has progressed
     #[serde(rename = "consumer_seq")]
     pub consumer_sequence: u64,
     /// The aggregate for all stream consumers
     #[serde(rename = "stream_seq")]
     pub stream_sequence: u64,
+    // Last activity for the sequence
+    #[serde(default, with = "rfc3339::option")]
+    pub last_active: Option<time::OffsetDateTime>,
 }
 
 /// Configuration for consumers. From a high level, the

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1242,7 +1242,7 @@ mod jetstream {
             })
             .await
             .unwrap();
-        let consumer: PullConsumer = stream.get_consumer("pull").await.unwrap();
+        let mut consumer: PullConsumer = stream.get_consumer("pull").await.unwrap();
 
         tokio::task::spawn(async move {
             for i in 0..1000 {
@@ -1257,6 +1257,9 @@ mod jetstream {
         while let Some(result) = iter.next().await {
             result.unwrap().ack().await.unwrap();
         }
+
+        let info = consumer.info().await.unwrap();
+        assert!(info.delivered.last_active.is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
fixes https://github.com/nats-io/nats-architecture-and-design/issues/122

@caspervonb do we take the liberty of being pre-1.0 and rename `SequencePair` to `SequenceInfo`? I would say - yes.