### PR TITLE
Revert "Add deleted messages details to stream info"

### DIFF
--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -77,49 +77,6 @@ impl Stream {
         }
     }
 
-    /// Retrieves `info` about [Stream] from the server, updates the cached `info` inside
-    /// [Stream] and returns it. This method fills the `deleted` field with the list of
-    /// deleted message IDs.
-    /// Deleted messages list only contains messages deleted with sequence number greater
-    /// than stream's lowest sequence number.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), async_nats::Error> {
-    /// let client = async_nats::connect("localhost:4222").await?;
-    /// let jetstream = async_nats::jetstream::new(client);
-    ///
-    /// let mut stream = jetstream
-    ///     .get_stream("events").await?;
-    ///
-    /// let info = stream.info_with_deleted().await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn info_with_deleted(&mut self) -> Result<&Info, Error> {
-        let subject = format!("STREAM.INFO.{}", self.info.config.name);
-
-        match self
-            .context
-            .request(subject, &json!({"deleted_details": true}))
-            .await?
-        {
-            Response::Ok::<Info>(info) => {
-                self.info = info;
-                Ok(&self.info)
-            }
-            Response::Err { error } => Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "nats: error while getting stream info: {}, {}, {}",
-                    error.code, error.status, error.description
-                ),
-            ))),
-        }
-    }
-
     /// Returns cached [Info] for the [Stream].
     /// Cache is either from initial creation/retrieval of the [Stream] or last call to
     /// [Stream::info].
@@ -1041,7 +998,7 @@ pub struct DeleteStatus {
 }
 
 /// information about the given stream.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct State {
     /// The number of messages contained in this stream
     pub messages: u64,
@@ -1061,11 +1018,6 @@ pub struct State {
     pub last_timestamp: time::OffsetDateTime,
     /// The number of consumers configured to consume this stream
     pub consumer_count: usize,
-    /// List of deleted messages
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deleted: Option<Vec<u64>>,
-    #[serde(default, rename = "num_deleted")]
-    pub deleted_count: usize,
 }
 
 /// A raw stream message in the representation it is stored.

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -834,7 +834,7 @@ mod jetstream {
         let client = async_nats::connect(server.client_url()).await.unwrap();
         let context = async_nats::jetstream::new(client);
 
-        let mut stream = context.get_or_create_stream("events").await.unwrap();
+        let stream = context.get_or_create_stream("events").await.unwrap();
         let payload = b"payload";
         context
             .publish("events".into(), payload.as_ref().into())
@@ -887,19 +887,6 @@ mod jetstream {
                 .stream_sequence,
             3
         );
-
-        stream.delete_message(3).await.unwrap();
-        let deleted = stream
-            .info_with_deleted()
-            .await
-            .unwrap()
-            .clone()
-            .state
-            .deleted
-            .unwrap();
-        assert!(deleted.contains(&2));
-        assert!(deleted.contains(&3));
-        assert_eq!(stream.cached_info().state.deleted_count, 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
As @derekcollison mentioned, we will need to change in the future how we handle retrieving deleted message ids, considering big numbers of those.

This reverts unreleased addition to `info`, preventing a breaking change when a new approach lands.

This reverts commit 7ebabc72a243da093b990ce96375a08b655a955b.