### PR TITLE
Increase rust test thread count

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   RUSTFLAGS: "-D warnings"
+  RUST_TEST_THREADS: 32
 
 defaults:
   run:


### PR DESCRIPTION
In theory, we're not CPU bound so a higher thread count lets more long running tests run in parallel. Seeing how CI test times improve if at all.