### PR TITLE
Implement `fmt::Display` for `HeaderName`

### DIFF
--- a/async-nats/src/header.rs
+++ b/async-nats/src/header.rs
@@ -14,7 +14,7 @@
 //! NATS [Message][crate::Message] headers, leveraging [http::header] crate.
 // pub use http::header::{HeaderMap, HeaderName, HeaderValue};
 
-use std::{collections::HashMap, slice, str::FromStr};
+use std::{collections::HashMap, fmt, slice, str::FromStr};
 
 use serde::Serialize;
 
@@ -308,6 +308,12 @@ impl FromStr for HeaderName {
         Ok(HeaderName {
             value: s.to_string(),
         })
+    }
+}
+
+impl fmt::Display for HeaderName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.value, f)
     }
 }
 


### PR DESCRIPTION
Implements `fmt::Display` for `HeaderName`, which in turn provides a blanket implementation for `ToString`.