### PR TITLE
Bump rustls-pemfile version

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -30,7 +30,7 @@ tokio-util = { version = "0.7.0", features = ["codec"] }
 itoa = "1"
 url = "2"
 tokio-rustls = "0.23"
-rustls-pemfile = "0.3.0"
+rustls-pemfile = "1.0.1"
 nuid = "0.3.2"
 serde_nanos = "0.1.1"
 time = { version = "0.3.6", features = ["parsing", "formatting", "serde", "serde-well-known"] }

--- a/async-nats/dependencies.md
+++ b/async-nats/dependencies.md
@@ -18,7 +18,6 @@ This file lists the dependencies used in this repository.
 | rand 0.8.5                | Apache-2.0 OR MIT        |
 | regex 1.5.5               | Apache-2.0 OR MIT        |
 | rustls-native-certs 0.6.2 | Apache-2.0 OR ISC OR MIT |
-| rustls-pemfile 0.3.0      | Apache-2.0 OR ISC OR MIT |
 | rustls-pemfile 1.0.0      | Apache-2.0 OR ISC OR MIT |
 | serde 1.0.136             | Apache-2.0 OR MIT        |
 | serde_json 1.0.79         | Apache-2.0 OR MIT        |


### PR DESCRIPTION
`async_nats` already depends on `rustls-native-certs v0.6.2`, which depends on `rustls-pemfile 1.0.1`. This change bumps the version of `rustls-pemfile` depended on directly on that version, so that the direct dependency matches the transitive dependency, preventing the compiler from compiling two different versions of that crate.