### PR TITLE
Prefer returning `&str` over String where applicable

### DIFF
--- a/async-nats/src/jetstream/kv/bucket.rs
+++ b/async-nats/src/jetstream/kv/bucket.rs
@@ -24,7 +24,7 @@ pub struct Status {
 
 impl Status {
     /// The name of the bucket
-    pub fn bucket(&self) -> &String {
+    pub fn bucket(&self) -> &str {
         &self.bucket
     }
 

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1243,18 +1243,18 @@ impl ServerAddr {
     }
 
     /// Returns the optional username in the url.
-    pub fn username(&self) -> Option<String> {
+    pub fn username(&self) -> Option<&str> {
         let user = self.0.username();
         if user.is_empty() {
             None
         } else {
-            Some(user.to_string())
+            Some(user)
         }
     }
 
     /// Returns the optional password in the url.
-    pub fn password(&self) -> Option<String> {
-        self.0.password().map(|pwd| pwd.to_string())
+    pub fn password(&self) -> Option<&str> {
+        self.0.password()
     }
 
     /// Return the sockets from resolving the server address.


### PR DESCRIPTION
Split out of #876 because of breaking changes to the public API