### PR TITLE
Change TLS to conditionally load native certs

### DIFF
--- a/async-nats/src/tls.rs
+++ b/async-nats/src/tls.rs
@@ -64,20 +64,23 @@ pub(crate) async fn load_key(path: PathBuf) -> io::Result<PrivateKey> {
 
 pub(crate) async fn config_tls(options: &ConnectorOptions) -> io::Result<rustls::ClientConfig> {
     let mut root_store = rustls::RootCertStore::empty();
-    for cert in rustls_native_certs::load_native_certs().map_err(|err| {
-        io::Error::new(
-            ErrorKind::Other,
-            format!("could not load platform certs: {err}"),
-        )
-    })? {
-        root_store
-            .add(&rustls::Certificate(cert.0))
-            .map_err(|err| {
-                io::Error::new(
-                    ErrorKind::Other,
-                    format!("failed to read root certificates: {err}"),
-                )
-            })?;
+    // load native system certs only if user did not specify them.
+    if options.tls_client_config.is_some() || options.certificates.is_empty() {
+        for cert in rustls_native_certs::load_native_certs().map_err(|err| {
+            io::Error::new(
+                ErrorKind::Other,
+                format!("could not load platform certs: {err}"),
+            )
+        })? {
+            root_store
+                .add(&rustls::Certificate(cert.0))
+                .map_err(|err| {
+                    io::Error::new(
+                        ErrorKind::Other,
+                        format!("failed to read root certificates: {err}"),
+                    )
+                })?;
+        }
     }
 
     // use provided ClientConfig or built it from options.

--- a/async-nats/tests/tls_tests.rs
+++ b/async-nats/tests/tls_tests.rs
@@ -54,4 +54,18 @@ mod client {
         .unwrap()
         .unwrap();
     }
+
+    #[tokio::test]
+    async fn tls_with_native_certs() {
+        let client = async_nats::ConnectOptions::new()
+            .require_tls(true)
+            .connect("tls://demo.nats.io")
+            .await
+            .unwrap();
+
+        client
+            .publish("subject".into(), "data".into())
+            .await
+            .unwrap();
+    }
 }


### PR DESCRIPTION
Until now, when TLS was used, native OS certs were always loaded. This should not be the case if CA is provided in rustls config or options.
