### PR TITLE
Fix broken clippy pipeline and errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,15 +119,16 @@ jobs:
       - name: Set up rust
         uses: actions-rs/toolchain@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           toolchain: stable
           components: clippy
           override: true
 
       - name: Check lint
-        uses: actions-rs/clippy-check@v1.0.7
+        uses: actions-rs/cargo@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           args: --tests --examples --all-features -- --deny clippy::all
+          command: clippy
 
   check_msrv:
     name: check (msrv)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,8 +119,7 @@ jobs:
       - name: Set up rust
         uses: actions-rs/toolchain@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          toolchain: stable
+          toolchain: nightly
           components: clippy
           override: true
 

--- a/async-nats/src/connection.rs
+++ b/async-nats/src/connection.rs
@@ -490,10 +490,7 @@ mod read_op {
         server.flush().await.unwrap();
 
         let result = connection.read_op().await.unwrap();
-        assert_eq!(
-            result,
-            Some(ServerOp::Info(Box::new(ServerInfo::default())))
-        );
+        assert_eq!(result, Some(ServerOp::Info(Box::default())));
 
         server
             .write_all(b"INFO { \"version\": \"1.0.0\" }\r\n")
@@ -521,10 +518,7 @@ mod read_op {
 
         server.write_all(b"INFO {}\r\n").await.unwrap();
         let result = connection.read_op().await.unwrap();
-        assert_eq!(
-            result,
-            Some(ServerOp::Info(Box::new(ServerInfo::default())))
-        );
+        assert_eq!(result, Some(ServerOp::Info(Box::default())));
 
         server
             .write_all(b"-ERR something went wrong\r\n")

--- a/nats/examples/nats-box/main.rs
+++ b/nats/examples/nats-box/main.rs
@@ -66,7 +66,7 @@ fn main() -> CliResult {
         }
         Command::Request { subject, msg } => {
             println!("Waiting on response for '{}'", subject);
-            let resp = nc.request(&subject, &msg)?;
+            let resp = nc.request(&subject, msg)?;
             println!("Response is {:?}", resp);
         }
         Command::Reply { subject, resp } => {
@@ -74,7 +74,7 @@ fn main() -> CliResult {
             println!("Listening for requests on '{}'", subject);
             for msg in sub.messages() {
                 println!("Received a request {:?}", msg);
-                msg.respond(&resp)?;
+                msg.respond(resp.clone())?;
             }
         }
     }

--- a/nats/examples/nats_bench.rs
+++ b/nats/examples/nats_bench.rs
@@ -88,7 +88,7 @@ fn main() -> std::io::Result<()> {
             barrier.wait();
             for _ in 0..messages / pubs {
                 let before = Instant::now();
-                nc.publish(&subject, &msg).unwrap();
+                nc.publish(&subject, msg.clone()).unwrap();
                 HISTOGRAM.measure(before.elapsed().as_nanos() as f64);
             }
         }));
@@ -138,7 +138,7 @@ fn main() -> std::io::Result<()> {
     println!("                min: {:10.0} ns", HISTOGRAM.percentile(0.0));
     for pctl in &[50., 75., 90., 95., 97.5, 99.0, 99.99, 99.999] {
         println!(
-            "{:6.}th percentile: {:10.0} ns",
+            "{:6}th percentile: {:10.0} ns",
             pctl,
             HISTOGRAM.percentile(*pctl)
         );

--- a/nats/nats_test_server/src/lib.rs
+++ b/nats/nats_test_server/src/lib.rs
@@ -554,8 +554,8 @@ fn test_pub_sub_2_clients() {
     env_logger::init();
     let server = NatsTestServer::build().spawn();
 
-    let conn1 = nats::connect(&server.address().to_string()).unwrap();
-    let conn2 = nats::connect(&server.address().to_string()).unwrap();
+    let conn1 = nats::connect(server.address().to_string()).unwrap();
+    let conn2 = nats::connect(server.address().to_string()).unwrap();
 
     let sub = conn1.subscribe("*").unwrap();
     // This test was sometimes failing due to some issues in `nats_test_server`.

--- a/nats/src/kv.rs
+++ b/nats/src/kv.rs
@@ -288,7 +288,7 @@ impl JetStream {
         }
 
         let stream_name = format!("KV_{}", bucket);
-        self.delete_stream(&stream_name)?;
+        self.delete_stream(stream_name)?;
 
         Ok(())
     }

--- a/nats/src/object_store.rs
+++ b/nats/src/object_store.rs
@@ -357,7 +357,7 @@ impl ObjectStore {
         let stream_name = format!("OBJ_{}", &self.name);
         let subject = format!("$O.{}.M.{}", &self.name, &object_name);
 
-        let message = self.context.get_last_message(&stream_name, &subject)?;
+        let message = self.context.get_last_message(stream_name, &subject)?;
         let object_info = serde_json::from_slice::<ObjectInfo>(&message.data)?;
 
         Ok(object_info)
@@ -469,7 +469,7 @@ impl ObjectStore {
             let chunk_subject = format!("$O.{}.C.{}", &self.name, &existing_object_info.nuid);
 
             self.context
-                .purge_stream_subject(&stream_name, &chunk_subject)?;
+                .purge_stream_subject(stream_name, &chunk_subject)?;
         }
 
         Ok(object_info)
@@ -565,7 +565,7 @@ impl ObjectStore {
         let chunk_subject = format!("$O.{}.C.{}", self.name, object_info.nuid);
 
         self.context
-            .purge_stream_subject(&stream_name, &chunk_subject)?;
+            .purge_stream_subject(stream_name, &chunk_subject)?;
 
         Ok(())
     }

--- a/nats/tests/async_errors.rs
+++ b/nats/tests/async_errors.rs
@@ -27,7 +27,7 @@ fn pub_perms() {
         .disconnect_callback(move || {
             let _ = dtx.send(true);
         })
-        .connect(&s.client_url())
+        .connect(s.client_url())
         .expect("could not connect");
 
     nc.publish("foo", "NOT ALLOWED").unwrap();
@@ -55,7 +55,7 @@ fn sub_perms() {
         .disconnect_callback(move || {
             let _ = dtx.send(true);
         })
-        .connect(&s.client_url())
+        .connect(s.client_url())
         .expect("could not connect");
 
     let _sub = nc.subscribe("foo").unwrap();

--- a/nats/tests/auth_nkey.rs
+++ b/nats/tests/auth_nkey.rs
@@ -21,8 +21,7 @@ fn basic_nkey_auth() -> io::Result<()> {
     let seed = "SUANQDPB2RUOE4ETUA26CNX7FUKE5ZZKFCQIIW63OX225F2CO7UEXTM7ZY";
     let kp = nkeys::KeyPair::from_seed(seed).unwrap();
 
-    nats::Options::with_nkey(nkey, move |nonce| kp.sign(nonce).unwrap())
-        .connect(&s.client_url())?;
+    nats::Options::with_nkey(nkey, move |nonce| kp.sign(nonce).unwrap()).connect(s.client_url())?;
 
     Ok(())
 }

--- a/nats/tests/auth_tls.rs
+++ b/nats/tests/auth_tls.rs
@@ -27,7 +27,7 @@ fn basic_tls() -> io::Result<()> {
             path.join("tests/configs/certs/client-cert.pem"),
             path.join("tests/configs/certs/client-key.pem"),
         )
-        .connect(&server.client_url())?;
+        .connect(server.client_url())?;
 
     // test scenario where rootCA, client certificate and client key are all in one .pem file
     nats::Options::with_user_pass("derek", "porkchop")
@@ -36,7 +36,7 @@ fn basic_tls() -> io::Result<()> {
             path.join("tests/configs/certs/client-all.pem"),
             path.join("tests/configs/certs/client-all.pem"),
         )
-        .connect(&server.client_url())?;
+        .connect(server.client_url())?;
 
     Ok(())
 }

--- a/nats/tests/auth_token.rs
+++ b/nats/tests/auth_token.rs
@@ -15,16 +15,16 @@
 fn token_auth() {
     let s = nats_server::run_server("tests/configs/token_auth.conf");
 
-    assert!(nats::connect(&s.client_url()).is_err());
+    assert!(nats::connect(s.client_url()).is_err());
 
     assert!(nats::Options::with_token("some-auth-token")
-        .connect(&s.client_url())
+        .connect(s.client_url())
         .is_ok());
 
-    assert!(nats::connect(&s.client_url_with_token("some-auth-token")).is_ok());
+    assert!(nats::connect(s.client_url_with_token("some-auth-token")).is_ok());
 
     // Check override.
     assert!(nats::Options::with_token("bad-auth-token")
-        .connect(&s.client_url_with_token("some-auth-token"))
+        .connect(s.client_url_with_token("some-auth-token"))
         .is_ok());
 }

--- a/nats/tests/auth_user_pass.rs
+++ b/nats/tests/auth_user_pass.rs
@@ -15,16 +15,16 @@
 fn basic_user_pass_auth() {
     let s = nats_server::run_server("tests/configs/user_pass.conf");
 
-    assert!(nats::connect(&s.client_url()).is_err());
+    assert!(nats::connect(s.client_url()).is_err());
 
     assert!(nats::Options::with_user_pass("derek", "s3cr3t")
-        .connect(&s.client_url())
+        .connect(s.client_url())
         .is_ok());
 
-    assert!(nats::connect(&s.client_url_with("derek", "s3cr3t")).is_ok());
+    assert!(nats::connect(s.client_url_with("derek", "s3cr3t")).is_ok());
 
     // Check override.
     assert!(nats::Options::with_user_pass("derek", "bad-password")
-        .connect(&s.client_url_with("derek", "s3cr3t"))
+        .connect(s.client_url_with("derek", "s3cr3t"))
         .is_ok());
 }

--- a/nats/tests/drop.rs
+++ b/nats/tests/drop.rs
@@ -22,8 +22,8 @@ use std::{
 fn drop_flushes() -> io::Result<()> {
     let s = nats_server::run_basic_server();
 
-    let nc1 = nats::connect(&s.client_url())?;
-    let nc2 = nats::connect(&s.client_url())?;
+    let nc1 = nats::connect(s.client_url())?;
+    let nc2 = nats::connect(s.client_url())?;
 
     let inbox = nc1.new_inbox();
     let sub = nc2.subscribe(&inbox)?;
@@ -41,7 +41,7 @@ fn drop_flushes() -> io::Result<()> {
 fn two_connections() -> io::Result<()> {
     let s = nats_server::run_basic_server();
 
-    let nc1 = nats::connect(&s.client_url())?;
+    let nc1 = nats::connect(s.client_url())?;
     let nc2 = nc1.clone();
 
     nc1.publish("foo", b"bar")?;
@@ -196,7 +196,7 @@ fn close_responsiveness_regression_jetstream_complex() {
 // Helper function to return server and client.
 pub fn run_basic_jetstream() -> (nats_server::Server, Connection, JetStream) {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
-    let nc = nats::connect(&s.client_url()).unwrap();
+    let nc = nats::connect(s.client_url()).unwrap();
     let js = JetStream::new(nc.clone(), JetStreamOptions::default());
 
     (s, nc, js)

--- a/nats/tests/jetstream.rs
+++ b/nats/tests/jetstream.rs
@@ -20,7 +20,7 @@ use nats::{jetstream, Connection};
 #[ignore]
 fn jetstream_not_enabled() {
     let s = nats_server::run_basic_server();
-    let nc = nats::connect(&s.client_url()).unwrap();
+    let nc = nats::connect(s.client_url()).unwrap();
     let js = nats::jetstream::new(nc);
 
     let err = js.account_info().unwrap_err();
@@ -38,7 +38,7 @@ fn jetstream_not_enabled() {
 #[test]
 fn jetstream_account_not_enabled() {
     let s = nats_server::run_server("tests/configs/jetstream_account_not_enabled.conf");
-    let nc = nats::connect(&s.client_url()).unwrap();
+    let nc = nats::connect(s.client_url()).unwrap();
     let js = nats::jetstream::new(nc);
 
     let err = js.account_info().unwrap_err();
@@ -80,7 +80,7 @@ fn jetstream_publish() {
     let err = js
         .publish_with_options(
             "foo",
-            &msg,
+            msg,
             &PublishOptions {
                 expected_stream: Some("ORDERS".to_string()),
                 ..Default::default()
@@ -247,7 +247,7 @@ fn jetstream_publish() {
 #[test]
 fn jetstream_subscribe() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
-    let nc = nats::connect(&s.client_url()).unwrap();
+    let nc = nats::connect(s.client_url()).unwrap();
     let js = nats::jetstream::new(nc.clone());
 
     js.add_stream(&StreamConfig {
@@ -299,7 +299,7 @@ fn jetstream_subscribe() {
 #[test]
 fn jetstream_subscribe_durable() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
-    let nc = nats::connect(&s.client_url()).unwrap();
+    let nc = nats::connect(s.client_url()).unwrap();
     let js = nats::jetstream::new(nc);
 
     js.add_stream(&StreamConfig {
@@ -361,7 +361,7 @@ fn jetstream_subscribe_durable() {
 #[test]
 fn jetstream_queue_subscribe() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
-    let nc = nats::connect(&s.client_url()).unwrap();
+    let nc = nats::connect(s.client_url()).unwrap();
     let js = nats::jetstream::new(nc);
 
     js.add_stream(&StreamConfig {
@@ -498,7 +498,7 @@ fn jetstream_queue_subscribe_no_mismatch_handle() {
 #[test]
 fn jetstream_flow_control() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
-    let nc = nats::connect(&s.client_url()).unwrap();
+    let nc = nats::connect(s.client_url()).unwrap();
     let js = nats::jetstream::new(nc);
 
     js.add_stream(&StreamConfig {
@@ -548,7 +548,7 @@ fn jetstream_flow_control() {
 #[test]
 fn jetstream_ordered() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
-    let nc = nats::connect(&s.client_url()).unwrap();
+    let nc = nats::connect(s.client_url()).unwrap();
     let js = nats::jetstream::new(nc);
 
     js.add_stream(&StreamConfig {
@@ -587,7 +587,7 @@ fn jetstream_pull_subscribe_fetch() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
     let nc = nats::Options::new()
         .error_callback(|err| println!("error!: {}", err))
-        .connect(&s.client_url())
+        .connect(s.client_url())
         .unwrap();
     let js = nats::jetstream::new(nc);
 
@@ -639,7 +639,7 @@ fn jetstream_pull_subscribe_timeout_fetch() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
     let nc = nats::Options::new()
         .error_callback(|err| println!("error!: {}", err))
-        .connect(&s.client_url())
+        .connect(s.client_url())
         .unwrap();
     let js = nats::jetstream::new(nc);
 
@@ -697,7 +697,7 @@ fn jetstream_pull_subscribe_fetch_with_handler() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
     let nc = nats::Options::new()
         .error_callback(|err| println!("error!: {}", err))
-        .connect(&s.client_url())
+        .connect(s.client_url())
         .unwrap();
     let js = nats::jetstream::new(nc.clone());
 
@@ -749,7 +749,7 @@ fn jetstream_pull_subscribe_ephemeral() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
     let nc = nats::Options::new()
         .error_callback(|err| println!("error!: {}", err))
-        .connect(&s.client_url())
+        .connect(s.client_url())
         .unwrap();
     let js = nats::jetstream::new(nc);
 
@@ -775,7 +775,7 @@ fn jetstream_pull_subscribe_bad_stream() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
     let nc = nats::Options::new()
         .error_callback(|err| println!("error!: {}", err))
-        .connect(&s.client_url())
+        .connect(s.client_url())
         .unwrap();
     let js = nats::jetstream::new(nc);
 
@@ -786,7 +786,7 @@ fn jetstream_pull_subscribe_bad_stream() {
 // Helper function to return server and client.
 pub fn run_basic_jetstream() -> (nats_server::Server, Connection, JetStream) {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
-    let nc = nats::connect(&s.client_url()).unwrap();
+    let nc = nats::connect(s.client_url()).unwrap();
     let js = JetStream::new(nc.clone(), JetStreamOptions::default());
 
     (s, nc, js)

--- a/nats/tests/kv.rs
+++ b/nats/tests/kv.rs
@@ -22,7 +22,7 @@ use nats::kv::*;
 #[test]
 fn key_value_entry() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let kv = context
@@ -79,7 +79,7 @@ fn key_value_entry() {
 #[test]
 fn key_value_short_history() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let kv = context
@@ -106,7 +106,7 @@ fn key_value_short_history() {
 #[test]
 fn key_value_long_history() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let kv = context
@@ -133,7 +133,7 @@ fn key_value_long_history() {
 #[test]
 fn key_value_watch() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let kv = context
@@ -172,7 +172,7 @@ fn key_value_watch() {
 #[test]
 fn key_value_watch_all() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let kv = context
@@ -222,7 +222,7 @@ fn key_value_watch_all() {
 #[test]
 fn key_value_bind() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     context
@@ -251,7 +251,7 @@ fn key_value_bind() {
 #[test]
 fn key_value_delete() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     context
@@ -270,7 +270,7 @@ fn key_value_delete() {
 #[test]
 fn key_value_purge() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let bucket = context
@@ -304,7 +304,7 @@ fn key_value_purge() {
 #[test]
 fn key_value_keys() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let kv = context
@@ -364,7 +364,7 @@ fn key_value_keys() {
 fn key_value_domain() {
     let _server = nats_server::run_server("tests/configs/jetstream-domain.conf");
     let leaf_server = nats_server::run_server("tests/configs/jetstream-domain-leaf.conf");
-    let client = nats::connect(&leaf_server.client_url()).unwrap();
+    let client = nats::connect(leaf_server.client_url()).unwrap();
     let opts = nats::jetstream::JetStreamOptions::new().domain("foobar");
     let context = nats::jetstream::JetStream::new(client, opts);
 

--- a/nats/tests/no_messages.rs
+++ b/nats/tests/no_messages.rs
@@ -17,7 +17,7 @@ pub use nats_server::*;
 #[test]
 fn no_messages() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
-    let nc = nats::connect(&s.client_url()).expect("could not connect");
+    let nc = nats::connect(s.client_url()).expect("could not connect");
     let js = nats::jetstream::new(nc);
 
     js.add_stream(&StreamConfig {

--- a/nats/tests/no_responders.rs
+++ b/nats/tests/no_responders.rs
@@ -17,6 +17,6 @@ pub use nats_server::*;
 #[should_panic(expected = "no responders")]
 fn no_responders() {
     let s = nats_server::run_basic_server();
-    let nc = nats::connect(&s.client_url()).expect("could not connect");
+    let nc = nats::connect(s.client_url()).expect("could not connect");
     nc.request("nobody-home", "hello").unwrap();
 }

--- a/nats/tests/object_store.rs
+++ b/nats/tests/object_store.rs
@@ -19,7 +19,7 @@ use std::io::Read;
 #[test]
 fn object_random() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let bucket = context
@@ -104,7 +104,7 @@ fn object_random() {
 #[test]
 fn object_sealed() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let bucket = context
@@ -123,7 +123,7 @@ fn object_sealed() {
 #[test]
 fn object_delete() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let bucket = context
@@ -150,7 +150,7 @@ fn object_delete() {
 #[test]
 fn object_multiple_delete() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let bucket = context
@@ -182,7 +182,7 @@ fn object_multiple_delete() {
 #[test]
 fn object_names() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let bucket = context
@@ -209,7 +209,7 @@ fn object_names() {
 #[test]
 fn object_watch() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let client = nats::connect(&server.client_url()).unwrap();
+    let client = nats::connect(server.client_url()).unwrap();
     let context = nats::jetstream::new(client);
 
     let bucket = context

--- a/nats/tests/reconnection.rs
+++ b/nats/tests/reconnection.rs
@@ -47,7 +47,7 @@ fn reconnect_test() {
     let nc = loop {
         if let Ok(nc) = nats::Options::new()
             .max_reconnects(None)
-            .connect(&server.address().to_string())
+            .connect(server.address().to_string())
         {
             break Arc::new(nc);
         }

--- a/nats/tests/request_timeout.rs
+++ b/nats/tests/request_timeout.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 #[test]
 fn request_timeout() {
     let s = nats_server::run_server("tests/configs/jetstream.conf");
-    let nc = nats::connect(&s.client_url()).expect("could not connect");
+    let nc = nats::connect(s.client_url()).expect("could not connect");
     let js = nats::jetstream::new(nc);
 
     js.add_stream(&StreamConfig {


### PR DESCRIPTION
Invokes clippy directly and uses nightly to avoid a regression that results in a panic every now and then.

 Closes https://github.com/nats-io/nats.rs/issues/693