### PR TITLE
Use `MissedTickBehavior::Skip` for flush interval

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -118,7 +118,7 @@ use std::slice;
 use std::str::{self, FromStr};
 use std::task::{Context, Poll};
 use tokio::io::ErrorKind;
-use tokio::time::{interval, Duration, Interval};
+use tokio::time::{interval, Duration, Interval, MissedTickBehavior};
 use url::{Host, Url};
 
 use bytes::Bytes;
@@ -316,7 +316,8 @@ impl ConnectionHandler {
         flush_period: Duration,
     ) -> ConnectionHandler {
         let ping_interval = interval(ping_period);
-        let flush_interval = interval(flush_period);
+        let mut flush_interval = interval(flush_period);
+        flush_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         ConnectionHandler {
             connection,


### PR DESCRIPTION
Partially addresses https://github.com/nats-io/nats.rs/issues/875

As suggested by @caspervonb I'll split this into multiple PRs.