### PR TITLE
Remove `Context::purge_subject`

### DIFF
--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -169,7 +169,7 @@ impl ObjectStore {
 
         let chunk_subject = format!("$O.{}.C.{}", self.name, object_info.nuid);
 
-        self.stream.purge_subject(&chunk_subject).await?;
+        self.stream.purge().filter(&chunk_subject).await?;
 
         Ok(())
     }
@@ -313,7 +313,7 @@ impl ObjectStore {
         if let Some(existing_object_info) = maybe_existing_object_info {
             let chunk_subject = format!("$O.{}.C.{}", &self.name, &existing_object_info.nuid);
 
-            self.stream.purge_subject(&chunk_subject).await?;
+            self.stream.purge().filter(chunk_subject).await?;
         }
 
         Ok(object_info)

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -522,28 +522,6 @@ impl Stream {
         Purge::build(self.clone())
     }
 
-    /// Purge `Stream` messages for a matching subject.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), async_nats::Error> {
-    /// let client = async_nats::connect("demo.nats.io").await?;
-    /// let jetstream = async_nats::jetstream::new(client);
-    ///
-    /// let stream = jetstream.get_stream("events").await?;
-    /// stream.purge_subject("data").await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn purge_subject<T>(&self, subject: T) -> Result<PurgeResponse, Error>
-    where
-        T: Into<String>,
-    {
-        self.purge().filter(subject).await
-    }
-
     /// Create a new `Durable` or `Ephemeral` Consumer (if `durable_name` was not provided) and
     /// returns the info from the server about created [Consumer][Consumer]
     ///

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -466,7 +466,7 @@ mod jetstream {
         let mut stream = context.get_stream("events").await.unwrap();
         assert_eq!(stream.cached_info().state.messages, 7);
 
-        stream.purge_subject("events.two").await.unwrap();
+        stream.purge().filter("events.two").await.unwrap();
 
         assert_eq!(stream.info().await.unwrap().state.messages, 3);
     }


### PR DESCRIPTION
Purge subject has become redundant with the into_future based purge builder introduced in https://github.com/nats-io/nats.rs/pull/739.

Removing in favour of a "one true way" to make the request.

