### PR TITLE
Make use of ìnto_future` for requests and messages

### DIFF
--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -26,6 +26,7 @@ use serde_json::{self, json};
 use std::borrow::Borrow;
 use std::future::IntoFuture;
 use std::io::{self, ErrorKind};
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::str::from_utf8;
 use std::task::Poll;
@@ -691,26 +692,12 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn request<T, V>(&self, subject: String, payload: &T) -> Result<Response<V>, Error>
+    pub fn request<T, V>(&self, subject: String, payload: T) -> Request<T, V>
     where
-        T: ?Sized + Serialize,
+        T: Sized + Serialize,
         V: DeserializeOwned,
     {
-        let request = serde_json::to_vec(&payload).map(Bytes::from)?;
-
-        debug!("JetStream request sent: {:?}", request);
-
-        let message = self
-            .client
-            .request(format!("{}.{}", self.prefix, subject), request)
-            .await?;
-        debug!(
-            "JetStream request response: {:?}",
-            from_utf8(&message.payload)
-        );
-        let response = serde_json::from_slice(message.payload.as_ref())?;
-
-        Ok(response)
+        Request::new(self.clone(), subject, payload)
     }
 
     /// Creates a new object store bucket.
@@ -1128,6 +1115,64 @@ impl IntoFuture for Publish {
                 timeout,
                 subscription,
             })
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct Request<T: Sized + Serialize, V: DeserializeOwned> {
+    context: Context,
+    subject: String,
+    payload: T,
+    timeout: Option<Duration>,
+    response_type: PhantomData<V>,
+}
+
+impl<T: Sized + Serialize, V: DeserializeOwned> Request<T, V> {
+    pub fn new(context: Context, subject: String, payload: T) -> Self {
+        Self {
+            context,
+            subject,
+            payload,
+            timeout: None,
+            response_type: PhantomData,
+        }
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+}
+
+impl<T: Sized + Serialize, V: DeserializeOwned> IntoFuture for Request<T, V> {
+    type Output = Result<Response<V>, Error>;
+
+    type IntoFuture = Pin<Box<dyn Future<Output = Result<Response<V>, Error>> + Send>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let payload_result = serde_json::to_vec(&self.payload).map(Bytes::from);
+
+        let prefix = self.context.prefix;
+        let client = self.context.client;
+        let subject = self.subject;
+        let timeout = self.timeout;
+
+        Box::pin(std::future::IntoFuture::into_future(async move {
+            let payload = payload_result?;
+            debug!("JetStream request sent: {:?}", payload);
+
+            let request = client.request(format!("{}.{}", prefix, subject), payload);
+            let request = request.timeout(timeout);
+            let message = request.await?;
+
+            debug!(
+                "JetStream request response: {:?}",
+                from_utf8(&message.payload)
+            );
+            let response = serde_json::from_slice(message.payload.as_ref())?;
+
+            Ok(response)
         }))
     }
 }

--- a/async-nats/src/jetstream/message.rs
+++ b/async-nats/src/jetstream/message.rs
@@ -18,6 +18,7 @@ use crate::Error;
 use bytes::Bytes;
 use futures::future::TryFutureExt;
 use futures::StreamExt;
+use std::future::IntoFuture;
 use time::OffsetDateTime;
 
 #[derive(Debug)]
@@ -73,6 +74,7 @@ impl Message {
             self.context
                 .client
                 .publish(reply.to_string(), "".into())
+                .into_future()
                 .map_err(Error::from)
                 .await
         } else {
@@ -113,6 +115,7 @@ impl Message {
             self.context
                 .client
                 .publish(reply.to_string(), kind.into())
+                .into_future()
                 .map_err(Error::from)
                 .await
         } else {

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -167,6 +167,7 @@ impl Stream {
                 message,
                 context: self.context.clone(),
             })?;
+
         if let Some(status) = response.status {
             if let Some(ref description) = response.description {
                 return Err(Box::from(std::io::Error::new(
@@ -226,11 +227,13 @@ impl Stream {
                 request_subject,
                 serde_json::to_vec(&payload).map(Bytes::from)?,
             )
+            .into_future()
             .await
             .map(|message| Message {
                 message,
                 context: self.context.clone(),
             })?;
+
         if let Some(status) = response.status {
             if let Some(ref description) = response.description {
                 return Err(Box::from(std::io::Error::new(
@@ -284,6 +287,7 @@ impl Stream {
             .context
             .client
             .request(subject, serde_json::to_vec(&payload).map(Bytes::from)?)
+            .into_future()
             .await
             .map(|message| Message {
                 context: self.context.clone(),

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -14,10 +14,11 @@
 mod client {
     use async_nats::connection::State;
     use async_nats::header::HeaderValue;
-    use async_nats::{ConnectOptions, Event, Request};
+    use async_nats::{ConnectOptions, Event};
     use bytes::Bytes;
     use futures::future::join_all;
     use futures::stream::StreamExt;
+    use std::future::IntoFuture;
     use std::io::ErrorKind;
     use std::str::FromStr;
     use std::time::Duration;
@@ -238,7 +239,9 @@ mod client {
 
         let resp = tokio::time::timeout(
             tokio::time::Duration::from_millis(500),
-            client.request("test".into(), "request".into()),
+            client
+                .request("test".into(), "request".into())
+                .into_future(),
         )
         .await
         .unwrap();
@@ -271,7 +274,9 @@ mod client {
 
         tokio::time::timeout(
             tokio::time::Duration::from_millis(300),
-            client.request("test".into(), "request".into()),
+            client
+                .request("test".into(), "request".into())
+                .into_future(),
         )
         .await
         .unwrap()
@@ -298,9 +303,9 @@ mod client {
             }
         });
 
-        let request = Request::new().inbox(inbox.clone());
         client
-            .send_request("service".into(), request)
+            .request("service".into(), "".into())
+            .inbox(inbox)
             .await
             .unwrap();
     }

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -125,6 +125,41 @@ mod client {
     }
 
     #[tokio::test]
+    async fn publish_into_future_with_headers() {
+        let server = nats_server::run_basic_server();
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+
+        let mut subscriber = client.subscribe("test".into()).await.unwrap();
+
+        let mut headers = async_nats::HeaderMap::new();
+        headers.insert("X-Test", HeaderValue::from_str("Test").unwrap());
+
+        client
+            .publish("test".into(), b"".as_ref().into())
+            .headers(headers.clone())
+            .await
+            .unwrap();
+
+        client.flush().await.unwrap();
+
+        let message = subscriber.next().await.unwrap();
+        assert_eq!(message.headers.unwrap(), headers);
+
+        let mut headers = async_nats::HeaderMap::new();
+        headers.insert("X-Test", HeaderValue::from_str("Test").unwrap());
+        headers.append("X-Test", "Second");
+
+        client
+            .publish("test".into(), b"".as_ref().into())
+            .headers(headers.clone())
+            .await
+            .unwrap();
+
+        let message = subscriber.next().await.unwrap();
+        assert_eq!(message.headers.unwrap(), headers);
+    }
+
+    #[tokio::test]
     async fn publish_with_headers() {
         let server = nats_server::run_basic_server();
         let client = async_nats::connect(server.client_url()).await.unwrap();

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -311,6 +311,21 @@ mod jetstream {
     }
 
     #[tokio::test]
+    async fn request_timeout() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+        let context = async_nats::jetstream::new(client);
+
+        let response: Response<AccountInfo> = context
+            .request("INFO".to_string(), &())
+            .timeout(Duration::from_secs(1))
+            .await
+            .unwrap();
+
+        assert!(matches!(response, Response::Ok { .. }));
+    }
+
+    #[tokio::test]
     async fn create_stream() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = async_nats::connect(server.client_url()).await.unwrap();


### PR DESCRIPTION
- [x] Makes Client::publish return an into_future based builder
- [x] Makes Client::request return an into_future based builder.
- [x] Makes Context::request return an into_future based builder.
- [x] Makes Context::publish return an into_future based builder.