### PR TITLE
Change event logs to info level

### DIFF
--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -99,7 +99,7 @@ impl Default for ConnectOptions {
             subscription_capacity: 1024,
             event_callback: CallbackArg1::<Event, ()>(Box::new(move |event| {
                 Box::pin(async move {
-                    tracing::error!("event: {}", event);
+                    tracing::info!("event: {}", event);
                 })
             })),
             inbox_prefix: "_INBOX".to_string(),


### PR DESCRIPTION
Having them as `error` was pretty misleading :).

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>