### PR TITLE
Further improve hearbeat tests

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1413,8 +1413,8 @@ mod jetstream {
         let consumer: PullConsumer = stream.get_consumer("pull").await.unwrap();
 
         tokio::task::spawn(async move {
-            for i in 0..25 {
-                tokio::time::sleep(Duration::from_millis(400)).await;
+            for i in 0..10 {
+                tokio::time::sleep(Duration::from_millis(600)).await;
                 context
                     .publish(
                         "events".to_string(),
@@ -1427,13 +1427,13 @@ mod jetstream {
 
         let mut iter = consumer
             .stream()
-            .max_messages_per_batch(25)
-            .expires(Duration::from_millis(500))
-            .heartbeat(Duration::from_millis(250))
+            .max_messages_per_batch(10)
+            .expires(Duration::from_millis(1000))
+            .heartbeat(Duration::from_millis(500))
             .messages()
             .await
             .unwrap()
-            .take(25);
+            .take(10);
         while let Some(result) = iter.next().await {
             result.unwrap().ack().await.unwrap();
         }


### PR DESCRIPTION
Small hearbeat interval is not something that should ever happen in production use cases so that is not a good way to test if they're implemented proberly.

Instead, I reduced the number of messages and increased the intervals.

That should have nice test-runs times with less flakyness.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>