### PR TITLE
Add `ignore_discovered_servers` connect option

### DIFF
--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -50,6 +50,7 @@ pub(crate) struct ConnectorOptions {
     pub(crate) no_echo: bool,
     pub(crate) connection_timeout: Duration,
     pub(crate) name: Option<String>,
+    pub(crate) ignore_discovered_servers: bool,
 }
 
 /// Maintains a list of servers and establishes connections.
@@ -121,9 +122,11 @@ impl Connector {
                     .await
                 {
                     Ok((server_info, mut connection)) => {
-                        for url in &server_info.connect_urls {
-                            let server_addr = url.parse::<ServerAddr>()?;
-                            self.servers.entry(server_addr).or_insert(0);
+                        if !self.options.ignore_discovered_servers {
+                            for url in &server_info.connect_urls {
+                                let server_addr = url.parse::<ServerAddr>()?;
+                                self.servers.entry(server_addr).or_insert(0);
+                            }
                         }
 
                         let server_attempts = self.servers.get_mut(&server_addr).unwrap();

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -679,6 +679,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
             no_echo: options.no_echo,
             connection_timeout: options.connection_timeout,
             name: options.name,
+            ignore_discovered_servers: options.ignore_discovered_servers,
         },
         events_tx,
         state_tx,

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -53,6 +53,7 @@ pub struct ConnectOptions {
     pub(crate) inbox_prefix: String,
     pub(crate) request_timeout: Option<Duration>,
     pub(crate) retry_on_initial_connect: bool,
+    pub(crate) ignore_discovered_servers: bool,
 }
 
 impl fmt::Debug for ConnectOptions {
@@ -105,6 +106,7 @@ impl Default for ConnectOptions {
             inbox_prefix: "_INBOX".to_string(),
             request_timeout: Some(Duration::from_secs(10)),
             retry_on_initial_connect: false,
+            ignore_discovered_servers: false,
         }
     }
 }
@@ -566,6 +568,11 @@ impl ConnectOptions {
 
     pub fn retry_on_initial_connect(mut self) -> ConnectOptions {
         self.retry_on_initial_connect = true;
+        self
+    }
+
+    pub fn ignore_discovered_servers(mut self) -> ConnectOptions {
+        self.ignore_discovered_servers = true;
         self
     }
 }


### PR DESCRIPTION
Conditionally includes discovered servers based on a boolean option.

Closes https://github.com/nats-io/nats.rs/issues/806