### PR TITLE
Fix missing hearbeats future wakup

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1691,7 +1691,7 @@ mod jetstream {
                 .kind(),
             std::io::ErrorKind::TimedOut
         );
-        println!("time elapsed {:?}", now.elapsed());
+        assert!(now.elapsed().le(&Duration::from_secs(50)));
     }
 
     #[tokio::test]

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1414,7 +1414,7 @@ mod jetstream {
 
         tokio::task::spawn(async move {
             for i in 0..25 {
-                tokio::time::sleep(Duration::from_millis(200)).await;
+                tokio::time::sleep(Duration::from_millis(400)).await;
                 context
                     .publish(
                         "events".to_string(),
@@ -1429,13 +1429,12 @@ mod jetstream {
             .stream()
             .max_messages_per_batch(25)
             .expires(Duration::from_millis(500))
-            .heartbeat(Duration::from_millis(150))
+            .heartbeat(Duration::from_millis(250))
             .messages()
             .await
             .unwrap()
             .take(25);
         while let Some(result) = iter.next().await {
-            println!("MESSAGE: {:?}", result);
             result.unwrap().ack().await.unwrap();
         }
     }


### PR DESCRIPTION
The previous solution worked only because after some time, something was polled. It was never related to heartbeats one shot `try_recv()`, because, quoting tokio docs

> If no value has been sent, the current task will not be registered for future notification.

I switched to mpsc for simplicity.


Signed-off-by: Tomasz Pietrek <tomasz@nats.io>