### PR TITLE
Use `BoxedFuture` where applicable

### DIFF
--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -19,6 +19,7 @@ use crate::jetstream::publish::PublishAck;
 use crate::jetstream::response::Response;
 use crate::{header, Client, Command, Error, HeaderMap, HeaderValue, StatusCode};
 use bytes::Bytes;
+use futures::future::BoxFuture;
 use futures::{Future, StreamExt, TryFutureExt};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -947,17 +948,17 @@ struct StreamInfoPage {
     streams: Option<Vec<super::stream::Info>>,
 }
 
-type PageRequest = Pin<Box<dyn Future<Output = Result<StreamPage, Error>>>>;
+type PageRequest<'a> = BoxFuture<'a, Result<StreamPage, Error>>;
 
-pub struct StreamNames {
+pub struct StreamNames<'a> {
     context: Context,
     offset: usize,
-    page_request: Option<PageRequest>,
+    page_request: Option<PageRequest<'a>>,
     streams: Vec<String>,
     done: bool,
 }
 
-impl futures::Stream for StreamNames {
+impl futures::Stream for StreamNames<'_> {
     type Item = Result<String, Error>;
 
     fn poll_next(
@@ -1017,17 +1018,17 @@ impl futures::Stream for StreamNames {
     }
 }
 
-type PageInfoRequest = Pin<Box<dyn Future<Output = Result<StreamInfoPage, Error>>>>;
+type PageInfoRequest<'a> = BoxFuture<'a, Result<StreamInfoPage, Error>>;
 
-pub struct Streams {
+pub struct Streams<'a> {
     context: Context,
     offset: usize,
-    page_request: Option<PageInfoRequest>,
+    page_request: Option<PageInfoRequest<'a>>,
     streams: Vec<super::stream::Info>,
     done: bool,
 }
 
-impl futures::Stream for Streams {
+impl futures::Stream for Streams<'_> {
     type Item = Result<super::stream::Info, Error>;
 
     fn poll_next(

--- a/async-nats/src/service/mod.rs
+++ b/async-nats/src/service/mod.rs
@@ -279,7 +279,7 @@ pub trait ServiceExt {
 }
 
 impl ServiceExt for crate::Client {
-    type Output = Pin<Box<dyn Future<Output = Result<Service, crate::Error>>>>;
+    type Output = Pin<Box<dyn Future<Output = Result<Service, crate::Error>> + Send>>;
 
     fn add_service(&self, config: Config) -> Self::Output {
         let client = self.clone();


### PR DESCRIPTION
Replaces `Pin<Box<dyn Future<Output = T> + Send>` with [BoxedFuture](https://docs.rs/futures/latest/futures/future/type.BoxFuture.html) where applicable.

Should also address issue: https://github.com/nats-io/nats.rs/issues/846