### PR TITLE
Fix flush after reconnect

### DIFF
--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -478,7 +478,9 @@ impl Stream {
                             }
                         },
                         _ = request_rx.changed() => debug!("task received request request"),
-                        _ = expires => debug!("expired pull request"),
+                        _ = expires => {
+                            pending_reset = true;
+                            debug!("expired pull request")},
                     }
 
                     let request = serde_json::to_vec(&batch).map(Bytes::from).unwrap();
@@ -488,7 +490,7 @@ impl Stream {
                         .publish_with_reply(subject.clone(), inbox.clone(), request.clone())
                         .await;
                     if let Err(err) = consumer.context.client.flush().await {
-                        debug!("flush failed: {}", err);
+                        debug!("flush failed: {err:?}");
                     }
                     debug!("request published");
                     // TODO: add tracing instead of ignoring this.

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -533,6 +533,10 @@ impl ConnectionHandler {
                         result.send(Err(err)).map_err(|_| {
                             io::Error::new(io::ErrorKind::Other, "one shot failed to be received")
                         })?;
+                    } else {
+                        result.send(Ok(())).map_err(|_| {
+                            io::Error::new(io::ErrorKind::Other, "one shot failed to be received")
+                        })?;
                     }
                 } else {
                     result.send(Ok(())).map_err(|_| {


### PR DESCRIPTION
Until now, if while flushing, reconnection was happening, in case of successful reconnect, flusher would not get the response that flush was successful.