### PR TITLE
Allocate object store buffer on heap

### DIFF
--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -258,7 +258,7 @@ impl ObjectStore {
         let mut object_chunks = 0;
         let mut object_size = 0;
 
-        let mut buffer = [0; DEFAULT_CHUNK_SIZE];
+        let mut buffer = Vec::with_capacity(DEFAULT_CHUNK_SIZE);
         let mut context = ring::digest::Context::new(&SHA256);
 
         loop {


### PR DESCRIPTION
I think we should not allocate that much data on stack.
Get into stack overflow few times by accident.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>