### PR TITLE
CI only write annotations from clippy when write permissions exist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,11 +123,24 @@ jobs:
           components: clippy
           override: true
 
-      - name: Check lint
+      - name: Check workflow permissions
+        id: check_permissions
+        uses: scherermichael-oss/action-has-permission@1.0.6
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check lint with annotations
         uses: actions-rs/clippy-check@v1.0.7
+        if: steps.check_permissions.outputs.has-permission
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --tests --examples --all-features -- --deny clippy::all
+
+      - name: Check lint without annotations
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        run: cargo clippy --tests --examples --all-features -- -D warnings
 
   check_msrv:
     name: check (msrv)


### PR DESCRIPTION
Update linting in CI to only use clippy-check (and therefore try to write annotations) when the write permission is present on the github token.

This solves https://github.com/nats-io/nats.rs/issues/693 due to clippy-check not being able to run in forks of a project https://github.com/actions-rs/clippy-check/issues/2