### PR TITLE
Update K/V purge documentation verbiage

### DIFF
--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -543,7 +543,7 @@ impl Store {
         Ok(())
     }
 
-    /// Purges the given key, destructively removing everything from the bucket.
+    /// Purges the given key history, destructively removing all key entries from the bucket.
     ///
     /// # Examples
     ///

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -543,7 +543,7 @@ impl Store {
         Ok(())
     }
 
-    /// Purges the given key history, destructively removing all key entries from the bucket.
+    /// Purges all the revisions of a entry destructively, leaving behind a single purge entry in-place.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Clarifies K/V purge documentation to record that it is a removal of entries not the key itself from the bucket.