### PR TITLE
Deprecate `Stream::purge_filter`

### DIFF
--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -169,7 +169,7 @@ impl ObjectStore {
 
         let chunk_subject = format!("$O.{}.C.{}", self.name, object_info.nuid);
 
-        self.stream.purge_subject(&chunk_subject).await?;
+        self.stream.purge().filter(&chunk_subject).await?;
 
         Ok(())
     }
@@ -313,7 +313,7 @@ impl ObjectStore {
         if let Some(existing_object_info) = maybe_existing_object_info {
             let chunk_subject = format!("$O.{}.C.{}", &self.name, &existing_object_info.nuid);
 
-            self.stream.purge_subject(&chunk_subject).await?;
+            self.stream.purge().filter(&chunk_subject).await?;
         }
 
         Ok(object_info)

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -537,6 +537,10 @@ impl Stream {
     /// # Ok(())
     /// # }
     /// ```
+    #[deprecated(
+        since = "0.25.0",
+        note = "Overloads have been replaced with an into_future based builder. Use Stream::purge().filter(subject) instead."
+    )]
     pub async fn purge_subject<T>(&self, subject: T) -> Result<PurgeResponse, Error>
     where
         T: Into<String>,

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -437,7 +437,7 @@ mod jetstream {
     }
 
     #[tokio::test]
-    async fn purge_stream_subject() {
+    async fn purge_filter() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = async_nats::connect(server.client_url()).await.unwrap();
         let context = async_nats::jetstream::new(client);
@@ -466,7 +466,7 @@ mod jetstream {
         let mut stream = context.get_stream("events").await.unwrap();
         assert_eq!(stream.cached_info().state.messages, 7);
 
-        stream.purge_subject("events.two").await.unwrap();
+        stream.purge().filter("events.two").await.unwrap();
 
         assert_eq!(stream.info().await.unwrap().state.messages, 3);
     }


### PR DESCRIPTION
Incremental step towards #745.
Soft deprecation since we can.