### PR TITLE
Remove unsafe usages in async-nats

### DIFF
--- a/.config/nats.dic
+++ b/.config/nats.dic
@@ -121,3 +121,4 @@ StatsResponse
 SemVer
 ServerAddr
 Vec
+const

--- a/async-nats/src/status.rs
+++ b/async-nats/src/status.rs
@@ -253,11 +253,21 @@ impl TryFrom<u16> for StatusCode {
 }
 
 impl StatusCode {
-    pub const IDLE_HEARTBEAT: StatusCode = StatusCode(unsafe { NonZeroU16::new_unchecked(100) });
-    pub const OK: StatusCode = StatusCode(unsafe { NonZeroU16::new_unchecked(200) });
-    pub const NOT_FOUND: StatusCode = StatusCode(unsafe { NonZeroU16::new_unchecked(404) });
-    pub const TIMEOUT: StatusCode = StatusCode(unsafe { NonZeroU16::new_unchecked(408) });
-    pub const NO_RESPONDERS: StatusCode = StatusCode(unsafe { NonZeroU16::new_unchecked(503) });
-    pub const REQUEST_TERMINATED: StatusCode =
-        StatusCode(unsafe { NonZeroU16::new_unchecked(409) });
+    pub const IDLE_HEARTBEAT: StatusCode = StatusCode(new_nonzero_u16(100));
+    pub const OK: StatusCode = StatusCode(new_nonzero_u16(200));
+    pub const NOT_FOUND: StatusCode = StatusCode(new_nonzero_u16(404));
+    pub const TIMEOUT: StatusCode = StatusCode(new_nonzero_u16(408));
+    pub const NO_RESPONDERS: StatusCode = StatusCode(new_nonzero_u16(503));
+    pub const REQUEST_TERMINATED: StatusCode = StatusCode(new_nonzero_u16(409));
+}
+
+/// This function is needed until const Option::unwrap becomes stable.
+/// Ref: https://github.com/nats-io/nats.rs/issues/804
+const fn new_nonzero_u16(n: u16) -> NonZeroU16 {
+    match NonZeroU16::new(n) {
+        Some(d) => d,
+        None => {
+            panic!("Invalid non-zero u16");
+        }
+    }
 }


### PR DESCRIPTION
While const Option::unwrap is not in stable it is possible to write our own const unwrap function.

Fixes #804

No more unsafe code 🔥 

<details> 
  <summary>If you are curious how Rust handles panics in const context: pretty well</summary>

```
error[E0080]: evaluation of constant value failed
   --> async-nats/src/status.rs:270:13
    |
270 |             panic!("Invalid non-zero u16");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Invalid non-zero u16', async-nats/src/status.rs:270:13
    |
note: inside `new_nonzero_u16`
   --> async-nats/src/status.rs:270:13
    |
270 |             panic!("Invalid non-zero u16");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `StatusCode::IDLE_HEARTBEAT`
   --> async-nats/src/status.rs:256:55
    |
256 |     pub const IDLE_HEARTBEAT: StatusCode = StatusCode(new_nonzero_u16(0));
    |                                                       ^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
```
</details> 