### PR TITLE
Rename server-2.10 feature name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         nats_server: [main, dev]
         include:
           - nats_server: dev
-            features: server-2.10
+            features: server_2_10
 
     steps:
       - name: Check out repository

--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Overview
 This release prepares the client for 2.10.0 server release and adds some fixes and improvements.
 
-To use the new features before the server 2.10.0 release, enable `server-2.10` feature.
+To use the new features before the server 2.10.0 release, enable `server_2_10` feature.
 
 ## Breaking Changes
 ### To enable NAK with backoff, `AckKind::NAK` enum variant was changed
@@ -39,8 +39,8 @@ as they do now, but those who would like to try continuing working with consumer
 even if it returned `idle heartbeats`, now they can.
 
 ## Added
-* Add support for consumers with multiple filters by @Jarema in https://github.com/nats-io/nats.rs/pull/814
-* Add metadata support (feature `server-2.10.0`) by @Jarema in https://github.com/nats-io/nats.rs/pull/837
+* Add support for consumers with multiple filters (feature `server_2_10`) by @Jarema in https://github.com/nats-io/nats.rs/pull/814
+* Add metadata support (feature `server_2_10`) by @Jarema in https://github.com/nats-io/nats.rs/pull/837
 * Add NAK and backoff support by @Jarema in https://github.com/nats-io/nats.rs/pull/839
 
 ## Fixed

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -53,7 +53,7 @@ async-nats = {path = ".", features = ["experimental"]}
 [features]
 service = []
 experimental = ["service"]
-"server-2.10" = []
+"server_2_10" = []
 slow_tests = []
 
 

--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -15,7 +15,7 @@
 
 pub mod pull;
 pub mod push;
-#[cfg(feature = "server-2.10")]
+#[cfg(feature = "server_2_10")]
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::time::Duration;
@@ -271,7 +271,7 @@ pub struct Config {
     /// When consuming from a Stream with many subjects, or wildcards, this selects only specific incoming subjects. Supports wildcards.
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subject: String,
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     /// Fulfills the same role as [Config::filter_subject], but allows filtering by many subjects.
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subjects: Vec<String>,
@@ -316,7 +316,7 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "is_default", rename = "mem_storage")]
     pub memory_storage: bool,
 
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     /// Additional consumer metadata.
     #[serde(default, skip_serializing_if = "is_default")]
     pub metadata: HashMap<String, String>,

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -14,7 +14,7 @@
 use bytes::Bytes;
 use futures::future::BoxFuture;
 
-#[cfg(feature = "server-2.10")]
+#[cfg(feature = "server_2_10")]
 use std::collections::HashMap;
 use std::{
     future,
@@ -1506,7 +1506,7 @@ pub struct Config {
     /// When consuming from a Stream with many subjects, or wildcards, this selects only specific incoming subjects. Supports wildcards.
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subject: String,
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     /// Fulfills the same role as [Config::filter_subject], but allows filtering by many subjects.
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subjects: Vec<String>,
@@ -1544,7 +1544,7 @@ pub struct Config {
     /// Force consumer to use memory storage.
     #[serde(default, skip_serializing_if = "is_default")]
     pub memory_storage: bool,
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     // Additional consumer metadata.
     #[serde(default, skip_serializing_if = "is_default")]
     pub metadata: HashMap<String, String>,
@@ -1572,7 +1572,7 @@ impl IntoConsumerConfig for Config {
             ack_wait: self.ack_wait,
             max_deliver: self.max_deliver,
             filter_subject: self.filter_subject,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             filter_subjects: self.filter_subjects,
             replay_policy: self.replay_policy,
             rate_limit: self.rate_limit,
@@ -1587,7 +1587,7 @@ impl IntoConsumerConfig for Config {
             inactive_threshold: self.inactive_threshold,
             num_replicas: self.num_replicas,
             memory_storage: self.memory_storage,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             metadata: self.metadata,
             backoff: self.backoff,
         }
@@ -1610,7 +1610,7 @@ impl FromConsumer for Config {
             ack_wait: config.ack_wait,
             max_deliver: config.max_deliver,
             filter_subject: config.filter_subject,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             filter_subjects: config.filter_subjects,
             replay_policy: config.replay_policy,
             rate_limit: config.rate_limit,
@@ -1623,7 +1623,7 @@ impl FromConsumer for Config {
             inactive_threshold: config.inactive_threshold,
             num_replicas: config.num_replicas,
             memory_storage: config.memory_storage,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             metadata: config.metadata,
             backoff: config.backoff,
         })

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -21,7 +21,7 @@ use crate::{
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "server-2.10")]
+#[cfg(feature = "server_2_10")]
 use std::collections::HashMap;
 use std::{
     io::{self, ErrorKind},
@@ -187,7 +187,7 @@ pub struct Config {
     /// When consuming from a Stream with many subjects, or wildcards, this selects only specific incoming subjects. Supports wildcards.
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subject: String,
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     /// Fulfills the same role as [Config::filter_subject], but allows filtering by many subjects.
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subjects: Vec<String>,
@@ -222,7 +222,7 @@ pub struct Config {
     /// Force consumer to use memory storage.
     #[serde(default, skip_serializing_if = "is_default")]
     pub memory_storage: bool,
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     // Additional consumer metadata.
     #[serde(default, skip_serializing_if = "is_default")]
     pub metadata: HashMap<String, String>,
@@ -251,7 +251,7 @@ impl FromConsumer for Config {
             ack_wait: config.ack_wait,
             max_deliver: config.max_deliver,
             filter_subject: config.filter_subject,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             filter_subjects: config.filter_subjects,
             replay_policy: config.replay_policy,
             rate_limit: config.rate_limit,
@@ -263,7 +263,7 @@ impl FromConsumer for Config {
             idle_heartbeat: config.idle_heartbeat,
             num_replicas: config.num_replicas,
             memory_storage: config.memory_storage,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             metadata: config.metadata,
             backoff: config.backoff,
         })
@@ -283,7 +283,7 @@ impl IntoConsumerConfig for Config {
             ack_wait: self.ack_wait,
             max_deliver: self.max_deliver,
             filter_subject: self.filter_subject,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             filter_subjects: self.filter_subjects,
             replay_policy: self.replay_policy,
             rate_limit: self.rate_limit,
@@ -298,7 +298,7 @@ impl IntoConsumerConfig for Config {
             inactive_threshold: Duration::default(),
             num_replicas: self.num_replicas,
             memory_storage: self.memory_storage,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             metadata: self.metadata,
             backoff: self.backoff,
         }
@@ -330,7 +330,7 @@ pub struct OrderedConfig {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subject: String,
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     /// Fulfills the same role as [Config::filter_subject], but allows filtering by many subjects.
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subjects: Vec<String>,
@@ -351,7 +351,7 @@ pub struct OrderedConfig {
     /// The maximum number of waiting consumers.
     #[serde(default, skip_serializing_if = "is_default")]
     pub max_waiting: i64,
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     // Additional consumer metadata.
     #[serde(default, skip_serializing_if = "is_default")]
     pub metadata: HashMap<String, String>,
@@ -373,7 +373,7 @@ impl FromConsumer for OrderedConfig {
             deliver_subject: config.deliver_subject.unwrap(),
             description: config.description,
             filter_subject: config.filter_subject,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             filter_subjects: config.filter_subjects,
             replay_policy: config.replay_policy,
             rate_limit: config.rate_limit,
@@ -381,7 +381,7 @@ impl FromConsumer for OrderedConfig {
             headers_only: config.headers_only,
             deliver_policy: config.deliver_policy,
             max_waiting: config.max_waiting,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             metadata: config.metadata,
         })
     }
@@ -400,7 +400,7 @@ impl IntoConsumerConfig for OrderedConfig {
             ack_wait: Duration::from_secs(60 * 60 * 22),
             max_deliver: 1,
             filter_subject: self.filter_subject,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             filter_subjects: self.filter_subjects,
             replay_policy: self.replay_policy,
             rate_limit: self.rate_limit,
@@ -415,7 +415,7 @@ impl IntoConsumerConfig for OrderedConfig {
             inactive_threshold: Duration::from_secs(30),
             num_replicas: 1,
             memory_storage: true,
-            #[cfg(feature = "server-2.10")]
+            #[cfg(feature = "server_2_10")]
             metadata: self.metadata,
             backoff: Vec::new(),
         }

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -13,7 +13,7 @@
 //
 //! Manage operations on a [Stream], create/delete/update [Consumer][crate::jetstream::consumer::Consumer].
 
-#[cfg(feature = "server-2.10")]
+#[cfg(feature = "server_2_10")]
 use std::collections::HashMap;
 use std::{
     fmt::Debug,
@@ -924,7 +924,7 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sources: Option<Vec<Source>>,
 
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     // Additional stream metadata.
     #[serde(default, skip_serializing_if = "is_default")]
     pub metadata: HashMap<String, String>,

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -24,7 +24,7 @@ pub struct AccountInfo {
 
 mod jetstream {
 
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     use std::collections::HashMap;
     use std::str::from_utf8;
     use std::time::{Duration, Instant};
@@ -2820,7 +2820,7 @@ mod jetstream {
         );
     }
 
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     #[tokio::test]
     async fn multiple_filters_consumer() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
@@ -2883,7 +2883,7 @@ mod jetstream {
         }
     }
 
-    #[cfg(feature = "server-2.10")]
+    #[cfg(feature = "server_2_10")]
     #[tokio::test]
     async fn metadata() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");


### PR DESCRIPTION
Crates with features containing `.` fail to publish.

 Signed-off-by: Tomasz Pietrek <tomasz@nats.io>