### PR TITLE
Release async-nats/v0.27.1

### DIFF
--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.27.1
+## Overview
+A patch release focused solely on important fixes.
+
+## Fixed
+* Fix no error when auth is not provided but required by @Jarema in https://github.com/nats-io/nats.rs/pull/822
+* Fix flush after reconnecting by @Jarema in https://github.com/nats-io/nats.rs/pull/823
+* Fix duplicate consumer creation by @thomastaylor312 in https://github.com/nats-io/nats.rs/pull/824
+
+
+**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.27.0...async-nats/v0.27.1
+
 # 0.27.0
 ## Overview
 

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
-version = "0.27.0"
+version = "0.27.1"
 edition = "2021"
 rust = "1.64.0"
 description = "A async Rust NATS client"


### PR DESCRIPTION
# 0.27.1
## Overview
A patch release focused solely on important fixes

## Fixed
* Fix no error when auth is not provided but required by @Jarema in https://github.com/nats-io/nats.rs/pull/822
* Fix flush after reconnecting by @Jarema in https://github.com/nats-io/nats.rs/pull/823
* Fix duplicate consumer creation by @thomastaylor312 in https://github.com/nats-io/nats.rs/pull/824


**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.27.0...async-nats/v0.27.1


Signed-off-by: Tomasz Pietrek <tomasz@nats.io>