### PR TITLE
Revert "Make `Client::publish` return an `IntoFuture` message builder"

### DIFF
--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -22,8 +22,6 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use std::error;
 use std::fmt;
-use std::future::{Future, IntoFuture};
-use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -38,63 +36,6 @@ lazy_static! {
 /// An error returned from the [`Client::publish`], [`Client::publish_with_headers`],
 /// [`Client::publish_with_reply`] or [`Client::publish_with_reply_and_headers`] functions.
 pub struct PublishError(mpsc::error::SendError<Command>);
-
-pub struct Publish {
-    sender: mpsc::Sender<Command>,
-    subject: String,
-    payload: Bytes,
-    headers: Option<HeaderMap>,
-    respond: Option<String>,
-}
-
-impl Publish {
-    pub fn new(sender: mpsc::Sender<Command>, subject: String, payload: Bytes) -> Publish {
-        Publish {
-            sender,
-            subject,
-            payload,
-            headers: None,
-            respond: None,
-        }
-    }
-
-    pub fn headers(mut self, headers: HeaderMap) -> Publish {
-        self.headers = Some(headers);
-        self
-    }
-
-    pub fn reply(mut self, subject: String) -> Publish {
-        self.respond = Some(subject);
-        self
-    }
-}
-
-impl IntoFuture for Publish {
-    type Output = Result<(), PublishError>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Result<(), PublishError>> + Send>>;
-
-    fn into_future(self) -> Self::IntoFuture {
-        let sender = self.sender.clone();
-        let subject = self.subject;
-        let payload = self.payload;
-        let respond = self.respond;
-        let headers = self.headers;
-
-        Box::pin(async move {
-            sender
-                .send(Command::Publish {
-                    subject,
-                    payload,
-                    respond,
-                    headers,
-                })
-                .map_err(PublishError)
-                .await?;
-
-            Ok(())
-        })
-    }
-}
 
 impl fmt::Debug for PublishError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -213,8 +154,17 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn publish(&self, subject: String, payload: Bytes) -> Publish {
-        Publish::new(self.sender.clone(), subject, payload)
+    pub async fn publish(&self, subject: String, payload: Bytes) -> Result<(), PublishError> {
+        self.sender
+            .send(Command::Publish {
+                subject,
+                payload,
+                respond: None,
+                headers: None,
+            })
+            .map_err(PublishError)
+            .await?;
+        Ok(())
     }
 
     /// Publish a [Message] with headers to a given subject.
@@ -237,8 +187,15 @@ impl Client {
         headers: HeaderMap,
         payload: Bytes,
     ) -> Result<(), PublishError> {
-        self.publish(subject, payload).headers(headers).await?;
-
+        self.sender
+            .send(Command::Publish {
+                subject,
+                payload,
+                respond: None,
+                headers: Some(headers),
+            })
+            .map_err(PublishError)
+            .await?;
         Ok(())
     }
 
@@ -262,8 +219,15 @@ impl Client {
         reply: String,
         payload: Bytes,
     ) -> Result<(), PublishError> {
-        self.publish(subject, payload).reply(reply).await?;
-
+        self.sender
+            .send(Command::Publish {
+                subject,
+                payload,
+                respond: Some(reply),
+                headers: None,
+            })
+            .map_err(PublishError)
+            .await?;
         Ok(())
     }
 
@@ -290,11 +254,15 @@ impl Client {
         headers: HeaderMap,
         payload: Bytes,
     ) -> Result<(), PublishError> {
-        self.publish(subject, payload)
-            .headers(headers)
-            .reply(reply)
+        self.sender
+            .send(Command::Publish {
+                subject,
+                payload,
+                respond: Some(reply),
+                headers: Some(headers),
+            })
+            .map_err(PublishError)
             .await?;
-
         Ok(())
     }
 

--- a/async-nats/src/jetstream/message.rs
+++ b/async-nats/src/jetstream/message.rs
@@ -18,7 +18,6 @@ use crate::Error;
 use bytes::Bytes;
 use futures::future::TryFutureExt;
 use futures::StreamExt;
-use std::future::IntoFuture;
 use time::OffsetDateTime;
 
 #[derive(Debug)]
@@ -74,7 +73,6 @@ impl Message {
             self.context
                 .client
                 .publish(reply.to_string(), "".into())
-                .into_future()
                 .map_err(Error::from)
                 .await
         } else {
@@ -115,7 +113,6 @@ impl Message {
             self.context
                 .client
                 .publish(reply.to_string(), kind.into())
-                .into_future()
                 .map_err(Error::from)
                 .await
         } else {

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -125,41 +125,6 @@ mod client {
     }
 
     #[tokio::test]
-    async fn publish_into_future_with_headers() {
-        let server = nats_server::run_basic_server();
-        let client = async_nats::connect(server.client_url()).await.unwrap();
-
-        let mut subscriber = client.subscribe("test".into()).await.unwrap();
-
-        let mut headers = async_nats::HeaderMap::new();
-        headers.insert("X-Test", HeaderValue::from_str("Test").unwrap());
-
-        client
-            .publish("test".into(), b"".as_ref().into())
-            .headers(headers.clone())
-            .await
-            .unwrap();
-
-        client.flush().await.unwrap();
-
-        let message = subscriber.next().await.unwrap();
-        assert_eq!(message.headers.unwrap(), headers);
-
-        let mut headers = async_nats::HeaderMap::new();
-        headers.insert("X-Test", HeaderValue::from_str("Test").unwrap());
-        headers.append("X-Test", "Second");
-
-        client
-            .publish("test".into(), b"".as_ref().into())
-            .headers(headers.clone())
-            .await
-            .unwrap();
-
-        let message = subscriber.next().await.unwrap();
-        assert_eq!(message.headers.unwrap(), headers);
-    }
-
-    #[tokio::test]
     async fn publish_with_headers() {
         let server = nats_server::run_basic_server();
         let client = async_nats::connect(server.client_url()).await.unwrap();


### PR DESCRIPTION
Reverts nats-io/nats.rs#749


As we need to release Service API, and this is a breaking change, reverting temporarily.
All breaking changes around using `IntoFuture` trait are meant to go into one release for consistency and less burden for the users to adopt.