### PR TITLE
Fix-up message header documentation

### DIFF
--- a/async-nats/src/message.rs
+++ b/async-nats/src/message.rs
@@ -26,7 +26,7 @@ pub struct Message {
     pub reply: Option<String>,
     /// Payload of the message. Can be any arbitrary data format.
     pub payload: Bytes,
-    /// Optional headers. Rust client uses [http::header].
+    /// Optional headers.
     pub headers: Option<HeaderMap>,
     /// Optional Status of the message. Used mostly for internal handling.
     pub status: Option<StatusCode>,


### PR DESCRIPTION
Fixup a minor documentation mention of the http crate, as we no longer use the http crate for headers.