### PR TITLE
Update `base64` crate and use it in place of `base64-url`

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["network-programming", "api-bindings"]
 
 [dependencies]
 memchr = "2.4"
-base64-url = "1.4.13"
 bytes = "1.4.0"
 futures = { version = "0.3.26", default-features = false, features = ["std", "async-await"] }
 nkeys = "0.2.0"
@@ -36,7 +35,7 @@ time = { version = "0.3.20", features = ["parsing", "formatting", "serde", "serd
 rustls-native-certs = "0.6"
 tracing = "0.1"
 thiserror = "1.0"
-base64 = "0.13"
+base64 = "0.21"
 tokio-retry = "0.3"
 ring = "0.16"
 

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -29,6 +29,8 @@ use crate::SocketAddr;
 use crate::ToServerAddrs;
 use crate::LANG;
 use crate::VERSION;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::engine::Engine;
 use bytes::BytesMut;
 use std::cmp;
 use std::collections::HashMap;
@@ -176,7 +178,7 @@ impl Connector {
                                             Ok(signed) => {
                                                 connect_info.nkey = Some(key_pair.public_key());
                                                 connect_info.signature =
-                                                    Some(base64_url::encode(&signed));
+                                                    Some(URL_SAFE_NO_PAD.encode(signed));
                                             }
                                             Err(_) => {
                                                 return Err(ConnectError::new(

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -27,6 +27,8 @@ use std::{
 
 use crate::{header::HeaderName, HeaderMap, HeaderValue};
 use crate::{Error, StatusCode};
+use base64::engine::general_purpose::STANDARD;
+use base64::engine::Engine;
 use bytes::Bytes;
 use futures::{Future, TryFutureExt};
 use serde::{Deserialize, Serialize};
@@ -1090,11 +1092,12 @@ impl TryFrom<RawMessage> for crate::Message {
     type Error = Error;
 
     fn try_from(value: RawMessage) -> Result<Self, Self::Error> {
-        let decoded_payload = base64::decode(value.payload)
+        let decoded_payload = STANDARD
+            .decode(value.payload)
             .map_err(|err| Box::new(std::io::Error::new(ErrorKind::Other, err)))?;
         let decoded_headers = value
             .headers
-            .map(base64::decode)
+            .map(|header| STANDARD.decode(header))
             .map_or(Ok(None), |v| v.map(Some))?;
 
         let length = decoded_headers

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -12,6 +12,8 @@
 // limitations under the License.
 
 use crate::{Authorization, Client, ConnectError, Event, ToServerAddrs};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::engine::Engine;
 use futures::Future;
 use std::fmt::Formatter;
 use std::{fmt, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
@@ -249,7 +251,7 @@ impl ConnectOptions {
                         let sig = sign_cb(nonce.as_bytes().to_vec())
                             .await
                             .map_err(AuthError::new)?;
-                        Ok(base64_url::encode(&sig))
+                        Ok(URL_SAFE_NO_PAD.encode(sig))
                     })
                 })),
             ),

--- a/async-nats/tests/object_store.rs
+++ b/async-nats/tests/object_store.rs
@@ -16,7 +16,7 @@ mod object_store {
     use std::{io, time::Duration};
 
     use async_nats::jetstream::object_store::ObjectMeta;
-    use base64::URL_SAFE;
+    use base64::Engine;
     use futures::StreamExt;
     use rand::RngCore;
     use ring::digest::SHA256;
@@ -60,7 +60,10 @@ mod object_store {
             }
         }
         assert_eq!(
-            format!("SHA-256={}", base64::encode_config(digest, URL_SAFE)),
+            format!(
+                "SHA-256={}",
+                base64::engine::general_purpose::URL_SAFE.encode(digest)
+            ),
             object.info.digest
         );
         assert_eq!(result, bytes);


### PR DESCRIPTION
Updates the `base64` crate to 0.21 and uses it everywhere for base64 url-safe encoding and decoding.

Let me know if you like the small module I created to wrap the `base64` API with something easier to use or if you'd prefer calling `base64` directly