### PR TITLE
Fix typo in retry_on_initial_connect

### DIFF
--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -549,7 +549,7 @@ impl ConnectOptions {
         self
     }
 
-    pub fn retry_on_intial_connect(mut self) -> ConnectOptions {
+    pub fn retry_on_initial_connect(mut self) -> ConnectOptions {
         self.retry_on_initial_connect = true;
         self
     }

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -699,7 +699,7 @@ mod client {
             .event_callback(|ev| async move {
                 println!("event: {}", ev);
             })
-            .retry_on_intial_connect()
+            .retry_on_initial_connect()
             .connect("localhost:7777")
             .await
             .unwrap();


### PR DESCRIPTION
Found by @stevelr , thanks!

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>