### PR TITLE
Disable all legacy client example excecution

### DIFF
--- a/nats/src/jetstream/mod.rs
+++ b/nats/src/jetstream/mod.rs
@@ -671,7 +671,7 @@ impl JetStream {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -690,7 +690,7 @@ impl JetStream {
     /// Creates a pull subscription.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use nats::jetstream::BatchOptions;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -830,7 +830,7 @@ impl JetStream {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);

--- a/nats/src/jetstream/pull_subscription.rs
+++ b/nats/src/jetstream/pull_subscription.rs
@@ -93,7 +93,7 @@ impl PullSubscription {
     /// in the Consumer.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use nats::jetstream::BatchOptions;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -144,7 +144,7 @@ impl PullSubscription {
     /// in the Consumer.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use std::time::Duration;
     /// # use nats::jetstream::BatchOptions;
     /// # fn main() -> std::io::Result<()> {
@@ -193,7 +193,7 @@ impl PullSubscription {
     /// closure and acks them automatically according to `Consumer` `AckPolicy`.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use nats::jetstream::BatchOptions;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -244,7 +244,7 @@ impl PullSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -296,7 +296,7 @@ impl PullSubscription {
     /// Keep in mind that this requires user to request for messages first.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use std::time::Duration;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -352,7 +352,7 @@ impl PullSubscription {
     /// to have more granular control of how many request and when are sent.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use nats::jetstream::BatchOptions;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -400,7 +400,7 @@ impl PullSubscription {
     /// As Pull Consumers requires Client to fetch messages, this will yield nothing if explicit [`PullSubscription::request_batch`] was not sent.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use nats::jetstream::BatchOptions;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;

--- a/nats/src/jetstream/push_subscription.rs
+++ b/nats/src/jetstream/push_subscription.rs
@@ -114,7 +114,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -150,7 +150,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -183,7 +183,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -285,7 +285,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -316,7 +316,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -363,7 +363,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -487,7 +487,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -510,7 +510,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -551,7 +551,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
     /// # let context = nats::jetstream::new(client);
@@ -581,7 +581,7 @@ impl PushSubscription {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # use std::sync::{Arc, atomic::{AtomicBool, Ordering::SeqCst}};
     /// # use std::thread;
     /// # use std::time::Duration;
@@ -657,7 +657,7 @@ impl Handler {
     /// Unsubscribe a subscription.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// let sub = nc.subscribe("foo")?.with_handler(move |msg| {

--- a/nats/src/kv.rs
+++ b/nats/src/kv.rs
@@ -109,7 +109,7 @@ impl JetStream {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -169,7 +169,7 @@ impl JetStream {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -258,7 +258,7 @@ impl JetStream {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -338,7 +338,7 @@ impl Store {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -400,7 +400,7 @@ impl Store {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -436,7 +436,7 @@ impl Store {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -474,7 +474,7 @@ impl Store {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -512,7 +512,7 @@ impl Store {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -558,7 +558,7 @@ impl Store {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -602,7 +602,7 @@ impl Store {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -643,7 +643,7 @@ impl Store {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -689,7 +689,7 @@ impl Store {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::kv::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;

--- a/nats/src/lib.rs
+++ b/nats/src/lib.rs
@@ -372,19 +372,19 @@ impl Drop for Inner {
 /// # Examples
 ///
 /// If no scheme is provided the `nats://` scheme is assumed. The default port is `4222`.
-/// ```
+/// ```no_run
 /// let nc = nats::connect("demo.nats.io")?;
 /// # Ok::<(), std::io::Error>(())
 /// ```
 ///
 /// It is possible to provide several URLs as a comma separated list.
-/// ```
+/// ```no_run
 /// let nc = nats::connect("demo.nats.io,tls://demo.nats.io:4443")?;
 /// # Ok::<(), std::io::Error>(())
 /// ```
 ///
 /// Alternatively, an array of strings can be passed.
-/// ```
+/// ```no_run
 /// # use nats::IntoServerList;
 /// let nc = nats::connect(&["demo.nats.io", "tls://demo.nats.io:4443"])?;
 /// # Ok::<(), std::io::Error>(())
@@ -392,7 +392,7 @@ impl Drop for Inner {
 ///
 /// Instead of using strings, [`ServerAddress`]es can be used directly as well. This is handy for
 /// validating user input.
-/// ```
+/// ```no_run
 /// use std::io;
 /// use structopt::StructOpt;
 /// use nats::ServerAddress;
@@ -444,7 +444,7 @@ impl Connection {
     /// Create a queue subscription for the given NATS connection.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// let sub = nc.queue_subscribe("foo", "production")?;
@@ -458,7 +458,7 @@ impl Connection {
     /// Publish a message on the given subject.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// nc.publish("foo", "Hello World!")?;
@@ -473,7 +473,7 @@ impl Connection {
     /// responses.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// let reply = nc.new_inbox();
@@ -496,7 +496,7 @@ impl Connection {
     /// Create a new globally unique inbox which can be used for replies.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// let reply = nc.new_inbox();
@@ -512,7 +512,7 @@ impl Connection {
     /// response.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// # nc.subscribe("foo")?.with_handler(move |m| { m.respond("ans=42")?; Ok(()) });
@@ -529,7 +529,7 @@ impl Connection {
     /// response is received.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// # nc.subscribe("foo")?.with_handler(move |m| { m.respond("ans=42")?; Ok(()) });
@@ -550,7 +550,7 @@ impl Connection {
     /// response.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// # nc.subscribe("foo")?.with_handler(move |m| { m.respond("ans=42")?; Ok(()) });
@@ -574,7 +574,7 @@ impl Connection {
     /// response is received. It also allows passing headers.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// # nc.subscribe("foo")?.with_handler(move |m| { m.respond("ans=42")?; Ok(()) });
@@ -619,7 +619,7 @@ impl Connection {
     /// responses.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// # nc.subscribe("foo")?.with_handler(move |m| { m.respond("ans=42")?; Ok(()) });
@@ -644,7 +644,7 @@ impl Connection {
     /// the connection to the server is lost.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// nc.flush()?;
@@ -662,7 +662,7 @@ impl Connection {
     /// `BrokenPipe` if the connection to the server is lost.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use std::time::Duration;
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
@@ -684,7 +684,7 @@ impl Connection {
     /// shutting down.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// nc.close();
@@ -701,7 +701,7 @@ impl Connection {
     /// the server takes more than 10 seconds to respond.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// println!("server rtt: {:?}", nc.rtt());
@@ -746,7 +746,7 @@ impl Connection {
     /// Returns the client IP as known by the server.
     /// Supported as of server version 2.1.6.
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// println!("ip: {:?}", nc.client_ip());
@@ -783,7 +783,7 @@ impl Connection {
     /// Returns the client ID as known by the most recently connected server.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
     /// println!("ip: {:?}", nc.client_id());
@@ -807,7 +807,7 @@ impl Connection {
     /// afterward.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use std::sync::{Arc, atomic::{AtomicBool, Ordering::SeqCst}};
     /// # fn main() -> std::io::Result<()> {
     /// # let nc = nats::connect("demo.nats.io")?;
@@ -866,7 +866,7 @@ impl Connection {
     /// connected server will accept.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # fn main() -> std::io::Result<()> {
     /// let nc = nats::connect("demo.nats.io")?;
     /// println!("max payload: {:?}", nc.max_payload());

--- a/nats/src/object_store.rs
+++ b/nats/src/object_store.rs
@@ -76,7 +76,7 @@ impl JetStream {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::object_store::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -130,7 +130,7 @@ impl JetStream {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::object_store::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -172,7 +172,7 @@ impl JetStream {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// use nats::object_store::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -344,7 +344,7 @@ impl ObjectStore {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::object_store::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -402,7 +402,7 @@ impl ObjectStore {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// # use nats::object_store::Config;
     /// # fn main() -> std::io::Result<()> {
     /// # let client = nats::connect("demo.nats.io")?;
@@ -503,7 +503,7 @@ impl ObjectStore {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// use std::io::Read;
     /// # use nats::object_store::Config;
     /// # fn main() -> std::io::Result<()> {
@@ -543,7 +543,7 @@ impl ObjectStore {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// use std::io::Read;
     /// # use nats::object_store::Config;
     /// # fn main() -> std::io::Result<()> {


### PR DESCRIPTION
As we're slowly moving away from legacy client, let's disable all examples run.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>