### PR TITLE
Fix flapping ack test

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1979,6 +1979,8 @@ mod jetstream {
             context
                 .publish("events".to_string(), "dat".into())
                 .await
+                .unwrap()
+                .await
                 .unwrap();
         }
 


### PR DESCRIPTION
This test started to flap after changes to publish ack and making it async.