### PR TITLE
use debug macro for logging instead of println

### DIFF
--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -413,7 +413,7 @@ impl Consumer<OrderedConfig> {
                                 .unwrap()
                                 .elapsed()
                                 .gt(&Duration::from_secs(10)) {
-                                    debug!("last seen ok. wait");
+                                    trace!("last seen ok. wait");
                                     continue;
                                     }
                             debug!("last seen not ok");

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -413,11 +413,11 @@ impl Consumer<OrderedConfig> {
                                 .unwrap()
                                 .elapsed()
                                 .gt(&Duration::from_secs(10)) {
-                                    println!("last seen ok. wait");
+                                    debug!("last seen ok. wait");
                                     continue;
                                     }
-                        println!("last seen not ok");
-                                }
+                            debug!("last seen not ok");
+                        }
                     }
                     debug!(
                         "idle hearbeats expired. recreating consumer s: {},  {:?}",


### PR DESCRIPTION
I was seeing the following being unexpectedly logged to the console:

```
last seen ok. wait
last seen not ok
last seen ok. wait
last seen ok. wait
last seen not ok

```