### PR TITLE
Fix flapping test for consumers list

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -2555,7 +2555,7 @@ mod jetstream {
         for i in 0..1200 {
             stream
                 .create_consumer(async_nats::jetstream::consumer::pull::Config {
-                    name: Some(format!("consumer_{i}").to_string()),
+                    durable_name: Some(format!("consumer_{i}").to_string()),
                     ..Default::default()
                 })
                 .await


### PR DESCRIPTION
This test was flapping because consumers could get deleted before the list was retrieved, if machine running it was slow.