### PR TITLE
Fix linting errors and suggestions

### DIFF
--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -69,11 +69,7 @@ impl Connector {
         events_tx: tokio::sync::mpsc::Sender<Event>,
         state_tx: tokio::sync::watch::Sender<State>,
     ) -> Result<Connector, io::Error> {
-        let servers = addrs
-            .to_server_addrs()?
-            .into_iter()
-            .map(|addr| (addr, 0))
-            .collect();
+        let servers = addrs.to_server_addrs()?.map(|addr| (addr, 0)).collect();
 
         Ok(Connector {
             servers,

--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -361,12 +361,13 @@ impl FromConsumer for Config {
 }
 
 /// `DeliverPolicy` determines how the consumer should select the first message to deliver.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 #[serde(tag = "deliver_policy")]
 pub enum DeliverPolicy {
     /// All causes the consumer to receive the oldest messages still present in the system.
     /// This is the default.
+    #[default]
     #[serde(rename = "all")]
     All,
     /// Last will start the consumer with the last sequence received.
@@ -396,18 +397,13 @@ pub enum DeliverPolicy {
     LastPerSubject,
 }
 
-impl Default for DeliverPolicy {
-    fn default() -> DeliverPolicy {
-        DeliverPolicy::All
-    }
-}
-
 /// Determines whether messages will be acknowledged individually,
 /// in batches, or never.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum AckPolicy {
     /// All messages will be individually acknowledged. This is the default.
+    #[default]
     #[serde(rename = "explicit")]
     Explicit = 2,
     /// No messages are acknowledged.
@@ -419,18 +415,13 @@ pub enum AckPolicy {
     All = 1,
 }
 
-impl Default for AckPolicy {
-    fn default() -> AckPolicy {
-        AckPolicy::Explicit
-    }
-}
-
 /// `ReplayPolicy` controls whether messages are sent to a consumer
 /// as quickly as possible or at the rate that they were originally received at.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ReplayPolicy {
     /// Sends all messages in a stream to the consumer as quickly as possible. This is the default.
+    #[default]
     #[serde(rename = "instant")]
     Instant = 0,
     /// Sends messages to a consumer in a rate-limited fashion based on the rate of receipt. This
@@ -440,11 +431,6 @@ pub enum ReplayPolicy {
     Original = 1,
 }
 
-impl Default for ReplayPolicy {
-    fn default() -> ReplayPolicy {
-        ReplayPolicy::Instant
-    }
-}
 fn is_default<T: Default + Eq>(t: &T) -> bool {
     t == &T::default()
 }

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -960,10 +960,11 @@ pub struct Republish {
 
 /// `DiscardPolicy` determines how we proceed when limits of messages or bytes are hit. The default, `Old` will
 /// remove older messages. `New` will fail to store the new message.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum DiscardPolicy {
     /// will remove older messages when limits are hit.
+    #[default]
     #[serde(rename = "old")]
     Old = 0,
     /// will error on a StoreMsg call when limits are hit
@@ -971,18 +972,13 @@ pub enum DiscardPolicy {
     New = 1,
 }
 
-impl Default for DiscardPolicy {
-    fn default() -> DiscardPolicy {
-        DiscardPolicy::Old
-    }
-}
-
 /// `RetentionPolicy` determines how messages in a set are retained.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum RetentionPolicy {
     /// `Limits` (default) means that messages are retained until any given limit is reached.
     /// This could be one of messages, bytes, or age.
+    #[default]
     #[serde(rename = "limits")]
     Limits = 0,
     /// `Interest` specifies that when all known observables have acknowledged a message it can be removed.
@@ -993,28 +989,17 @@ pub enum RetentionPolicy {
     WorkQueue = 2,
 }
 
-impl Default for RetentionPolicy {
-    fn default() -> RetentionPolicy {
-        RetentionPolicy::Limits
-    }
-}
-
 /// determines how messages are stored for retention.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum StorageType {
     /// Stream data is kept in files. This is the default.
+    #[default]
     #[serde(rename = "file")]
     File = 0,
     /// Stream data is kept only in memory.
     #[serde(rename = "memory")]
     Memory = 1,
-}
-
-impl Default for StorageType {
-    fn default() -> StorageType {
-        StorageType::File
-    }
 }
 
 /// Shows config and current state for this stream.

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -442,11 +442,12 @@ pub struct StreamState {
 }
 
 /// `DeliverPolicy` determines how the consumer should select the first message to deliver.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum DeliverPolicy {
     /// All causes the consumer to receive the oldest messages still present in the system.
     /// This is the default.
+    #[default]
     #[serde(rename = "all")]
     All = 0,
     /// Last will start the consumer with the last sequence received.
@@ -470,18 +471,13 @@ pub enum DeliverPolicy {
     LastPerSubject = 5,
 }
 
-impl Default for DeliverPolicy {
-    fn default() -> DeliverPolicy {
-        DeliverPolicy::All
-    }
-}
-
 /// Determines whether messages will be acknowledged individually,
 /// in batches, or never.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum AckPolicy {
     /// All messages will be individually acknowledged. This is the default.
+    #[default]
     #[serde(rename = "explicit")]
     Explicit = 2,
     /// No messages are acknowledged.
@@ -493,18 +489,13 @@ pub enum AckPolicy {
     All = 1,
 }
 
-impl Default for AckPolicy {
-    fn default() -> AckPolicy {
-        AckPolicy::Explicit
-    }
-}
-
 /// `ReplayPolicy` controls whether messages are sent to a consumer
 /// as quickly as possible or at the rate that they were originally received at.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ReplayPolicy {
     /// Sends all messages in a stream to the consumer as quickly as possible. This is the default.
+    #[default]
     #[serde(rename = "instant")]
     Instant = 0,
     /// Sends messages to a consumer in a rate-limited fashion based on the rate of receipt. This
@@ -512,12 +503,6 @@ pub enum ReplayPolicy {
     /// traffic patterns.
     #[serde(rename = "original")]
     Original = 1,
-}
-
-impl Default for ReplayPolicy {
-    fn default() -> ReplayPolicy {
-        ReplayPolicy::Instant
-    }
 }
 
 /// The payload used to generate a purge request.
@@ -546,11 +531,12 @@ pub struct PurgeResponse {
 }
 
 /// `RetentionPolicy` determines how messages in a set are retained.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum RetentionPolicy {
     /// `Limits` (default) means that messages are retained until any given limit is reached.
     /// This could be one of messages, bytes, or age.
+    #[default]
     #[serde(rename = "limits")]
     Limits = 0,
     /// `Interest` specifies that when all known observables have acknowledged a message it can be removed.
@@ -561,18 +547,13 @@ pub enum RetentionPolicy {
     WorkQueue = 2,
 }
 
-impl Default for RetentionPolicy {
-    fn default() -> RetentionPolicy {
-        RetentionPolicy::Limits
-    }
-}
-
 /// `DiscardPolicy` determines how we proceed when limits of messages or bytes are hit. The default, `Old` will
 /// remove older messages. `New` will fail to store the new message.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum DiscardPolicy {
     /// will remove older messages when limits are hit.
+    #[default]
     #[serde(rename = "old")]
     Old = 0,
     /// will error on a StoreMsg call when limits are hit
@@ -580,28 +561,17 @@ pub enum DiscardPolicy {
     New = 1,
 }
 
-impl Default for DiscardPolicy {
-    fn default() -> DiscardPolicy {
-        DiscardPolicy::Old
-    }
-}
-
 /// determines how messages are stored for retention.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum StorageType {
     /// Stream data is kept in files. This is the default.
+    #[default]
     #[serde(rename = "file")]
     File = 0,
     /// Stream data is kept only in memory.
     #[serde(rename = "memory")]
     Memory = 1,
-}
-
-impl Default for StorageType {
-    fn default() -> StorageType {
-        StorageType::File
-    }
 }
 
 /// Various limits imposed on a particular account.

--- a/nats/src/options.rs
+++ b/nats/src/options.rs
@@ -664,9 +664,10 @@ impl Options {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) enum AuthStyle {
     /// No authentication.
+    #[default]
     NoAuth,
 
     /// Authenticate using a token.
@@ -705,12 +706,6 @@ impl fmt::Debug for AuthStyle {
             AuthStyle::Credentials { .. } => f.debug_struct("Credentials").finish(),
             AuthStyle::NKey { .. } => f.debug_struct("NKey").finish(),
         }
-    }
-}
-
-impl Default for AuthStyle {
-    fn default() -> AuthStyle {
-        AuthStyle::NoAuth
     }
 }
 


### PR DESCRIPTION
Fixes linting errors related to the `derive_default_enum` feature, more info [here](https://rust-lang.github.io/rfcs/3107-derive-default-enum.html). 
Also, incorporated some other linter suggestions (getting rid of an unnecessary `into_iter` call).