### PR TITLE
Add concrete error types to JetStream

### DIFF
--- a/.config/nats.dic
+++ b/.config/nats.dic
@@ -136,3 +136,6 @@ rustls
 Acker
 EndpointSchema
 auth
+filter_subject
+filter_subjects
+rollup

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1.17.1"
 regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
-serde_repr = "0.1.10"
+serde_repr = "0.1.11"
 http = "0.2.9"
 tokio = { version = "1.25.0", features = ["macros", "rt", "fs", "net", "sync", "time", "io-util"] }
 itoa = "1"

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1.17.1"
 regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
-serde_repr = "0.1.11"
+serde_repr = "0.1.10"
 http = "0.2.9"
 tokio = { version = "1.25.0", features = ["macros", "rt", "fs", "net", "sync", "time", "io-util"] }
 itoa = "1"

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -622,47 +622,33 @@ pub enum RequestErrorKind {
 
 /// Error returned when a core NATS request fails.
 /// To be enumerate over the variants, call [RequestError::kind].
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub struct RequestError {
     kind: RequestErrorKind,
     source: Option<Box<dyn std::error::Error + Send + Sync>>,
 }
+
+crate::error_impls!(RequestError, RequestErrorKind);
 
 impl Display for RequestError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.kind {
             RequestErrorKind::TimedOut => write!(f, "request timed out"),
             RequestErrorKind::NoResponders => write!(f, "no responders"),
-            RequestErrorKind::Other => write!(f, "request failed: {:?}", self.source),
+            RequestErrorKind::Other => write!(f, "request failed: {:?}", self.kind),
         }
-    }
-}
-
-impl RequestError {
-    fn with_source<E>(kind: RequestErrorKind, source: E) -> RequestError
-    where
-        E: Into<Box<dyn std::error::Error + Send + Sync>>,
-    {
-        RequestError {
-            kind,
-            source: Some(source.into()),
-        }
-    }
-
-    /// Returns the [RequestErrorKind] enum, allowing iterating over
-    /// all error variants.
-    pub fn kind(&self) -> RequestErrorKind {
-        self.kind
     }
 }
 
 /// Error returned when flushing the messages buffered on the client fails.
 /// To be enumerate over the variants, call [FlushError::kind].
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub struct FlushError {
     kind: FlushErrorKind,
     source: Option<Box<dyn std::error::Error + Send + Sync>>,
 }
+
+crate::error_impls!(FlushError, FlushErrorKind);
 
 impl Display for FlushError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -675,21 +661,6 @@ impl Display for FlushError {
             FlushErrorKind::SendError => write!(f, "failed to send flush request: {}", source_info),
             FlushErrorKind::FlushError => write!(f, "flush failed: {}", source_info),
         }
-    }
-}
-
-impl FlushError {
-    fn with_source<E>(kind: FlushErrorKind, source: E) -> FlushError
-    where
-        E: Into<Box<dyn std::error::Error + Send + Sync>>,
-    {
-        FlushError {
-            kind,
-            source: Some(source.into()),
-        }
-    }
-    pub fn kind(&self) -> FlushErrorKind {
-        self.kind
     }
 }
 

--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -425,3 +425,25 @@ pub enum ReplayPolicy {
 fn is_default<T: Default + Eq>(t: &T) -> bool {
     t == &T::default()
 }
+
+#[derive(Debug)]
+pub struct StreamError {
+    kind: StreamErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+crate::error_impls!(StreamError, StreamErrorKind);
+
+impl std::fmt::Display for StreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind() {
+            StreamErrorKind::TimedOut => write!(f, "timed out"),
+            StreamErrorKind::Other => write!(f, "failed: {}", self.format_source()),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum StreamErrorKind {
+    TimedOut,
+    Other,
+}

--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -17,14 +17,13 @@ pub mod pull;
 pub mod push;
 #[cfg(feature = "server_2_10")]
 use std::collections::HashMap;
-use std::io::ErrorKind;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use time::serde::rfc3339;
 
-use super::response::Response;
+use super::context::RequestError;
 use super::stream::ClusterInfo;
 use super::Context;
 use crate::jetstream::consumer;
@@ -74,37 +73,17 @@ impl<T: IntoConsumerConfig> Consumer<T> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn info(&mut self) -> Result<&consumer::Info, Error> {
+    pub async fn info(&mut self) -> Result<&consumer::Info, RequestError> {
         let subject = format!("CONSUMER.INFO.{}.{}", self.info.stream_name, self.info.name);
 
-        match self.context.request(subject, &json!({})).await? {
-            Response::Ok::<Info>(info) => {
-                self.info = info;
-                Ok(&self.info)
-            }
-            Response::Err { error } => Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "nats: error while getting consumer info: {}, {}, {}",
-                    error.code, error.status, error.description
-                ),
-            ))),
-        }
+        let info = self.context.request(subject, &json!({})).await?;
+        self.info = info;
+        Ok(&self.info)
     }
 
-    async fn fetch_info(&self) -> Result<consumer::Info, Error> {
+    async fn fetch_info(&self) -> Result<consumer::Info, RequestError> {
         let subject = format!("CONSUMER.INFO.{}.{}", self.info.stream_name, self.info.name);
-
-        match self.context.request(subject, &json!({})).await? {
-            Response::Ok::<Info>(info) => Ok(info),
-            Response::Err { error } => Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "nats: error while getting consumer info: {}, {}, {}",
-                    error.code, error.status, error.description
-                ),
-            ))),
-        }
+        self.context.request(subject, &json!({})).await
     }
 
     /// Returns cached [Info] for the [Consumer].

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -12,13 +12,13 @@
 // limitations under the License.
 
 use bytes::Bytes;
-use futures::{future::BoxFuture, FutureExt, StreamExt};
+use futures::{future::BoxFuture, FutureExt, StreamExt, TryFutureExt};
 
 #[cfg(feature = "server_2_10")]
 use std::collections::HashMap;
 use std::{
     future,
-    io::{self, ErrorKind},
+    io::ErrorKind,
     pin::Pin,
     sync::{Arc, Mutex},
     task::Poll,
@@ -85,7 +85,7 @@ impl Consumer<Config> {
     /// Ok(())
     /// # }
     /// ```
-    pub async fn messages(&self) -> Result<Stream, Error> {
+    pub async fn messages(&self) -> Result<Stream, StreamError> {
         Stream::stream(
             BatchConfig {
                 batch: 200,
@@ -726,7 +726,7 @@ pub struct Ordered<'a> {
     consumer: OrderedConfig,
     consumer_name: String,
     stream: Option<Stream>,
-    create_stream: Option<BoxFuture<'a, Result<Stream, Error>>>,
+    create_stream: Option<BoxFuture<'a, Result<Stream, ConsumerRecreateError>>>,
     consumer_sequence: u64,
     stream_sequence: u64,
 }
@@ -812,7 +812,7 @@ impl<'a> futures::Stream for Ordered<'a> {
 pub struct Stream {
     pending_messages: usize,
     pending_bytes: usize,
-    request_result_rx: tokio::sync::mpsc::Receiver<Result<bool, crate::Error>>,
+    request_result_rx: tokio::sync::mpsc::Receiver<Result<bool, super::RequestError>>,
     request_tx: tokio::sync::watch::Sender<()>,
     subscriber: Subscriber,
     batch_config: BatchConfig,
@@ -834,13 +834,40 @@ impl Drop for Stream {
     }
 }
 
+#[derive(Debug)]
+pub struct StreamError {
+    kind: StreamErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+crate::error_impls!(StreamError, StreamErrorKind);
+
+impl std::fmt::Display for StreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind() {
+            StreamErrorKind::TimedOut => write!(f, "timed out"),
+            StreamErrorKind::Other => write!(f, "failed: {}", self.format_source()),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum StreamErrorKind {
+    TimedOut,
+    Other,
+}
+
 impl Stream {
     async fn stream(
         batch_config: BatchConfig,
         consumer: &Consumer<Config>,
-    ) -> Result<Stream, Error> {
+    ) -> Result<Stream, StreamError> {
         let inbox = consumer.context.client.new_inbox();
-        let subscription = consumer.context.client.subscribe(inbox.clone()).await?;
+        let subscription = consumer
+            .context
+            .client
+            .subscribe(inbox.clone())
+            .await
+            .map_err(|err| StreamError::with_source(StreamErrorKind::Other, err))?;
         let subject = format!(
             "{}.CONSUMER.MSG.NEXT.{}.{}",
             consumer.context.prefix, consumer.info.stream_name, consumer.info.name
@@ -903,14 +930,16 @@ impl Stream {
                         .client
                         .publish_with_reply(subject.clone(), inbox.clone(), request.clone())
                         .await
-                        .map(|_| pending_reset)
-                        .map_err(|err| Box::from(io::Error::new(io::ErrorKind::Other, err)));
+                        .map(|_| pending_reset);
                     if let Err(err) = consumer.context.client.flush().await {
                         debug!("flush failed: {err:?}");
                     }
                     // TODO: add tracing instead of ignoring this.
                     request_result_tx
-                        .send(result.map(|_| pending_reset))
+                        .send(result.map(|_| pending_reset).map_err(|err| {
+                            crate::RequestError::with_source(crate::RequestErrorKind::Other, err)
+                                .into()
+                        }))
                         .await
                         .unwrap();
                     trace!("result send over tx");
@@ -971,8 +1000,39 @@ impl Stream {
     }
 }
 
+#[derive(Debug)]
+pub struct MessagesError {
+    kind: MessagesErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+impl std::fmt::Display for MessagesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind() {
+            MessagesErrorKind::MissingHeartbeat => write!(f, "missed idle heartbeat"),
+            MessagesErrorKind::ConsumerDeleted => write!(f, "consumer deleted"),
+            MessagesErrorKind::PullFailed => {
+                write!(f, "pull request failed: {}", self.format_source())
+            }
+            MessagesErrorKind::Other => write!(f, "error: {}", self.format_source()),
+            MessagesErrorKind::PushBasedConsumer => write!(f, "cannot use with push consumer"),
+        }
+    }
+}
+
+crate::error_impls!(MessagesError, MessagesErrorKind);
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MessagesErrorKind {
+    MissingHeartbeat,
+    ConsumerDeleted,
+    PullFailed,
+    PushBasedConsumer,
+    Other,
+}
+
 impl futures::Stream for Stream {
-    type Item = Result<jetstream::Message, Error>;
+    type Item = Result<jetstream::Message, MessagesError>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -997,17 +1057,16 @@ impl futures::Stream for Stream {
                     Poll::Ready(resp) => match resp {
                         Some(()) => {
                             trace!("received missing heartbeats notification");
-                            return Poll::Ready(Some(Err(Box::new(std::io::Error::new(
-                                std::io::ErrorKind::TimedOut,
-                                "did not receive idle heartbeat in time",
-                            )))));
+                            return Poll::Ready(Some(Err(MessagesError::new(
+                                MessagesErrorKind::MissingHeartbeat,
+                            ))));
                         }
                         None => {
                             self.terminated = true;
-                            return Poll::Ready(Some(Err(Box::new(std::io::Error::new(
-                                std::io::ErrorKind::Other,
+                            return Poll::Ready(Some(Err(MessagesError::with_source(
+                                MessagesErrorKind::Other,
                                 "unexpected termination of heartbeat checker",
-                            )))));
+                            ))));
                         }
                     },
                     Poll::Pending => {
@@ -1031,7 +1090,12 @@ impl futures::Stream for Stream {
                             self.pending_request = false;
                             continue;
                         }
-                        Err(err) => return Poll::Ready(Some(Err(err))),
+                        Err(err) => {
+                            return Poll::Ready(Some(Err(MessagesError::with_source(
+                                MessagesErrorKind::PullFailed,
+                                err,
+                            ))))
+                        }
                     },
                     None => return Poll::Ready(None),
                 },
@@ -1048,18 +1112,16 @@ impl futures::Stream for Stream {
                             // If consumer has been deleted, error and shutdown the iterator.
                             if message.description.as_deref() == Some("Consumer Deleted") {
                                 self.terminated = true;
-                                return Poll::Ready(Some(Err(Box::new(std::io::Error::new(
-                                    std::io::ErrorKind::NotFound,
-                                    format!("{:?}: {:?}", message.status, message.description),
-                                )))));
+                                return Poll::Ready(Some(Err(MessagesError::new(
+                                    MessagesErrorKind::ConsumerDeleted,
+                                ))));
                             }
                             // If consumer is not pull based, error and shutdown the iterator.
                             if message.description.as_deref() == Some("Consumer is push based") {
                                 self.terminated = true;
-                                return Poll::Ready(Some(Err(Box::new(std::io::Error::new(
-                                    std::io::ErrorKind::Other,
-                                    format!("{:?}: {:?}", message.status, message.description),
-                                )))));
+                                return Poll::Ready(Some(Err(MessagesError::new(
+                                    MessagesErrorKind::PushBasedConsumer,
+                                ))));
                             }
                             // All other cases can be handled.
 
@@ -1077,7 +1139,10 @@ impl futures::Stream for Stream {
                                 .map(|h| h.iter())
                                 .and_then(|mut i| i.next())
                                 .map(|e| e.parse::<usize>())
-                                .unwrap_or(Ok(self.batch_config.batch))?;
+                                .unwrap_or(Ok(self.batch_config.batch))
+                                .map_err(|err| {
+                                    MessagesError::with_source(MessagesErrorKind::Other, err)
+                                })?;
                             let pending_bytes = message
                                 .headers
                                 .as_ref()
@@ -1085,7 +1150,10 @@ impl futures::Stream for Stream {
                                 .map(|h| h.iter())
                                 .and_then(|mut i| i.next())
                                 .map(|e| e.parse::<usize>())
-                                .unwrap_or(Ok(self.batch_config.max_bytes))?;
+                                .unwrap_or(Ok(self.batch_config.max_bytes))
+                                .map_err(|err| {
+                                    MessagesError::with_source(MessagesErrorKind::Other, err)
+                                })?;
                             debug!(
                                 "timeout reached. remaining messages: {}, bytes {}",
                                 pending_messages, pending_bytes
@@ -1120,13 +1188,13 @@ impl futures::Stream for Stream {
                         }
                         status => {
                             debug!("received unknown message: {:?}", message);
-                            return Poll::Ready(Some(Err(Box::new(std::io::Error::new(
-                                std::io::ErrorKind::Other,
+                            return Poll::Ready(Some(Err(MessagesError::with_source(
+                                MessagesErrorKind::Other,
                                 format!(
                                     "error while processing messages from the stream: {}, {:?}",
                                     status, message.description
                                 ),
-                            )))));
+                            ))));
                         }
                     },
                     None => return Poll::Ready(None),
@@ -1380,7 +1448,7 @@ impl<'a> StreamBuilder<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn messages(self) -> Result<Stream, Error> {
+    pub async fn messages(self) -> Result<Stream, StreamError> {
         Stream::stream(
             BatchConfig {
                 batch: self.batch,
@@ -2089,15 +2157,55 @@ impl FromConsumer for Config {
     }
 }
 
+#[derive(Debug)]
+pub struct ConsumerRecreateError {
+    kind: ConsumerRecreateErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+crate::error_impls!(ConsumerRecreateError, ConsumerRecreateErrorKind);
+
+impl std::fmt::Display for ConsumerRecreateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind() {
+            ConsumerRecreateErrorKind::StreamGetFailed => {
+                write!(f, "error getting stream: {}", self.format_source())
+            }
+            ConsumerRecreateErrorKind::RecreationFailed => {
+                write!(f, "consumer creation failed: {}", self.format_source())
+            }
+            ConsumerRecreateErrorKind::TimedOut => write!(f, "timed out"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Copy)]
+pub enum ConsumerRecreateErrorKind {
+    StreamGetFailed,
+    RecreationFailed,
+    TimedOut,
+}
+
 async fn recreate_consumer_stream(
     context: Context,
     config: Config,
     stream_name: String,
     consumer_name: String,
     sequence: u64,
-) -> Result<Stream, Error> {
-    let stream = context.get_stream(stream_name.clone()).await?;
-    stream.delete_consumer(&consumer_name).await?;
+) -> Result<Stream, ConsumerRecreateError> {
+    // TODO(jarema): retry whole operation few times?
+    let stream = context
+        .get_stream(stream_name.clone())
+        .await
+        .map_err(|err| {
+            ConsumerRecreateError::with_source(ConsumerRecreateErrorKind::StreamGetFailed, err)
+        })?;
+    stream
+        .delete_consumer(&consumer_name)
+        .await
+        .map_err(|err| {
+            ConsumerRecreateError::with_source(ConsumerRecreateErrorKind::RecreationFailed, err)
+        })?;
 
     let deliver_policy = {
         if sequence == 0 {
@@ -2116,7 +2224,13 @@ async fn recreate_consumer_stream(
         }),
     )
     .await
-    .map_err(|_| io::Error::new(ErrorKind::TimedOut, "timed out"))??
+    .map_err(|_| ConsumerRecreateError::new(ConsumerRecreateErrorKind::TimedOut))?
+    .map_err(|err| {
+        ConsumerRecreateError::with_source(ConsumerRecreateErrorKind::RecreationFailed, err)
+    })?
     .messages()
+    .map_err(|err| {
+        ConsumerRecreateError::with_source(ConsumerRecreateErrorKind::RecreationFailed, err)
+    })
     .await
 }

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -17,7 +17,7 @@ use crate::header::{IntoHeaderName, IntoHeaderValue};
 use crate::jetstream::account::Account;
 use crate::jetstream::publish::PublishAck;
 use crate::jetstream::response::Response;
-use crate::{header, Client, Command, Error, HeaderMap, HeaderValue, StatusCode};
+use crate::{header, Client, Command, HeaderMap, HeaderValue, StatusCode};
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::{Future, StreamExt, TryFutureExt};
@@ -25,8 +25,9 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{self, json};
 use std::borrow::Borrow;
+use std::fmt::Display;
 use std::future::IntoFuture;
-use std::io::{self, ErrorKind};
+use std::io::ErrorKind;
 use std::pin::Pin;
 use std::str::from_utf8;
 use std::task::Poll;
@@ -34,6 +35,7 @@ use std::time::Duration;
 use tracing::debug;
 
 use super::consumer::{Consumer, FromConsumer, IntoConsumerConfig};
+use super::errors::ErrorCode;
 use super::kv::{Store, MAX_HISTORY};
 use super::object_store::{is_valid_bucket_name, ObjectStore};
 use super::stream::{self, Config, DeleteStatus, DiscardPolicy, External, Info, Stream};
@@ -128,7 +130,7 @@ impl Context {
         &self,
         subject: String,
         payload: Bytes,
-    ) -> Result<PublishAckFuture, Error> {
+    ) -> Result<PublishAckFuture, PublishError> {
         self.send_publish(subject, Publish::build().payload(payload))
             .await
     }
@@ -159,7 +161,7 @@ impl Context {
         subject: String,
         headers: crate::header::HeaderMap,
         payload: Bytes,
-    ) -> Result<PublishAckFuture, Error> {
+    ) -> Result<PublishAckFuture, PublishError> {
         self.send_publish(subject, Publish::build().payload(payload).headers(headers))
             .await
     }
@@ -190,9 +192,13 @@ impl Context {
         &self,
         subject: String,
         publish: Publish,
-    ) -> Result<PublishAckFuture, Error> {
+    ) -> Result<PublishAckFuture, PublishError> {
         let inbox = self.client.new_inbox();
-        let response = self.client.subscribe(inbox.clone()).await?;
+        let response = self
+            .client
+            .subscribe(inbox.clone())
+            .await
+            .map_err(|err| PublishError::with_source(PublishErrorKind::Other, err))?;
         tokio::time::timeout(self.timeout, async {
             if let Some(headers) = publish.headers {
                 self.client
@@ -209,10 +215,9 @@ impl Context {
                     .await
             }
         })
-        .map_err(|_| {
-            std::io::Error::new(ErrorKind::TimedOut, "JetStream publish request timed out")
-        })
-        .await??;
+        .map_err(|_| PublishError::new(PublishErrorKind::TimedOut))
+        .await?
+        .map_err(|err| PublishError::with_source(PublishErrorKind::Other, err))?;
 
         Ok(PublishAckFuture {
             timeout: self.timeout,
@@ -221,17 +226,11 @@ impl Context {
     }
 
     /// Query the server for account information
-    pub async fn query_account(&self) -> Result<Account, Error> {
+    pub async fn query_account(&self) -> Result<Account, RequestError> {
         let response: Response<Account> = self.request("INFO".into(), b"").await?;
 
         match response {
-            Response::Err { error } => Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "nats: error while querying account information: {}, {}, {}",
-                    error.code, error.status, error.description
-                ),
-            ))),
+            Response::Err { error } => Err(RequestError::new(RequestErrorKind::JetStream(error))),
             Response::Ok(account) => Ok(account),
         }
     }
@@ -260,24 +259,27 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn create_stream<S>(&self, stream_config: S) -> Result<Stream, Error>
+    pub async fn create_stream<S>(&self, stream_config: S) -> Result<Stream, CreateStreamError>
     where
         Config: From<S>,
     {
         let mut config: Config = stream_config.into();
         if config.name.is_empty() {
-            return Err(Box::new(io::Error::new(
-                ErrorKind::InvalidInput,
-                "the stream name must not be empty",
-            )));
+            return Err(CreateStreamError::new(
+                CreateStreamErrorKind::EmptyStreamName,
+            ));
+        }
+        if config.name.contains([' ', '.']) {
+            return Err(CreateStreamError::new(
+                CreateStreamErrorKind::InvalidStreamName,
+            ));
         }
         if let Some(ref mut mirror) = config.mirror {
             if let Some(ref mut domain) = mirror.domain {
                 if mirror.external.is_some() {
-                    return Err(Box::new(io::Error::new(
-                        ErrorKind::Other,
-                        "domain and external are both set",
-                    )));
+                    return Err(CreateStreamError::new(
+                        CreateStreamErrorKind::DomainAndExternalSet,
+                    ));
                 }
                 mirror.external = Some(External {
                     api_prefix: format!("$JS.{domain}.API"),
@@ -290,10 +292,9 @@ impl Context {
             for source in sources {
                 if let Some(ref mut domain) = source.domain {
                     if source.external.is_some() {
-                        return Err(Box::new(io::Error::new(
-                            ErrorKind::Other,
-                            "domain and external are both set",
-                        )));
+                        return Err(CreateStreamError::new(
+                            CreateStreamErrorKind::DomainAndExternalSet,
+                        ));
                     }
                     source.external = Some(External {
                         api_prefix: format!("$JS.{domain}.API"),
@@ -306,13 +307,7 @@ impl Context {
         let response: Response<Info> = self.request(subject, &config).await?;
 
         match response {
-            Response::Err { error } => Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "nats: error while creating stream: {}, {}, {}",
-                    error.code, error.status, error.description
-                ),
-            ))),
+            Response::Err { error } => Err(error.into()),
             Response::Ok(info) => Ok(Stream {
                 context: self.clone(),
                 info,
@@ -335,25 +330,21 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_stream<T: AsRef<str>>(&self, stream: T) -> Result<Stream, Error> {
+    pub async fn get_stream<T: AsRef<str>>(&self, stream: T) -> Result<Stream, GetStreamError> {
         let stream = stream.as_ref();
         if stream.is_empty() {
-            return Err(Box::new(io::Error::new(
-                ErrorKind::InvalidInput,
-                "the stream name must not be empty",
-            )));
+            return Err(GetStreamError::new(GetStreamErrorKind::EmptyName));
         }
 
         let subject = format!("STREAM.INFO.{stream}");
-        let request: Response<Info> = self.request(subject, &()).await?;
+        let request: Response<Info> = self
+            .request(subject, &())
+            .await
+            .map_err(|err| GetStreamError::with_source(GetStreamErrorKind::RequestError, err))?;
         match request {
-            Response::Err { error } => Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "nats: error while getting stream: {}, {}, {}",
-                    error.code, error.status, error.description
-                ),
-            ))),
+            Response::Err { error } => Err(GetStreamError::new(
+                GetStreamErrorKind::JetStreamError(error),
+            )),
             Response::Ok(info) => Ok(Stream {
                 context: self.clone(),
                 info,
@@ -384,7 +375,10 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_or_create_stream<S>(&self, stream_config: S) -> Result<Stream, Error>
+    pub async fn get_or_create_stream<S>(
+        &self,
+        stream_config: S,
+    ) -> Result<Stream, CreateStreamError>
     where
         S: Into<Config>,
     {
@@ -393,14 +387,8 @@ impl Context {
 
         let request: Response<Info> = self.request(subject, &()).await?;
         match request {
-            Response::Err { error } if error.status == 404 => self.create_stream(&config).await,
-            Response::Err { error } => Err(Box::new(io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "nats: error while getting or creating stream: {}, {}, {}",
-                    error.code, error.status, error.description
-                ),
-            ))),
+            Response::Err { error } if error.code() == 404 => self.create_stream(&config).await,
+            Response::Err { error } => Err(error.into()),
             Response::Ok(info) => Ok(Stream {
                 context: self.clone(),
                 info,
@@ -423,23 +411,21 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn delete_stream<T: AsRef<str>>(&self, stream: T) -> Result<DeleteStatus, Error> {
+    pub async fn delete_stream<T: AsRef<str>>(
+        &self,
+        stream: T,
+    ) -> Result<DeleteStatus, DeleteStreamError> {
         let stream = stream.as_ref();
         if stream.is_empty() {
-            return Err(Box::new(io::Error::new(
-                ErrorKind::InvalidInput,
-                "the stream name must not be empty",
-            )));
+            return Err(DeleteStreamError::new(DeleteStreamErrorKind::EmptyName));
         }
         let subject = format!("STREAM.DELETE.{stream}");
-        match self.request(subject, &json!({})).await? {
-            Response::Err { error } => Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "nats: error while deleting stream: {}, {}, {}",
-                    error.code, error.status, error.description
-                ),
-            ))),
+        match self.request(subject, &json!({})).await.map_err(|err| {
+            DeleteStreamError::with_source(DeleteStreamErrorKind::RequestError, err)
+        })? {
+            Response::Err { error } => Err(DeleteStreamError::new(
+                DeleteStreamErrorKind::JetStreamError(error),
+            )),
             Response::Ok(delete_response) => Ok(delete_response),
         }
     }
@@ -468,20 +454,14 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn update_stream<S>(&self, config: S) -> Result<Info, Error>
+    pub async fn update_stream<S>(&self, config: S) -> Result<Info, UpdateStreamError>
     where
         S: Borrow<Config>,
     {
         let config = config.borrow();
         let subject = format!("STREAM.UPDATE.{}", config.name);
         match self.request(subject, config).await? {
-            Response::Err { error } => Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                format!(
-                    "nats: error while updating stream: {}, {}, {}",
-                    error.code, error.status, error.description
-                ),
-            ))),
+            Response::Err { error } => Err(error.into()),
             Response::Ok(info) => Ok(info),
         }
     }
@@ -552,23 +532,20 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_key_value<T: Into<String>>(&self, bucket: T) -> Result<Store, Error> {
+    pub async fn get_key_value<T: Into<String>>(&self, bucket: T) -> Result<Store, KeyValueError> {
         let bucket: String = bucket.into();
         if !crate::jetstream::kv::is_valid_bucket_name(&bucket) {
-            return Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                "invalid bucket name",
-            )));
+            return Err(KeyValueError::new(KeyValueErrorKind::InvalidStoreName));
         }
 
         let stream_name = format!("KV_{}", &bucket);
-        let stream = self.get_stream(stream_name.clone()).await?;
+        let stream = self
+            .get_stream(stream_name.clone())
+            .map_err(|err| KeyValueError::with_source(KeyValueErrorKind::FailedGetBucket, err))
+            .await?;
 
         if stream.info.config.max_messages_per_subject < 1 {
-            return Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                "not a valid key-value store",
-            )));
+            return Err(KeyValueError::new(KeyValueErrorKind::InvalidStoreName));
         }
         let mut store = Store {
             prefix: format!("$KV.{}.", &bucket),
@@ -616,20 +593,18 @@ impl Context {
     pub async fn create_key_value(
         &self,
         mut config: crate::jetstream::kv::Config,
-    ) -> Result<Store, Error> {
+    ) -> Result<Store, CreateKeyValueError> {
         if !crate::jetstream::kv::is_valid_bucket_name(&config.bucket) {
-            return Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                "invalid bucket name",
-            )));
+            return Err(CreateKeyValueError::new(
+                CreateKeyValueErrorKind::InvalidStoreName,
+            ));
         }
 
         let history = if config.history > 0 {
             if config.history > MAX_HISTORY {
-                return Err(Box::new(io::Error::new(
-                    io::ErrorKind::Other,
-                    "history limited to a max of 64",
-                )));
+                return Err(CreateKeyValueError::new(
+                    CreateKeyValueErrorKind::TooLongHistory,
+                ));
             }
             config.history
         } else {
@@ -680,7 +655,17 @@ impl Context {
                 mirror_direct: config.mirror_direct,
                 ..Default::default()
             })
-            .await?;
+            .await
+            .map_err(|err| {
+                if err.kind() == CreateStreamErrorKind::TimedOut {
+                    CreateKeyValueError::with_source(CreateKeyValueErrorKind::TimedOut, err)
+                } else {
+                    CreateKeyValueError::with_source(
+                        CreateKeyValueErrorKind::BucketCreationFailed,
+                        err,
+                    )
+                }
+            })?;
 
         let mut store = Store {
             prefix: format!("$KV.{}.", &config.bucket),
@@ -725,16 +710,18 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn delete_key_value<T: AsRef<str>>(&self, bucket: T) -> Result<DeleteStatus, Error> {
+    pub async fn delete_key_value<T: AsRef<str>>(
+        &self,
+        bucket: T,
+    ) -> Result<DeleteStatus, KeyValueError> {
         if !crate::jetstream::kv::is_valid_bucket_name(bucket.as_ref()) {
-            return Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                "invalid bucket name",
-            )));
+            return Err(KeyValueError::new(KeyValueErrorKind::InvalidStoreName));
         }
 
         let stream_name = format!("KV_{}", bucket.as_ref());
-        self.delete_stream(stream_name).await
+        self.delete_stream(stream_name)
+            .map_err(|err| KeyValueError::with_source(KeyValueErrorKind::JetStreamError, err))
+            .await
     }
 
     // pub async fn update_key_value<C: Borrow<kv::Config>>(&self, config: C) -> Result<(), Error> {
@@ -778,7 +765,7 @@ impl Context {
         &self,
         consumer: C,
         stream: S,
-    ) -> Result<Consumer<T>, Error>
+    ) -> Result<Consumer<T>, crate::Error>
     where
         T: FromConsumer + IntoConsumerConfig,
         S: AsRef<str>,
@@ -791,10 +778,7 @@ impl Context {
             Response::Err { error } => {
                 return Err(Box::new(std::io::Error::new(
                     ErrorKind::Other,
-                    format!(
-                        "nats: error while getting consumer info: {}, {}, {}",
-                        error.code, error.status, error.description
-                    ),
+                    format!("nats: error while getting consumer info: {}", error),
                 )))
             }
         };
@@ -827,24 +811,28 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn request<T, V>(&self, subject: String, payload: &T) -> Result<Response<V>, Error>
+    pub async fn request<T, V>(&self, subject: String, payload: &T) -> Result<V, RequestError>
     where
         T: ?Sized + Serialize,
         V: DeserializeOwned,
     {
-        let request = serde_json::to_vec(&payload).map(Bytes::from)?;
+        let request = serde_json::to_vec(&payload)
+            .map(Bytes::from)
+            .map_err(|err| RequestError::with_source(RequestErrorKind::Other, err))?;
 
         debug!("JetStream request sent: {:?}", request);
 
         let message = self
             .client
             .request(format!("{}.{}", self.prefix, subject), request)
-            .await?;
+            .await;
+        let message = message?;
         debug!(
             "JetStream request response: {:?}",
             from_utf8(&message.payload)
         );
-        let response = serde_json::from_slice(message.payload.as_ref())?;
+        let response = serde_json::from_slice(message.payload.as_ref())
+            .map_err(|err| RequestError::with_source(RequestErrorKind::Other, err))?;
 
         Ok(response)
     }
@@ -870,12 +858,11 @@ impl Context {
     pub async fn create_object_store(
         &self,
         config: super::object_store::Config,
-    ) -> Result<super::object_store::ObjectStore, Error> {
+    ) -> Result<super::object_store::ObjectStore, CreateObjectStoreError> {
         if !super::object_store::is_valid_bucket_name(&config.bucket) {
-            return Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                "invalid bucket name",
-            )));
+            return Err(CreateObjectStoreError::new(
+                CreateKeyValueErrorKind::InvalidStoreName,
+            ));
         }
 
         let bucket_name = config.bucket.clone();
@@ -896,7 +883,13 @@ impl Context {
                 allow_direct: true,
                 ..Default::default()
             })
-            .await?;
+            .await
+            .map_err(|err| {
+                CreateObjectStoreError::with_source(
+                    CreateKeyValueErrorKind::BucketCreationFailed,
+                    err,
+                )
+            })?;
 
         Ok(ObjectStore {
             name: bucket_name,
@@ -920,22 +913,17 @@ impl Context {
     pub async fn get_object_store<T: AsRef<str>>(
         &self,
         bucket_name: T,
-    ) -> Result<ObjectStore, Error> {
-        if !self.client.is_server_compatible(2, 6, 2) {
-            return Err(Box::new(io::Error::new(
-                ErrorKind::Other,
-                "object-store requires at least server version 2.6.2",
-            )));
-        }
+    ) -> Result<ObjectStore, ObjectStoreError> {
         let bucket_name = bucket_name.as_ref();
         if !is_valid_bucket_name(bucket_name) {
-            return Err(Box::new(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "invalid bucket name",
-            )));
+            return Err(ObjectStoreError::new(
+                ObjectStoreErrorKind::InvalidBucketName,
+            ));
         }
         let stream_name = format!("OBJ_{bucket_name}");
-        let stream = self.get_stream(stream_name).await?;
+        let stream = self.get_stream(stream_name).await.map_err(|err| {
+            ObjectStoreError::with_source(ObjectStoreErrorKind::FailedGetStore, err)
+        })?;
 
         Ok(ObjectStore {
             name: bucket_name.to_string(),
@@ -956,11 +944,48 @@ impl Context {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn delete_object_store<T: AsRef<str>>(&self, bucket_name: T) -> Result<(), Error> {
+    pub async fn delete_object_store<T: AsRef<str>>(
+        &self,
+        bucket_name: T,
+    ) -> Result<(), DeleteObjectStore> {
         let stream_name = format!("OBJ_{}", bucket_name.as_ref());
-        self.delete_stream(stream_name).await?;
+        self.delete_stream(stream_name).await.map_err(|err| {
+            ObjectStoreError::with_source(ObjectStoreErrorKind::FailedGetStore, err)
+        })?;
         Ok(())
     }
+}
+
+#[derive(Debug)]
+pub struct PublishError {
+    kind: PublishErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+crate::error_impls!(PublishError, PublishErrorKind);
+
+impl Display for PublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let source = self.format_source();
+        match self.kind {
+            PublishErrorKind::StreamNotFound => write!(f, "no stream found for given subject"),
+            PublishErrorKind::TimedOut => write!(f, "timed out: didn't receive ack in time"),
+            PublishErrorKind::Other => write!(f, "publish failed: {}", source),
+            PublishErrorKind::BrokenPipe => write!(f, "broken pipe"),
+            PublishErrorKind::WrongLastMessageId => write!(f, "wrong last message id"),
+            PublishErrorKind::WrongLastSequence => write!(f, "wrong last sequence"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PublishErrorKind {
+    StreamNotFound,
+    WrongLastMessageId,
+    WrongLastSequence,
+    TimedOut,
+    BrokenPipe,
+    Other,
 }
 
 #[derive(Debug)]
@@ -970,34 +995,31 @@ pub struct PublishAckFuture {
 }
 
 impl PublishAckFuture {
-    async fn next_with_timeout(mut self) -> Result<PublishAck, Error> {
+    async fn next_with_timeout(mut self) -> Result<PublishAck, PublishError> {
         self.subscription.sender.send(Command::TryFlush).await.ok();
         let next = tokio::time::timeout(self.timeout, self.subscription.next())
             .await
-            .map_err(|_| std::io::Error::new(ErrorKind::TimedOut, "acknowledgment timed out"))?;
+            .map_err(|_| PublishError::new(PublishErrorKind::TimedOut))?;
         next.map_or_else(
-            || {
-                Err(Box::from(std::io::Error::new(
-                    ErrorKind::Other,
-                    "broken pipe",
-                )))
-            },
+            || Err(PublishError::new(PublishErrorKind::BrokenPipe)),
             |m| {
                 if m.status == Some(StatusCode::NO_RESPONDERS) {
-                    return Err(Box::from(std::io::Error::new(
-                        ErrorKind::NotFound,
-                        "no stream found for given subject",
-                    )));
+                    return Err(PublishError::new(PublishErrorKind::StreamNotFound));
                 }
-                let response = serde_json::from_slice(m.payload.as_ref())?;
+                let response = serde_json::from_slice(m.payload.as_ref())
+                    .map_err(|err| PublishError::with_source(PublishErrorKind::Other, err))?;
                 match response {
-                    Response::Err { error } => Err(Box::from(std::io::Error::new(
-                        ErrorKind::Other,
-                        format!(
-                            "nats: error while publishing message: {}, {}, {}",
-                            error.code, error.status, error.description
-                        ),
-                    ))),
+                    Response::Err { error } => match error.error_code() {
+                        ErrorCode::STREAM_WRONG_LAST_MSG_ID => Err(PublishError::with_source(
+                            PublishErrorKind::WrongLastMessageId,
+                            error,
+                        )),
+                        ErrorCode::STREAM_WRONG_LAST_SEQUENCE => Err(PublishError::with_source(
+                            PublishErrorKind::WrongLastSequence,
+                            error,
+                        )),
+                        _ => Err(PublishError::with_source(PublishErrorKind::Other, error)),
+                    },
                     Response::Ok(publish_ack) => Ok(publish_ack),
                 }
             },
@@ -1005,9 +1027,9 @@ impl PublishAckFuture {
     }
 }
 impl IntoFuture for PublishAckFuture {
-    type Output = Result<PublishAck, Error>;
+    type Output = Result<PublishAck, PublishError>;
 
-    type IntoFuture = Pin<Box<dyn Future<Output = Result<PublishAck, Error>> + Send>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Result<PublishAck, PublishError>> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(std::future::IntoFuture::into_future(
@@ -1028,7 +1050,7 @@ struct StreamInfoPage {
     streams: Option<Vec<super::stream::Info>>,
 }
 
-type PageRequest<'a> = BoxFuture<'a, Result<StreamPage, Error>>;
+type PageRequest<'a> = BoxFuture<'a, Result<StreamPage, RequestError>>;
 
 pub struct StreamNames<'a> {
     context: Context,
@@ -1039,7 +1061,7 @@ pub struct StreamNames<'a> {
 }
 
 impl futures::Stream for StreamNames<'_> {
-    type Item = Result<String, Error>;
+    type Item = Result<String, StreamsError>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -1049,7 +1071,8 @@ impl futures::Stream for StreamNames<'_> {
             Some(page) => match page.try_poll_unpin(cx) {
                 std::task::Poll::Ready(page) => {
                     self.page_request = None;
-                    let page = page?;
+                    let page = page
+                        .map_err(|err| StreamsError::with_source(RequestErrorKind::Other, err))?;
                     if let Some(streams) = page.streams {
                         self.offset += streams.len();
                         self.streams = streams;
@@ -1086,7 +1109,7 @@ impl futures::Stream for StreamNames<'_> {
                             .await?
                         {
                             Response::Err { error } => {
-                                Err(Box::from(std::io::Error::new(ErrorKind::Other, error)))
+                                Err(RequestError::with_source(RequestErrorKind::Other, error))
                             }
                             Response::Ok(page) => Ok(page),
                         }
@@ -1098,7 +1121,20 @@ impl futures::Stream for StreamNames<'_> {
     }
 }
 
-type PageInfoRequest<'a> = BoxFuture<'a, Result<StreamInfoPage, Error>>;
+type PageInfoRequest<'a> = BoxFuture<'a, Result<StreamInfoPage, RequestError>>;
+
+#[derive(Debug)]
+pub struct StreamsError {
+    kind: RequestErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+crate::error_impls!(StreamsError, RequestErrorKind);
+
+impl Display for StreamsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self::Display::fmt(&self, f)
+    }
+}
 
 pub struct Streams<'a> {
     context: Context,
@@ -1109,7 +1145,7 @@ pub struct Streams<'a> {
 }
 
 impl futures::Stream for Streams<'_> {
-    type Item = Result<super::stream::Info, Error>;
+    type Item = Result<super::stream::Info, StreamsError>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -1119,7 +1155,8 @@ impl futures::Stream for Streams<'_> {
             Some(page) => match page.try_poll_unpin(cx) {
                 std::task::Poll::Ready(page) => {
                     self.page_request = None;
-                    let page = page?;
+                    let page = page
+                        .map_err(|err| StreamsError::with_source(RequestErrorKind::Other, err))?;
                     if let Some(streams) = page.streams {
                         self.offset += streams.len();
                         self.streams = streams;
@@ -1156,7 +1193,7 @@ impl futures::Stream for Streams<'_> {
                             .await?
                         {
                             Response::Err { error } => {
-                                Err(Box::from(std::io::Error::new(ErrorKind::Other, error)))
+                                Err(RequestError::with_source(RequestErrorKind::Other, error))
                             }
                             Response::Ok(page) => Ok(page),
                         }
@@ -1233,3 +1270,244 @@ impl Publish {
         )
     }
 }
+
+#[derive(Debug)]
+pub struct RequestError {
+    kind: RequestErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+crate::error_impls!(RequestError, RequestErrorKind);
+
+impl Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let source = self.format_source();
+        match &self.kind {
+            RequestErrorKind::TimedOut => write!(f, "timed out"),
+            RequestErrorKind::Other => write!(f, "request failed: {}", source),
+            RequestErrorKind::NoResponders => {
+                write!(f, "requested JetStream resource does not exist: {}", source)
+            }
+            RequestErrorKind::JetStream(err) => write!(f, "request failed: {}", err),
+        }
+    }
+}
+
+impl From<crate::RequestError> for RequestError {
+    fn from(error: crate::RequestError) -> Self {
+        match error.kind() {
+            crate::RequestErrorKind::TimedOut => {
+                RequestError::with_source(RequestErrorKind::TimedOut, error)
+            }
+            crate::RequestErrorKind::NoResponders => {
+                RequestError::new(RequestErrorKind::NoResponders)
+            }
+            crate::RequestErrorKind::Other => {
+                RequestError::with_source(RequestErrorKind::Other, error)
+            }
+        }
+    }
+}
+
+impl From<super::errors::Error> for RequestError {
+    fn from(err: super::errors::Error) -> Self {
+        RequestError::with_source(RequestErrorKind::Other, err)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RequestErrorKind {
+    NoResponders,
+    TimedOut,
+    JetStream(super::errors::Error),
+    Other,
+}
+
+#[derive(Debug)]
+pub struct CreateStreamError {
+    kind: CreateStreamErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+crate::error_impls!(CreateStreamError, CreateStreamErrorKind);
+
+impl Display for CreateStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind {
+            CreateStreamErrorKind::EmptyStreamName => write!(f, "stream name cannot be empty"),
+            CreateStreamErrorKind::InvalidStreamName => {
+                write!(f, "stream name cannot contain `.`, `_`")
+            }
+            CreateStreamErrorKind::DomainAndExternalSet => {
+                write!(f, "domain and external are both set")
+            }
+            CreateStreamErrorKind::JetStreamError(err) => {
+                write!(f, "jetstream error: {}", err)
+            }
+            CreateStreamErrorKind::TimedOut => write!(f, "jetstream request timed out"),
+            CreateStreamErrorKind::JetStreamUnavailable => write!(f, "jetstream unavailable"),
+            CreateStreamErrorKind::ResponseParse => write!(f, "failed to parse server response"),
+            CreateStreamErrorKind::ResponseError => {
+                write!(f, "response error: {}", self.format_source())
+            }
+        }
+    }
+}
+
+impl From<super::errors::Error> for CreateStreamError {
+    fn from(error: super::errors::Error) -> Self {
+        CreateStreamError::new(CreateStreamErrorKind::JetStreamError(error))
+    }
+}
+
+impl From<RequestError> for CreateStreamError {
+    fn from(error: RequestError) -> Self {
+        match error.kind() {
+            RequestErrorKind::NoResponders => {
+                CreateStreamError::new(CreateStreamErrorKind::JetStreamUnavailable)
+            }
+            RequestErrorKind::TimedOut => CreateStreamError::new(CreateStreamErrorKind::TimedOut),
+            RequestErrorKind::Other => {
+                CreateStreamError::with_source(CreateStreamErrorKind::ResponseError, error)
+            }
+            RequestErrorKind::JetStream(err) => {
+                CreateStreamError::new(CreateStreamErrorKind::JetStreamError(err))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CreateStreamErrorKind {
+    EmptyStreamName,
+    InvalidStreamName,
+    DomainAndExternalSet,
+    JetStreamUnavailable,
+    JetStreamError(super::errors::Error),
+    TimedOut,
+    ResponseError,
+    ResponseParse,
+}
+
+#[derive(Debug)]
+pub struct GetStreamError {
+    kind: GetStreamErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+crate::error_impls!(GetStreamError, GetStreamErrorKind);
+
+impl Display for GetStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind() {
+            GetStreamErrorKind::EmptyName => write!(f, "empty name cannot be empty"),
+            GetStreamErrorKind::RequestError => {
+                write!(f, "request error: {}", self.format_source())
+            }
+            GetStreamErrorKind::JetStreamError(err) => write!(f, "jetstream error: {}", err),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GetStreamErrorKind {
+    EmptyName,
+    RequestError,
+    JetStreamError(super::errors::Error),
+}
+
+pub type UpdateStreamError = CreateStreamError;
+pub type UpdateStreamErrorKind = CreateStreamErrorKind;
+pub type DeleteStreamError = GetStreamError;
+pub type DeleteStreamErrorKind = GetStreamErrorKind;
+
+#[derive(Debug)]
+pub struct KeyValueError {
+    kind: KeyValueErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum KeyValueErrorKind {
+    InvalidStoreName,
+    FailedGetBucket,
+    JetStreamError,
+}
+
+crate::error_impls!(KeyValueError, KeyValueErrorKind);
+
+impl Display for KeyValueError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind() {
+            KeyValueErrorKind::InvalidStoreName => write!(f, "invalid Key Value Store name"),
+            KeyValueErrorKind::FailedGetBucket => write!(f, "failed to get the bucket"),
+            KeyValueErrorKind::JetStreamError => {
+                write!(f, "JetStream error: {}", self.format_source())
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CreateKeyValueError {
+    kind: CreateKeyValueErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CreateKeyValueErrorKind {
+    InvalidStoreName,
+    TooLongHistory,
+    JetStreamError,
+    BucketCreationFailed,
+    TimedOut,
+}
+
+crate::error_impls!(CreateKeyValueError, CreateKeyValueErrorKind);
+
+impl Display for CreateKeyValueError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let source = self.format_source();
+        match self.kind() {
+            CreateKeyValueErrorKind::InvalidStoreName => write!(f, "invalid Key Value Store name"),
+            CreateKeyValueErrorKind::TooLongHistory => write!(f, "too long history"),
+            CreateKeyValueErrorKind::JetStreamError => {
+                write!(f, "JetStream error: {}", source)
+            }
+            CreateKeyValueErrorKind::BucketCreationFailed => {
+                write!(f, "bucket creation failed: {}", source)
+            }
+            CreateKeyValueErrorKind::TimedOut => write!(f, "timed out"),
+        }
+    }
+}
+
+pub type CreateObjectStoreError = CreateKeyValueError;
+pub type CreateObjectStoreErrorKind = CreateKeyValueErrorKind;
+
+#[derive(Debug)]
+pub struct ObjectStoreError {
+    kind: ObjectStoreErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+crate::error_impls!(ObjectStoreError, ObjectStoreErrorKind);
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ObjectStoreErrorKind {
+    InvalidBucketName,
+    FailedGetStore,
+}
+
+impl Display for ObjectStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind() {
+            ObjectStoreErrorKind::InvalidBucketName => {
+                write!(f, "invalid Object Store bucket name")
+            }
+            ObjectStoreErrorKind::FailedGetStore => write!(f, "failed to get Object Store"),
+        }
+    }
+}
+
+pub type DeleteObjectStore = ObjectStoreError;
+pub type DeleteObjectStoreKind = ObjectStoreErrorKind;

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -1010,7 +1010,7 @@ impl PublishAckFuture {
                     .map_err(|err| PublishError::with_source(PublishErrorKind::Other, err))?;
                 match response {
                     Response::Err { error } => match error.error_code() {
-                        ErrorCode::STREAM_WRONG_LAST_MSG_ID => Err(PublishError::with_source(
+                        ErrorCode::STREAM_WRONG_LAST_MESSAGE_ID => Err(PublishError::with_source(
                             PublishErrorKind::WrongLastMessageId,
                             error,
                         )),

--- a/async-nats/src/jetstream/errors.rs
+++ b/async-nats/src/jetstream/errors.rs
@@ -26,7 +26,7 @@ impl ErrorCode {
     pub const CONSUMER_EPHEMERAL_WITH_DURABLE: ErrorCode = ErrorCode(10019);
 
     /// Stream external delivery prefix overlaps with stream subject
-    pub const STREAM_EXTERNAL_DEL_PREFIX_OVERLAPS: ErrorCode = ErrorCode(10022);
+    pub const STREAM_EXTERNAL_DELETE_PREFIX_OVERLAPS: ErrorCode = ErrorCode(10022);
 
     /// Resource limits exceeded for account
     pub const ACCOUNT_RESOURCES_EXCEEDED: ErrorCode = ErrorCode(10002);
@@ -125,7 +125,7 @@ impl ErrorCode {
     pub const STREAM_SEQUENCE_NOT_MATCH: ErrorCode = ErrorCode(10063);
 
     /// Wrong last msg id
-    pub const STREAM_WRONG_LAST_MSG_ID: ErrorCode = ErrorCode(10070);
+    pub const STREAM_WRONG_LAST_MESSAGE_ID: ErrorCode = ErrorCode(10070);
 
     /// Jetstream unable to open temp storage for restore
     pub const TEMP_STORAGE_FAILED: ErrorCode = ErrorCode(10072);

--- a/async-nats/src/jetstream/errors.rs
+++ b/async-nats/src/jetstream/errors.rs
@@ -1,0 +1,476 @@
+// Copyright 2020-2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize)]
+pub struct ErrorCode(u64);
+
+impl ErrorCode {
+    /// Peer not a member
+    pub const CLUSTER_PEER_NOT_MEMBER: ErrorCode = ErrorCode(10040);
+
+    /// Consumer expected to be ephemeral but detected a durable name set in subject
+    pub const CONSUMER_EPHEMERAL_WITH_DURABLE: ErrorCode = ErrorCode(10019);
+
+    /// Stream external delivery prefix overlaps with stream subject
+    pub const STREAM_EXTERNAL_DEL_PREFIX_OVERLAPS: ErrorCode = ErrorCode(10022);
+
+    /// Resource limits exceeded for account
+    pub const ACCOUNT_RESOURCES_EXCEEDED: ErrorCode = ErrorCode(10002);
+
+    /// Jetstream system temporarily unavailable
+    pub const CLUSTER_NOT_AVAILABLE: ErrorCode = ErrorCode(10008);
+
+    /// Subjects overlap with an existing stream
+    pub const STREAM_SUBJECT_OVERLAP: ErrorCode = ErrorCode(10065);
+
+    /// Wrong last sequence
+    pub const STREAM_WRONG_LAST_SEQUENCE: ErrorCode = ErrorCode(10071);
+
+    /// Template name in subject does not match request
+    pub const NAME_NOT_MATCH_SUBJECT: ErrorCode = ErrorCode(10073);
+
+    /// No suitable peers for placement
+    pub const CLUSTER_NO_PEERS: ErrorCode = ErrorCode(10005);
+
+    /// Consumer expected to be ephemeral but a durable name was set in request
+    pub const CONSUMER_EPHEMERAL_WITH_DURABLE_NAME: ErrorCode = ErrorCode(10020);
+
+    /// Insufficient resources
+    pub const INSUFFICIENT_RESOURCES: ErrorCode = ErrorCode(10023);
+
+    /// Stream mirror must have max message size >= source
+    pub const MIRROR_MAX_MESSAGE_SIZE_TOO_BIG: ErrorCode = ErrorCode(10030);
+
+    /// Generic error from stream deletion operation
+    pub const STREAM_DELETE_FAILED: ErrorCode = ErrorCode(10067);
+
+    /// Bad request
+    pub const BAD_REQUEST: ErrorCode = ErrorCode(10003);
+
+    /// Not currently supported in clustered mode
+    pub const NOT_SUPPORTED_IN_CLUSTER_MODE: ErrorCode = ErrorCode(10036);
+
+    /// Consumer not found
+    pub const CONSUMER_NOT_FOUND: ErrorCode = ErrorCode(10014);
+
+    /// Stream source must have max message size >= target
+    pub const SOURCE_MAX_MESSAGE_SIZE_TOO_BIG: ErrorCode = ErrorCode(10046);
+
+    /// Generic error when stream operation fails.
+    pub const STREAM_ASSIGNMENT: ErrorCode = ErrorCode(10048);
+
+    /// Message size exceeds maximum allowed
+    pub const STREAM_MESSAGE_EXCEEDS_MAXIMUM: ErrorCode = ErrorCode(10054);
+
+    /// Generic error for stream creation error with a string
+    pub const STREAM_CREATE_TEMPLATE: ErrorCode = ErrorCode(10066);
+
+    /// Invalid JSON
+    pub const INVALID_JSON: ErrorCode = ErrorCode(10025);
+
+    /// Stream external delivery prefix must not contain wildcards
+    pub const STREAM_INVALID_EXTERNAL_DELIVERY_SUBJECT: ErrorCode = ErrorCode(10024);
+
+    /// Restore failed
+    pub const STREAM_RESTORE: ErrorCode = ErrorCode(10062);
+
+    /// Incomplete results
+    pub const CLUSTER_INCOMPLETE: ErrorCode = ErrorCode(10004);
+
+    /// Account not found
+    pub const NO_ACCOUNT: ErrorCode = ErrorCode(10035);
+
+    /// General RAFT error
+    pub const RAFT_GENERAL: ErrorCode = ErrorCode(10041);
+
+    /// Jetstream unable to subscribe to restore snapshot     
+    pub const RESTORE_SUBSCRIBE_FAILED: ErrorCode = ErrorCode(10042);
+
+    /// Stream deletion failed
+    pub const STREAM_DELETE: ErrorCode = ErrorCode(10050);
+
+    /// Stream external api prefix must not overlap
+    pub const STREAM_EXTERNAL_API_OVERLAP: ErrorCode = ErrorCode(10021);
+
+    /// Stream mirrors can not contain subjects
+    pub const MIRROR_WITH_SUBJECTS: ErrorCode = ErrorCode(10034);
+
+    /// Jetstream not enabled
+    pub const JETSTREAM_NOT_ENABLED: ErrorCode = ErrorCode(10076);
+
+    /// Jetstream not enabled for account
+    pub const JETSTREAM_NOT_ENABLED_FOR_ACCOUNT: ErrorCode = ErrorCode(10039);
+
+    /// Sequence not found
+    pub const SEQUENCE_NOT_FOUND: ErrorCode = ErrorCode(10043);
+
+    /// Stream mirror configuration can not be updated
+    pub const STREAM_MIRROR_NOT_UPDATABLE: ErrorCode = ErrorCode(10055);
+
+    /// Expected stream sequence does not match
+    pub const STREAM_SEQUENCE_NOT_MATCH: ErrorCode = ErrorCode(10063);
+
+    /// Wrong last msg id
+    pub const STREAM_WRONG_LAST_MSG_ID: ErrorCode = ErrorCode(10070);
+
+    /// Jetstream unable to open temp storage for restore
+    pub const TEMP_STORAGE_FAILED: ErrorCode = ErrorCode(10072);
+
+    /// Insufficient storage resources available
+    pub const STORAGE_RESOURCES_EXCEEDED: ErrorCode = ErrorCode(10047);
+
+    /// Stream name in subject does not match request
+    pub const STREAM_MISMATCH: ErrorCode = ErrorCode(10056);
+
+    /// Expected stream does not match
+    pub const STREAM_NOT_MATCH: ErrorCode = ErrorCode(10060);
+
+    /// Setting up consumer mirror failed
+    pub const MIRROR_CONSUMER_SETUP_FAILED: ErrorCode = ErrorCode(10029);
+
+    /// Expected an empty request payload
+    pub const NOT_EMPTY_REQUEST: ErrorCode = ErrorCode(10038);
+
+    /// Stream name already in use with a different configuration
+    pub const STREAM_NAME_EXIST: ErrorCode = ErrorCode(10058);
+
+    /// Tags placement not supported for operation
+    pub const CLUSTER_TAGS: ErrorCode = ErrorCode(10011);
+
+    /// Maximum consumers limit reached
+    pub const MAXIMUM_CONSUMERS_LIMIT: ErrorCode = ErrorCode(10026);
+
+    /// General source consumer setup failure
+    pub const SOURCE_CONSUMER_SETUP_FAILED: ErrorCode = ErrorCode(10045);
+
+    /// Consumer creation failed
+    pub const CONSUMER_CREATE: ErrorCode = ErrorCode(10012);
+
+    /// Consumer expected to be durable but no durable name set in subject
+    pub const CONSUMER_DURABLE_NAME_NOT_IN_SUBJECT: ErrorCode = ErrorCode(10016);
+
+    /// Stream limits error
+    pub const STREAM_LIMITS: ErrorCode = ErrorCode(10053);
+
+    /// Replicas configuration can not be updated
+    pub const STREAM_REPLICAS_NOT_UPDATABLE: ErrorCode = ErrorCode(10061);
+
+    /// Template not found
+    pub const STREAM_TEMPLATE_NOT_FOUND: ErrorCode = ErrorCode(10068);
+
+    /// Jetstream cluster not assigned to this server
+    pub const CLUSTER_NOT_ASSIGNED: ErrorCode = ErrorCode(10007);
+
+    /// Jetstream cluster can't handle request
+    pub const CLUSTER_NOT_LEADER: ErrorCode = ErrorCode(10009);
+
+    /// Consumer name already in use
+    pub const CONSUMER_NAME_EXIST: ErrorCode = ErrorCode(10013);
+
+    /// Stream mirrors can't also contain other sources
+    pub const MIRROR_WITH_SOURCES: ErrorCode = ErrorCode(10031);
+
+    /// Stream not found
+    pub const STREAM_NOT_FOUND: ErrorCode = ErrorCode(10059);
+
+    /// Jetstream clustering support required
+    pub const CLUSTER_REQUIRED: ErrorCode = ErrorCode(10010);
+
+    /// Consumer expected to be durable but a durable name was not set
+    pub const CONSUMER_DURABLE_NAME_NOT_SET: ErrorCode = ErrorCode(10018);
+
+    /// Maximum number of streams reached
+    pub const MAXIMUM_STREAMS_LIMIT: ErrorCode = ErrorCode(10027);
+
+    /// Stream mirrors can not have both start seq and start time configured
+    pub const MIRROR_WITH_START_SEQ_AND_TIME: ErrorCode = ErrorCode(10032);
+
+    /// Stream snapshot failed
+    pub const STREAM_SNAPSHOT: ErrorCode = ErrorCode(10064);
+
+    /// Stream update failed
+    pub const STREAM_UPDATE: ErrorCode = ErrorCode(10069);
+
+    /// Jetstream not in clustered mode
+    pub const CLUSTER_NOT_ACTIVE: ErrorCode = ErrorCode(10006);
+
+    /// Consumer name in subject does not match durable name in request
+    pub const CONSUMER_DURABLE_NAME_NOT_MATCH_SUBJECT: ErrorCode = ErrorCode(10017);
+
+    /// Insufficient memory resources available
+    pub const MEMORY_RESOURCES_EXCEEDED: ErrorCode = ErrorCode(10028);
+
+    /// Stream mirrors can not contain filtered subjects
+    pub const MIRROR_WITH_SUBJECT_FILTERS: ErrorCode = ErrorCode(10033);
+
+    /// Stream create failed with a string
+    pub const STREAM_CREATE: ErrorCode = ErrorCode(10049);
+
+    /// Server is not a member of the cluster
+    pub const CLUSTER_SERVER_NOT_MEMBER: ErrorCode = ErrorCode(10044);
+
+    /// No message found
+    pub const NO_MESSAGE_FOUND: ErrorCode = ErrorCode(10037);
+
+    /// Deliver subject not valid
+    pub const SNAPSHOT_DELIVER_SUBJECT_INVALID: ErrorCode = ErrorCode(10015);
+
+    /// General stream failure
+    pub const STREAM_GENERALOR: ErrorCode = ErrorCode(10051);
+
+    /// Invalid stream config
+    pub const STREAM_INVALID_CONFIG: ErrorCode = ErrorCode(10052);
+
+    /// Replicas > 1 not supported in non-clustered mode
+    pub const STREAM_REPLICAS_NOT_SUPPORTED: ErrorCode = ErrorCode(10074);
+
+    /// Stream message delete failed
+    pub const STREAM_MESSAGE_DELETE_FAILED: ErrorCode = ErrorCode(10057);
+
+    /// Peer remap failed
+    pub const PEER_REMAP: ErrorCode = ErrorCode(10075);
+
+    /// Stream store failed
+    pub const STREAM_STORE_FAILED: ErrorCode = ErrorCode(10077);
+
+    /// Consumer config required
+    pub const CONSUMER_CONFIG_REQUIRED: ErrorCode = ErrorCode(10078);
+
+    /// Consumer deliver subject has wildcards
+    pub const CONSUMER_DELIVER_TO_WILDCARDS: ErrorCode = ErrorCode(10079);
+
+    /// Consumer in push mode can not set max waiting
+    pub const CONSUMER_PUSH_MAX_WAITING: ErrorCode = ErrorCode(10080);
+
+    /// Consumer deliver subject forms a cycle
+    pub const CONSUMER_DELIVER_CYCLE: ErrorCode = ErrorCode(10081);
+
+    /// Consumer requires ack policy for max ack pending
+    pub const CONSUMER_MAX_PENDING_ACK_POLICY_REQUIRED: ErrorCode = ErrorCode(10082);
+
+    /// Consumer idle heartbeat needs to be >= 100ms
+    pub const CONSUMER_SMALL_HEARTBEAT: ErrorCode = ErrorCode(10083);
+
+    /// Consumer in pull mode requires ack policy
+    pub const CONSUMER_PULL_REQUIRES_ACK: ErrorCode = ErrorCode(10084);
+
+    /// Consumer in pull mode requires a durable name
+    pub const CONSUMER_PULL_NOT_DURABLE: ErrorCode = ErrorCode(10085);
+
+    /// Consumer in pull mode can not have rate limit set
+    pub const CONSUMER_PULL_WITH_RATE_LIMIT: ErrorCode = ErrorCode(10086);
+
+    /// Consumer max waiting needs to be positive
+    pub const CONSUMER_MAX_WAITING_NEGATIVE: ErrorCode = ErrorCode(10087);
+
+    /// Consumer idle heartbeat requires a push based consumer
+    pub const CONSUMER_HEARTBEAT_REQUIRES_PUSH: ErrorCode = ErrorCode(10088);
+
+    /// Consumer flow control requires a push based consumer
+    pub const CONSUMER_FC_REQUIRES_PUSH: ErrorCode = ErrorCode(10089);
+
+    /// Consumer direct requires a push based consumer
+    pub const CONSUMER_DIRECT_REQUIRES_PUSH: ErrorCode = ErrorCode(10090);
+
+    /// Consumer direct requires an ephemeral consumer
+    pub const CONSUMER_DIRECT_REQUIRES_EPHEMERAL: ErrorCode = ErrorCode(10091);
+
+    /// Consumer direct on a mapped consumer
+    pub const CONSUMER_ON_MAPPED: ErrorCode = ErrorCode(10092);
+
+    /// Consumer filter subject is not a valid subset of the interest subjects
+    pub const CONSUMER_FILTER_NOT_SUBSET: ErrorCode = ErrorCode(10093);
+
+    /// Invalid consumer policy
+    pub const CONSUMER_INVALID_POLICY: ErrorCode = ErrorCode(10094);
+
+    /// Failed to parse consumer sampling configuration
+    pub const CONSUMER_INVALID_SAMPLING: ErrorCode = ErrorCode(10095);
+
+    /// Stream not valid
+    pub const STREAM_INVALID: ErrorCode = ErrorCode(10096);
+
+    /// Workqueue stream requires explicit ack
+    pub const CONSUMER_WQ_REQUIRES_EXPLICIT_ACK: ErrorCode = ErrorCode(10098);
+
+    /// Multiple non-filtered consumers not allowed on workqueue stream
+    pub const CONSUMER_WQ_MULTIPLE_UNFILTERED: ErrorCode = ErrorCode(10099);
+
+    /// Filtered consumer not unique on workqueue stream
+    pub const CONSUMER_WQ_CONSUMER_NOT_UNIQUE: ErrorCode = ErrorCode(10100);
+
+    /// Consumer must be deliver all on workqueue stream
+    pub const CONSUMER_WQ_CONSUMER_NOT_DELIVER_ALL: ErrorCode = ErrorCode(10101);
+
+    /// Consumer name is too long
+    pub const CONSUMER_NAME_TOO_LONG: ErrorCode = ErrorCode(10102);
+
+    /// Durable name can not contain token separators and wildcards
+    pub const CONSUMER_BAD_DURABLE_NAME: ErrorCode = ErrorCode(10103);
+
+    /// Error creating store for consumer
+    pub const CONSUMER_STORE_FAILED: ErrorCode = ErrorCode(10104);
+
+    /// Consumer already exists and is still active
+    pub const CONSUMER_EXISTING_ACTIVE: ErrorCode = ErrorCode(10105);
+
+    /// Consumer replacement durable config not the same
+    pub const CONSUMER_REPLACEMENT_WITH_DIFFERENT_NAME: ErrorCode = ErrorCode(10106);
+
+    /// Consumer description is too long
+    pub const CONSUMER_DESCRIPTION_TOO_LONG: ErrorCode = ErrorCode(10107);
+
+    /// Header size exceeds maximum allowed of 64k
+    pub const STREAM_HEADER_EXCEEDS_MAXIMUM: ErrorCode = ErrorCode(10097);
+
+    /// Consumer with flow control also needs heartbeats
+    pub const CONSUMER_WITH_FLOW_CONTROL_NEEDS_HEARTBEATS: ErrorCode = ErrorCode(10108);
+
+    /// Invalid operation on sealed stream
+    pub const STREAM_SEALED: ErrorCode = ErrorCode(10109);
+
+    /// Stream purge failed
+    pub const STREAM_PURGE_FAILED: ErrorCode = ErrorCode(10110);
+
+    /// Stream rollup failed
+    pub const STREAM_ROLLUP_FAILED: ErrorCode = ErrorCode(10111);
+
+    /// Invalid push consumer deliver subject
+    pub const CONSUMER_INVALID_DELIVER_SUBJECT: ErrorCode = ErrorCode(10112);
+
+    /// Account requires a stream config to have max bytes set
+    pub const STREAM_MAX_BYTES_REQUIRED: ErrorCode = ErrorCode(10113);
+
+    /// Consumer max request batch needs to be > 0
+    pub const CONSUMER_MAX_REQUEST_BATCH_NEGATIVE: ErrorCode = ErrorCode(10114);
+
+    /// Consumer max request expires needs to be >= 1ms
+    pub const CONSUMER_MAX_REQUEST_EXPIRES_TO_SMALL: ErrorCode = ErrorCode(10115);
+
+    /// Max deliver is required to be > length of backoff values
+    pub const CONSUMER_MAX_DELIVER_BACKOFF: ErrorCode = ErrorCode(10116);
+
+    /// Subject details would exceed maximum allowed
+    pub const STREAM_INFO_MAX_SUBJECTS: ErrorCode = ErrorCode(10117);
+
+    /// Stream is offline
+    pub const STREAM_OFFLINE: ErrorCode = ErrorCode(10118);
+
+    /// Consumer is offline
+    pub const CONSUMER_OFFLINE: ErrorCode = ErrorCode(10119);
+
+    /// No jetstream default or applicable tiered limit present
+    pub const NO_LIMITS: ErrorCode = ErrorCode(10120);
+
+    /// Consumer max ack pending exceeds system limit
+    pub const CONSUMER_MAX_PENDING_ACK_EXCESS: ErrorCode = ErrorCode(10121);
+
+    /// Stream max bytes exceeds account limit max stream bytes
+    pub const STREAM_MAX_STREAM_BYTES_EXCEEDED: ErrorCode = ErrorCode(10122);
+
+    /// Can not move and scale a stream in a single update
+    pub const STREAM_MOVE_AND_SCALE: ErrorCode = ErrorCode(10123);
+
+    /// Stream move already in progress
+    pub const STREAM_MOVE_IN_PROGRESS: ErrorCode = ErrorCode(10124);
+
+    /// Consumer max request batch exceeds server limit
+    pub const CONSUMER_MAX_REQUEST_BATCH_EXCEEDED: ErrorCode = ErrorCode(10125);
+
+    /// Consumer config replica count exceeds parent stream
+    pub const CONSUMER_REPLICAS_EXCEEDS_STREAM: ErrorCode = ErrorCode(10126);
+
+    /// Consumer name can not contain path separators
+    pub const CONSUMER_NAME_CONTAINS_PATH_SEPARATORS: ErrorCode = ErrorCode(10127);
+
+    /// Stream name can not contain path separators
+    pub const STREAM_NAME_CONTAINS_PATH_SEPARATORS: ErrorCode = ErrorCode(10128);
+
+    /// Stream move not in progress
+    pub const STREAM_MOVE_NOT_IN_PROGRESS: ErrorCode = ErrorCode(10129);
+
+    /// Stream name already in use, cannot restore
+    pub const STREAM_NAME_EXIST_RESTORE_FAILED: ErrorCode = ErrorCode(10130);
+
+    /// Consumer create request did not match filtered subject from create subject
+    pub const CONSUMER_CREATE_FILTER_SUBJECT_MISMATCH: ErrorCode = ErrorCode(10131);
+
+    /// Consumer durable and name have to be equal if both are provided
+    pub const CONSUMER_CREATE_DURABLE_AND_NAME_MISMATCH: ErrorCode = ErrorCode(10132);
+
+    /// Replicas count cannot be negative
+    pub const REPLICAS_COUNT_CANNOT_BE_NEGATIVE: ErrorCode = ErrorCode(10133);
+
+    /// Consumer config replicas must match interest retention stream's replicas
+    pub const CONSUMER_REPLICAS_SHOULD_MATCH_STREAM: ErrorCode = ErrorCode(10134);
+
+    /// Consumer metadata exceeds maximum size
+    pub const CONSUMER_METADATA_LENGTH: ErrorCode = ErrorCode(10135);
+
+    /// Consumer cannot have both filter_subject and filter_subjects specified
+    pub const CONSUMER_DUPLICATE_FILTER_SUBJECTS: ErrorCode = ErrorCode(10136);
+
+    /// Consumer with multiple subject filters cannot use subject based api
+    pub const CONSUMER_MULTIPLE_FILTERS_NOT_ALLOWED: ErrorCode = ErrorCode(10137);
+
+    /// Consumer subject filters cannot overlap
+    pub const CONSUMER_OVERLAPPING_SUBJECT_FILTERS: ErrorCode = ErrorCode(10138);
+
+    /// Consumer filter in filter_subjects cannot be empty
+    pub const CONSUMER_EMPTY_FILTER: ErrorCode = ErrorCode(10139);
+
+    /// Duplicate source configuration detected
+    pub const SOURCE_DUPLICATE_DETECTED: ErrorCode = ErrorCode(10140);
+}
+
+/// `Error` type returned from an API response when an error occurs.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Error {
+    code: usize,
+    err_code: ErrorCode,
+    description: Option<String>,
+}
+
+impl Error {
+    /// Returns the status code associated with this error
+    pub fn code(&self) -> usize {
+        self.code
+    }
+
+    /// Returns the server side error code associated with this error.
+    pub fn error_code(&self) -> ErrorCode {
+        self.err_code
+    }
+
+    pub fn kind(&self) -> ErrorCode {
+        self.err_code
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            fmt,
+            "{} (code {}, error code {})",
+            self.code,
+            self.description.as_ref().unwrap_or(&"unknown".to_string()),
+            self.err_code.0,
+        )
+    }
+}
+
+impl error::Error for Error {}

--- a/async-nats/src/jetstream/errors.rs
+++ b/async-nats/src/jetstream/errors.rs
@@ -197,7 +197,7 @@ impl ErrorCode {
     pub const MAXIMUM_STREAMS_LIMIT: ErrorCode = ErrorCode(10027);
 
     /// Stream mirrors can not have both start seq and start time configured
-    pub const MIRROR_WITH_START_SEQ_AND_TIME: ErrorCode = ErrorCode(10032);
+    pub const MIRROR_WITH_START_SEQUENCE_AND_TIME: ErrorCode = ErrorCode(10032);
 
     /// Stream snapshot failed
     pub const STREAM_SNAPSHOT: ErrorCode = ErrorCode(10064);
@@ -281,7 +281,7 @@ impl ErrorCode {
     pub const CONSUMER_HEARTBEAT_REQUIRES_PUSH: ErrorCode = ErrorCode(10088);
 
     /// Consumer flow control requires a push based consumer
-    pub const CONSUMER_FC_REQUIRES_PUSH: ErrorCode = ErrorCode(10089);
+    pub const CONSUMER_FLOW_CONTROL_REQUIRES_PUSH: ErrorCode = ErrorCode(10089);
 
     /// Consumer direct requires a push based consumer
     pub const CONSUMER_DIRECT_REQUIRES_PUSH: ErrorCode = ErrorCode(10090);

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -315,7 +315,6 @@ impl Store {
                         Some((message.message, operation, sequence, created))
                     }
                     Err(err) => {
-                        println!("ERROR FOR DIRECT GET: {:?}", err);
                         if err.kind() == DirectGetErrorKind::NotFound {
                             None
                         } else {

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -28,13 +28,13 @@ use regex::Regex;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::debug;
 
-use crate::{header, jetstream::response, Error, Message};
+use crate::{header, Error, Message};
 
 use self::bucket::Status;
 
 use super::{
     consumer::DeliverPolicy,
-    stream::{RawMessage, Republish, Source, StorageType, Stream},
+    stream::{DirectGetErrorKind, RawMessage, Republish, Source, StorageType, Stream},
 };
 
 // Helper to extract key value operation from message headers
@@ -315,11 +315,11 @@ impl Store {
                         Some((message.message, operation, sequence, created))
                     }
                     Err(err) => {
-                        let e: std::io::Error = *err.downcast().unwrap();
-                        if e.kind() == ErrorKind::NotFound {
+                        println!("ERROR FOR DIRECT GET: {:?}", err);
+                        if err.kind() == DirectGetErrorKind::NotFound {
                             None
                         } else {
-                            return Err(Box::new(e));
+                            return Err(Box::new(err));
                         }
                     }
                 }
@@ -340,17 +340,13 @@ impl Store {
                             raw_message.time,
                         ))
                     }
-                    Err(err) => {
-                        let e: std::io::Error = *err.downcast().unwrap();
-                        let d = e.get_ref().unwrap();
-                        let de = d.downcast_ref::<response::Error>().unwrap();
-                        // 10037 is returned when there are no messages found.
-                        if de.code == 10037 {
-                            None
-                        } else {
-                            return Err(Box::new(e));
+                    Err(err) => match err.kind() {
+                        crate::jetstream::stream::LastRawMessageErrorKind::NoMessageFound => None,
+                        crate::jetstream::stream::LastRawMessageErrorKind::Other
+                        | crate::jetstream::stream::LastRawMessageErrorKind::JetStreamError => {
+                            return Err(Box::new(err))
                         }
-                    }
+                    },
                 }
             }
         };
@@ -588,6 +584,7 @@ impl Store {
             .await?
             .await
             .map(|publish_ack| publish_ack.sequence)
+            .map_err(|err| Box::from(std::io::Error::new(ErrorKind::Other, err)))
     }
 
     /// Deletes a given key. This is a non-destructive operation, which sets a `DELETE` marker.

--- a/async-nats/src/jetstream/mod.rs
+++ b/async-nats/src/jetstream/mod.rs
@@ -132,6 +132,7 @@ use crate::Client;
 pub mod account;
 pub mod consumer;
 pub mod context;
+pub mod errors;
 pub mod kv;
 pub mod message;
 pub mod object_store;

--- a/async-nats/src/jetstream/mod.rs
+++ b/async-nats/src/jetstream/mod.rs
@@ -132,7 +132,7 @@ use crate::Client;
 pub mod account;
 pub mod consumer;
 pub mod context;
-pub mod errors;
+mod errors;
 pub mod kv;
 pub mod message;
 pub mod object_store;
@@ -141,6 +141,8 @@ pub mod response;
 pub mod stream;
 
 pub use context::Context;
+pub use errors::Error;
+pub use errors::ErrorCode;
 pub use message::{AckKind, Message};
 
 /// Creates a new JetStream [Context] that provides JetStream API for managing and using [Streams][crate::jetstream::stream::Stream],

--- a/async-nats/src/jetstream/response.rs
+++ b/async-nats/src/jetstream/response.rs
@@ -13,41 +13,12 @@
 
 //! A low level `JetStream` responses.
 
-use core::fmt;
-
 use serde::Deserialize;
-
-/// An error description returned in a response to a jetstream request.
-#[derive(Debug, Deserialize)]
-pub struct Error {
-    /// Error code
-    #[serde(rename = "err_code")]
-    pub code: u64,
-
-    /// Status code
-    #[serde(rename = "code")]
-    pub status: u16,
-
-    /// Description
-    pub description: String,
-}
-
-impl std::error::Error for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "JetStream response error code: {}, status: {}, description: {}",
-            self.code, self.status, self.description
-        )
-    }
-}
 
 /// A response returned from a request to jetstream.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum Response<T> {
-    Err { error: Error },
+    Err { error: super::errors::Error },
     Ok(T),
 }

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1318,6 +1318,8 @@ macro_rules! error_impls {
             pub(crate) fn new(kind: $k) -> $t {
                 Self { kind, source: None }
             }
+            #[allow(dead_code)]
+            #[allow(unreachable_pub)]
             pub(crate) fn with_source<S>(kind: $k, source: S) -> $t
             where
                 S: Into<Box<dyn std::error::Error + Sync + Send>>,

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1314,6 +1314,7 @@ macro_rules! error_impls {
     ($t:ty, $k:ty) => {
         impl $t {
             #[allow(dead_code)]
+            #[allow(unreachable_pub)]
             pub(crate) fn new(kind: $k) -> $t {
                 Self { kind, source: None }
             }
@@ -1327,6 +1328,7 @@ macro_rules! error_impls {
                 }
             }
             #[allow(dead_code)]
+            #[allow(unreachable_pub)]
             pub fn kind(&self) -> $k {
                 // ALmost all `kind` types implement `Copy`, so it's almost always copy.
                 // We need to clone, as some more complex one may have nested other errors, that
@@ -1334,6 +1336,7 @@ macro_rules! error_impls {
                 self.kind.clone()
             }
             #[allow(dead_code)]
+            #[allow(unreachable_pub)]
             pub(crate) fn format_source(&self) -> String {
                 self.source
                     .as_ref()


### PR DESCRIPTION
TODO:
- [x] add test for nonexisting jetstream error
- [x] check if JetStreamError is literal tuple in enum where sensible
- [x] check if what is StreamsError can be JetstreamRequestError (aggregating both request errors and response errors)
- [x] self-review