### PR TITLE
Fix typos in async-nats docs

### DIFF
--- a/async-nats/examples/jetstream_pull.rs
+++ b/async-nats/examples/jetstream_pull.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), async_nats::Error> {
     }
 
     // Attach to the messages iterator for the Consumer.
-    // The iterator does its best to optimize retrival of messages from the server.
+    // The iterator does its best to optimize retrieval of messages from the server.
     let mut messages = consumer.messages().await?.take(10);
 
     // Iterate over messages.

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -50,7 +50,7 @@ impl fmt::Display for PublishError {
 
 impl error::Error for PublishError {}
 
-/// Client is a `Clonable` handle to NATS connection.
+/// Client is a `Cloneable` handle to NATS connection.
 /// Client should not be created directly. Instead, one of two methods can be used:
 /// [crate::connect] and [crate::ConnectOptions::connect]
 #[derive(Clone, Debug)]
@@ -378,7 +378,7 @@ impl Request {
         Default::default()
     }
 
-    /// Sets the payload of the request. If not used, empty paylaod will be sent.
+    /// Sets the payload of the request. If not used, empty payload will be sent.
     ///
     /// # Examples
     /// ```no_run

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -86,7 +86,7 @@ impl Client {
 
     /// Returns last received info from the server.
     ///
-    /// Examples
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]

--- a/async-nats/src/connection.rs
+++ b/async-nats/src/connection.rs
@@ -55,7 +55,7 @@ pub(crate) struct Connection {
 }
 
 /// Internal representation of the connection.
-/// Helds connection with NATS Server and communicates with `Client` via channels.
+/// Holds connection with NATS Server and communicates with `Client` via channels.
 impl Connection {
     pub(crate) fn try_read_op(&mut self) -> Result<Option<ServerOp>, io::Error> {
         let maybe_len = self.buffer.find(b"\r\n");

--- a/async-nats/src/header.rs
+++ b/async-nats/src/header.rs
@@ -79,12 +79,14 @@ impl HeaderMap {
     ///
     /// # Examples
     ///
+    /// ```
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::Error> {
     /// let headers = async_nats::HeaderMap::new();
     /// headers.insert("Key", "Value");
     /// # Ok(())
     /// # }
+    /// ```
     pub fn insert<K: IntoHeaderName, V: IntoHeaderValue>(&mut self, name: K, value: V) {
         self.inner
             .insert(name.into_header_name(), value.into_header_value());

--- a/async-nats/src/header.rs
+++ b/async-nats/src/header.rs
@@ -82,7 +82,7 @@ impl HeaderMap {
     /// ```
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::Error> {
-    /// let headers = async_nats::HeaderMap::new();
+    /// let mut headers = async_nats::HeaderMap::new();
     /// headers.insert("Key", "Value");
     /// # Ok(())
     /// # }

--- a/async-nats/src/jetstream/account.rs
+++ b/async-nats/src/jetstream/account.rs
@@ -78,7 +78,7 @@ pub struct Tier {
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Account {
-    /// Memory stoage being used for Stream Message storage
+    /// Memory storage being used for Stream Message storage
     pub memory: u64,
     /// File Storage being used for Stream Message storage
     pub storage: u64,

--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -104,8 +104,8 @@ impl<T: IntoConsumerConfig> Consumer<T> {
     }
 
     /// Returns cached [Info] for the [Consumer].
-    /// Cache is either from initial creation/retrival of the [Consumer] or last call to
-    /// [Consumer::info].
+    /// Cache is either from initial creation/retrieval of the [Consumer] or last call to
+    /// [Info].
     ///
     /// # Examples
     ///
@@ -157,7 +157,7 @@ pub struct Info {
     pub config: Config,
     /// Statistics for delivered messages
     pub delivered: SequenceInfo,
-    /// Statistics for acknowleged messages
+    /// Statistics for acknowledged messages
     pub ack_floor: SequenceInfo,
     /// The difference between delivered and acknowledged messages
     pub num_ack_pending: usize,
@@ -296,13 +296,13 @@ pub struct Config {
     /// Maximum size of a request batch
     #[serde(default, skip_serializing_if = "is_default")]
     pub max_batch: i64,
-    /// Maximum value for request exiration
+    /// Maximum value for request expiration
     #[serde(default, with = "serde_nanos", skip_serializing_if = "is_default")]
     pub max_expires: Duration,
-    /// Threshold for ephemeral consumer intactivity
+    /// Threshold for ephemeral consumer inactivity
     #[serde(default, with = "serde_nanos", skip_serializing_if = "is_default")]
     pub inactive_threshold: Duration,
-    /// Number of consumer replucas
+    /// Number of consumer replicas
     #[serde(default, skip_serializing_if = "is_default")]
     pub num_replicas: usize,
     /// Force consumer to use memory storage.
@@ -368,7 +368,7 @@ pub enum DeliverPolicy {
         #[serde(rename = "opt_start_seq")]
         start_sequence: u64,
     },
-    /// `ByStartTime` will select the first messsage with a timestamp >= to the consumer's
+    /// `ByStartTime` will select the first message with a timestamp >= to the consumer's
     /// configured `opt_start_time` parameter.
     #[serde(rename = "by_start_time")]
     ByStartTime {

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -110,6 +110,7 @@ impl Consumer<Config> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn stream(&self) -> StreamBuilder<'_> {
         StreamBuilder::new(self)
     }
@@ -711,6 +712,7 @@ impl<'a> StreamBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn max_bytes_per_batch(mut self, max_bytes: usize) -> Self {
         self.max_bytes = max_bytes;
         self
@@ -748,6 +750,7 @@ impl<'a> StreamBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn max_messages_per_batch(mut self, batch: usize) -> Self {
         self.batch = batch;
         self
@@ -781,6 +784,7 @@ impl<'a> StreamBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn heartbeat(mut self, heartbeat: Duration) -> Self {
         self.heartbeat = heartbeat;
         self
@@ -815,6 +819,7 @@ impl<'a> StreamBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn expires(mut self, expires: Duration) -> Self {
         self.expires = expires.as_nanos().try_into().unwrap();
         self
@@ -847,6 +852,7 @@ impl<'a> StreamBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub async fn messages(self) -> Result<Stream, Error> {
         Stream::stream(
             BatchConfig {
@@ -862,7 +868,7 @@ impl<'a> StreamBuilder<'a> {
     }
 }
 
-/// Used for building configuration for a [Fetch]. Created by a [Consumer::fetch_builder] on a [Consumer].
+/// Used for building configuration for a [`Fetch`]. Created by a [FetchBuilder] on a [Consumer].
 ///
 /// # Examples
 ///
@@ -890,6 +896,7 @@ impl<'a> StreamBuilder<'a> {
 /// }
 /// # Ok(())
 /// # }
+/// ```
 pub struct FetchBuilder<'a> {
     batch: usize,
     max_bytes: usize,
@@ -940,6 +947,7 @@ impl<'a> FetchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn max_bytes(mut self, max_bytes: usize) -> Self {
         self.max_bytes = max_bytes;
         self
@@ -976,6 +984,7 @@ impl<'a> FetchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn max_messages(mut self, batch: usize) -> Self {
         self.batch = batch;
         self
@@ -1009,6 +1018,7 @@ impl<'a> FetchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn heartbeat(mut self, heartbeat: Duration) -> Self {
         self.heartbeat = heartbeat;
         self
@@ -1044,6 +1054,7 @@ impl<'a> FetchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn expires(mut self, expires: Duration) -> Self {
         self.expires = expires.as_nanos().try_into().unwrap();
         self
@@ -1076,6 +1087,7 @@ impl<'a> FetchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub async fn messages(self) -> Result<Batch, Error> {
         Batch::batch(
             BatchConfig {
@@ -1119,6 +1131,7 @@ impl<'a> FetchBuilder<'a> {
 /// }
 /// # Ok(())
 /// # }
+/// ```
 pub struct BatchBuilder<'a> {
     batch: usize,
     max_bytes: usize,
@@ -1170,6 +1183,7 @@ impl<'a> BatchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn max_bytes(mut self, max_bytes: usize) -> Self {
         self.max_bytes = max_bytes;
         self
@@ -1207,6 +1221,7 @@ impl<'a> BatchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn max_messages(mut self, batch: usize) -> Self {
         self.batch = batch;
         self
@@ -1240,6 +1255,7 @@ impl<'a> BatchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn heartbeat(mut self, heartbeat: Duration) -> Self {
         self.heartbeat = heartbeat;
         self
@@ -1274,6 +1290,7 @@ impl<'a> BatchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub fn expires(mut self, expires: Duration) -> Self {
         self.expires = expires.as_nanos().try_into().unwrap();
         self
@@ -1306,6 +1323,7 @@ impl<'a> BatchBuilder<'a> {
     /// }
     /// # Ok(())
     /// # }
+    /// ```
     pub async fn messages(self) -> Result<Batch, Error> {
         Batch::batch(
             BatchConfig {
@@ -1413,13 +1431,13 @@ pub struct Config {
     /// Maximum size of a request batch
     #[serde(default, skip_serializing_if = "is_default")]
     pub max_batch: i64,
-    /// Maximum value for request exiration
+    /// Maximum value for request expiration
     #[serde(default, with = "serde_nanos", skip_serializing_if = "is_default")]
     pub max_expires: Duration,
-    /// Threshold for ephemeral consumer intactivity
+    /// Threshold for ephemeral consumer inactivity
     #[serde(default, with = "serde_nanos", skip_serializing_if = "is_default")]
     pub inactive_threshold: Duration,
-    /// Number of consumer replucas
+    /// Number of consumer replicas
     #[serde(default, skip_serializing_if = "is_default")]
     pub num_replicas: usize,
     /// Force consumer to use memory storage.

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -305,7 +305,7 @@ pub struct OrderedConfig {
     /// The maximum number of waiting consumers.
     #[serde(default, skip_serializing_if = "is_default")]
     pub max_waiting: i64,
-    /// Number of consumer replucas
+    /// Number of consumer replicas
     #[serde(default, skip_serializing_if = "is_default")]
     pub num_replicas: usize,
 }

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -191,7 +191,7 @@ pub struct Config {
     /// Enable idle heartbeat messages
     #[serde(default, with = "serde_nanos", skip_serializing_if = "is_default")]
     pub idle_heartbeat: Duration,
-    /// Number of consumer replucas
+    /// Number of consumer replicas
     #[serde(default, skip_serializing_if = "is_default")]
     pub num_replicas: usize,
     /// Force consumer to use memory storage.

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -98,7 +98,7 @@ pub struct Config {
     pub storage: StorageType,
     /// How many replicas to keep for each entry in a cluster.
     pub num_replicas: usize,
-    /// Republish is for republishing messages once persisten in the Key Value Bucket.
+    /// Republish is for republishing messages once persistent in the Key Value Bucket.
     pub republish: Option<Republish>,
 }
 
@@ -708,7 +708,7 @@ pub struct Entry {
     pub bucket: String,
     /// The key that was retrieved.
     pub key: String,
-    /// The value that was retreived.
+    /// The value that was retrieved.
     // TODO: should we use Bytes?
     pub value: Vec<u8>,
     /// A unique sequence for this value.

--- a/async-nats/src/jetstream/message.rs
+++ b/async-nats/src/jetstream/message.rs
@@ -46,7 +46,7 @@ impl Message {
     /// If [AckPolicy][crate::jetstream::consumer::AckPolicy] is set to `All` or `Explicit`, messages has to be acked.
     /// Otherwise redeliveries will occur and [Consumer][crate::jetstream::consumer::Consumer] will not be able to advance.
     ///
-    /// Examples
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -83,9 +83,9 @@ impl Message {
         }
     }
 
-    /// Acknowledges a message delivery by sending a choosen [AckKind] variant to the server.
+    /// Acknowledges a message delivery by sending a chosen [AckKind] variant to the server.
     ///
-    /// Examples
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -130,7 +130,7 @@ impl Message {
     /// If [AckPolicy][crate::jetstream::consumer::AckPolicy] is set to `All` or `Explicit`, messages has to be acked.
     /// Otherwise redeliveries will occur and [Consumer][crate::jetstream::consumer::Consumer] will not be able to advance.
     ///
-    /// Examples
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]

--- a/async-nats/src/jetstream/mod.rs
+++ b/async-nats/src/jetstream/mod.rs
@@ -118,7 +118,7 @@ pub fn new(client: Client) -> Context {
     Context::new(client)
 }
 
-/// Creates a new JetStream [Context] with given JetStteam domain.
+/// Creates a new JetStream [Context] with given JetStream domain.
 ///
 /// # Examples
 ///

--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -200,9 +200,9 @@ impl ObjectStore {
             .stream
             .get_last_raw_message_by_subject(subject.as_str())
             .await?;
-        let decoded_payload = base64::decode(message.payload)
+        let decoded_paylaod = base64::decode(message.payload)
             .map_err(|err| Box::new(std::io::Error::new(ErrorKind::Other, err)))?;
-        let object_info = serde_json::from_slice::<ObjectInfo>(&decoded_payload)?;
+        let object_info = serde_json::from_slice::<ObjectInfo>(&decoded_paylaod)?;
 
         Ok(object_info)
     }

--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -86,8 +86,10 @@ pub struct ObjectStore {
 impl ObjectStore {
     /// Gets an [Object] from the [Store].
     ///
-    /// [Object] implements [use tokio::io::AsyncRead] that allows
+    /// [Object] implements [tokio::io::AsyncRead] that allows
     /// to read the data from Object Store.
+    ///
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -124,8 +126,10 @@ impl ObjectStore {
 
     /// Gets an [Object] from the [Store].
     ///
-    /// [Object] implements [use tokio::io::AsyncRead] that allows
+    /// [Object] implements [tokio::io::AsyncRead] that allows
     /// to read the data from Object Store.
+    ///
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main]
@@ -166,6 +170,8 @@ impl ObjectStore {
 
     /// Retrieves [Object] [Info].
     ///
+    /// # Examples
+    ///
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::Error> {
@@ -194,9 +200,9 @@ impl ObjectStore {
             .stream
             .get_last_raw_message_by_subject(subject.as_str())
             .await?;
-        let decoded_paylaod = base64::decode(message.payload)
+        let decoded_payload = base64::decode(message.payload)
             .map_err(|err| Box::new(std::io::Error::new(ErrorKind::Other, err)))?;
-        let object_info = serde_json::from_slice::<ObjectInfo>(&decoded_paylaod)?;
+        let object_info = serde_json::from_slice::<ObjectInfo>(&decoded_payload)?;
 
         Ok(object_info)
     }
@@ -235,7 +241,7 @@ impl ObjectStore {
                 "invalid object name",
             )));
         }
-        // Fetch any existing object info, if ther is any for later use.
+        // Fetch any existing object info, if there is any for later use.
         let maybe_existing_object_info = match self.info(&object_name).await {
             Ok(object_info) => Some(object_info),
             Err(_) => None,
@@ -342,7 +348,7 @@ impl ObjectStore {
         })
     }
 
-    /// Seals a [ObjestStore], preventing any further changes to it or its [Objects][Object].
+    /// Seals a [ObjectStore], preventing any further changes to it or its [Objects][Object].
     ///
     /// # Examples
     ///

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -79,7 +79,7 @@ impl Stream {
 
     /// Returns cached [Info] for the [Stream].
     /// Cache is either from initial creation/retrival of the [Stream] or last call to
-    /// [Stream::info].
+    /// [Stream::Info].
     ///
     /// # Examples
     ///
@@ -378,7 +378,7 @@ impl Stream {
     ///
     /// let publish_ack = context.publish("events".to_string(), "data".into()).await?;
     /// let raw_message = stream.get_raw_message(publish_ack.sequence).await?;
-    /// println!("Retreived raw message {:?}", raw_message);
+    /// println!("Retrieved raw message {:?}", raw_message);
     /// # Ok(())
     /// # }
     /// ```
@@ -422,7 +422,7 @@ impl Stream {
     ///
     /// let publish_ack = context.publish("events".to_string(), "data".into()).await?;
     /// let raw_message = stream.get_last_raw_message_by_subject("events").await?;
-    /// println!("Retreived raw message {:?}", raw_message);
+    /// println!("Retrieved raw message {:?}", raw_message);
     /// # Ok(())
     /// # }
     /// ```
@@ -487,6 +487,7 @@ impl Stream {
     ///
     /// # Examples
     ///
+    /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::Error> {
     /// let client = async_nats::connect("demo.nats.io").await?;
@@ -496,6 +497,7 @@ impl Stream {
     /// stream.purge().await?;
     /// # Ok(())
     /// # }
+    /// ```
     pub async fn purge(&self) -> Result<PurgeResponse, Error> {
         let subject = format!("STREAM.PURGE.{}", self.info.config.name);
 
@@ -516,6 +518,7 @@ impl Stream {
     ///
     /// # Examples
     ///
+    /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::Error> {
     /// let client = async_nats::connect("demo.nats.io").await?;
@@ -525,6 +528,7 @@ impl Stream {
     /// stream.purge_subject("data").await?;
     /// # Ok(())
     /// # }
+    /// ```
     pub async fn purge_subject<T>(&self, subject: T) -> Result<PurgeResponse, Error>
     where
         T: Into<String>,

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -61,7 +61,6 @@
 //! # use bytes::Bytes;
 //! # use std::error::Error;
 //! # use std::time::Instant;
-//!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), async_nats::Error> {
 //! let client = async_nats::connect("demo.nats.io").await?;
@@ -82,7 +81,6 @@
 //! # use futures::StreamExt;
 //! # use std::error::Error;
 //! # use std::time::Instant;
-//!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), async_nats::Error> {
 //! let client = async_nats::connect("demo.nats.io").await?;
@@ -94,6 +92,7 @@
 //! }
 //! #     Ok(())
 //! # }
+//! ```
 
 #![deny(unreachable_pub)]
 
@@ -784,6 +783,7 @@ impl Subscriber {
     ///  subscriber.unsubscribe().await?;
     /// # Ok(())
     /// # }
+    /// ```
     pub async fn unsubscribe(&mut self) -> io::Result<()> {
         self.sender
             .send(Command::Unsubscribe {
@@ -797,8 +797,8 @@ impl Subscriber {
     }
 
     /// Unsubscribes from subscription after reaching given number of messages.
-    /// This is the total number of messages received by this subcsription in it's whole
-    /// lifespan. If it already reeached or surpassed the passed value, it will immediately stop.
+    /// This is the total number of messages received by this subscription in it's whole
+    /// lifespan. If it already reached or surpassed the passed value, it will immediately stop.
     ///
     /// # Examples
     /// ```
@@ -821,6 +821,7 @@ impl Subscriber {
     /// println!("no more messages, unsubscribed");
     /// # Ok(())
     /// # }
+    /// ```
     pub async fn unsubscribe_after(&mut self, unsub_after: u64) -> io::Result<()> {
         self.sender
             .send(Command::Unsubscribe {

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -508,7 +508,6 @@ impl ConnectOptions {
     /// async_nats::ConnectOptions::new().client_capacity(256).connect("demo.nats.io").await?;
     /// # Ok(())
     /// # }
-
     /// ```
     ///
     pub fn client_capacity(mut self, capacity: usize) -> ConnectOptions {
@@ -535,12 +534,13 @@ impl ConnectOptions {
     /// Sets the name for the client.
     ///
     /// # Examples
-    ///
+    /// ```
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::Error> {
     /// async_nats::ConnectOptions::new().name("rust-service").connect("demo.nats.io").await?;
     /// # Ok(())
     /// # }
+    /// ```
     pub fn name<T: ToString>(mut self, name: T) -> ConnectOptions {
         self.name = Some(name.to_string());
         self

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -391,7 +391,7 @@ impl ConnectOptions {
 
     /// Sets the capacity for `Subscribers`. Exceeding it will trigger `slow consumer` error
     /// callback and drop messages.
-    /// Defualt is set to 1024 messages buffer.
+    /// Default is set to 1024 messages buffer.
     ///
     /// # Examples
     /// ```no_run
@@ -440,7 +440,7 @@ impl ConnectOptions {
     /// Registers asynchronous callback for errors that are receiver over the wire from the server.
     ///
     /// # Examples
-    /// As asynchronous callbacks are stil not in `stable` channel, here are some examples how to
+    /// As asynchronous callbacks are still not in `stable` channel, here are some examples how to
     /// work around this
     ///
     /// ## Basic
@@ -450,7 +450,7 @@ impl ConnectOptions {
     /// # #[tokio::main]
     /// # async fn main() -> std::io::Result<()> {
     /// async_nats::ConnectOptions::new().event_callback(|event| async move {
-    ///         println!("event occured: {}", event);
+    ///         println!("event occurred: {}", event);
     /// }).connect("demo.nats.io").await?;
     /// # Ok(())
     /// # }
@@ -465,7 +465,7 @@ impl ConnectOptions {
     ///     match event {
     ///     async_nats::Event::Disconnect => println!("disconnected"),
     ///         async_nats::Event::Reconnect => println!("reconnected"),
-    ///         async_nats::Event::ClientError(err) => println!("client error occured: {}", err),
+    ///         async_nats::Event::ClientError(err) => println!("client error occurred: {}", err),
     ///         other => println!("other event happened: {}", other),
     /// }
     /// }).connect("demo.nats.io").await?;


### PR DESCRIPTION
This PR fixes a couple of issues that I found with the docs while using the async-nats client.

The issues I found were mostly:
* Typos
* Code Examples without the `#Examples` title
* Code Examples that didn't have ``` , to indicate a code block