### PR TITLE
fix(kv): Fixes key listing for async client to match go client 

### DIFF
--- a/async-nats/tests/kv_tests.rs
+++ b/async-nats/tests/kv_tests.rs
@@ -472,6 +472,19 @@ mod kv {
         keys.sort();
         assert_eq!(vec!["bar", "foo"], keys);
 
+        // Delete a key and make sure it doesn't show up in the keys list
+        kv.delete("bar").await.unwrap();
+        let keys = kv.keys().await.unwrap().collect::<Vec<String>>();
+        assert_eq!(vec!["foo"], keys, "Deleted key shouldn't appear in list");
+
+        // Put the key back, and then purge and make sure the key doesn't show up
+        for i in 0..10 {
+            kv.put("bar", i.to_string().into()).await.unwrap();
+        }
+        kv.purge("foo").await.unwrap();
+        let keys = kv.keys().await.unwrap().collect::<Vec<String>>();
+        assert_eq!(vec!["bar"], keys, "Purged key shouldn't appear in the list");
+
         let kv = context
             .create_key_value(async_nats::jetstream::kv::Config {
                 bucket: "history2".to_string(),


### PR DESCRIPTION
The go client [filters out deleted and purged keys](https://github.com/nats-io/nats.go/blob/66009489432be03ff32e5384a2b502fe88f4c635/kv.go#L909) and the async client was not filtering out those keys. This fixes the behavior to be the same and is also slightly more efficient as we aren't iterating over the _entire_ stream of key value history to get the current keys.

I also included an optional commit that I figured I'd do while I was here. The original documentation for this method suggested that the `keys` method should be returning a `Stream` rather than an iter. So I implemented a stream version of it if desired. This commit can be popped off (or moved to a separate PR) depending on maintainer preference