### PR TITLE
Use stable channel for clippy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Set up rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           components: clippy
           override: true
 


### PR DESCRIPTION
New version shipped over the last couple of days, clippy should be working again on stable