### PR TITLE
Reset `ping_interval` when handling `Command::Ping`

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -511,6 +511,7 @@ impl ConnectionHandler {
                     self.pending_pings, self.max_pings
                 );
                 self.pending_pings += 1;
+                self.ping_interval.reset();
 
                 if self.pending_pings > self.max_pings {
                     debug!(


### PR DESCRIPTION
Resets `ping_interval` for `Command::Ping`