### PR TITLE
Remove outdated `actions-rs` github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,17 +88,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
-      - name: Set up rust
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
 
-      - name: Check format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+      - name: Run the check
+        run: cargo fmt -- --check
 
   check_lint:
     name: check (lint)
@@ -118,17 +114,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: clippy
-          override: true
 
       - name: Check lint
-        uses: actions-rs/cargo@v1
-        with:
-          args: --benches --tests --examples --all-features -- --deny clippy::all
-          command: clippy
+        run: cargo clippy --benches --tests --examples --all-features -- --deny clippy::all
   
   check_docs:
     name: check (docs)
@@ -148,16 +140,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: clippy
-          override: true
 
-      - name: Check docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
+      - name: Check lint
+        run: cargo doc
 
   check_licenses:
     name: check (licenses)
@@ -226,6 +215,7 @@ jobs:
         run: |
           rustup update
           cargo check --examples
+
   check_spelling:
       name: check (spelling)
       runs-on: ubuntu-latest
@@ -243,22 +233,15 @@ jobs:
           uses: actions/checkout@v2
 
         - name: Set up rust
-          uses: actions-rs/toolchain@v1
+          uses: dtolnay/rust-toolchain@stable
           with:
             toolchain: nightly
-            override: true
 
         - name: Install llvm-config
           run: sudo apt-get install -y libclang-dev
 
         - name: Install cargo spellcheck
-          uses: actions-rs/cargo@v1
-          with:
-            args: cargo-spellcheck
-            command: install
+          run: cargo install cargo-spellcheck
 
         - name: Check spelling
-          uses: actions-rs/cargo@v1
-          with:
-            command: spellcheck
-            args: --code 1
+          run: cargo spellcheck --code 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Set up go
+      - name: Setup Rust
+        run: rustup install stable
+
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: '1.19'
@@ -89,9 +92,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+        run: rustup install stable
 
       - name: Run the check
         run: cargo fmt -- --check
@@ -114,10 +115,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: clippy
+        run: |
+          rustup install stable
+          rustup component add clippy
 
       - name: Check lint
         run: cargo clippy --benches --tests --examples --all-features -- --deny clippy::all
@@ -140,10 +140,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: clippy
+        run: |
+          rustup install stable
+          rustup component add clippy
 
       - name: Check lint
         run: cargo doc
@@ -233,9 +232,7 @@ jobs:
           uses: actions/checkout@v2
 
         - name: Set up rust
-          uses: dtolnay/rust-toolchain@stable
-          with:
-            toolchain: nightly
+          run: rustup install nightly
 
         - name: Install llvm-config
           run: sudo apt-get install -y libclang-dev


### PR DESCRIPTION
As actions-rs/toolchain@v1 is no longer maintained and will break soon, we're moving to dtolnay/rust-toolchain@stable

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>
