### PR TITLE
Fix serialization of `ObjectInfo` fields

### DIFF
--- a/nats/src/object_store.rs
+++ b/nats/src/object_store.rs
@@ -215,11 +215,12 @@ pub struct ObjectInfo {
     /// Number of chunks the object is stored in.
     pub chunks: usize,
     /// Date and time the object was last modified.
-    #[serde(with = "rfc3339")]
+    #[serde(with = "rfc3339", rename = "mtime")]
     pub modified: DateTime,
     /// Digest of the object stream.
     pub digest: String,
     /// Set to true if the object has been deleted.
+    #[serde(default)]
     pub deleted: bool,
 }
 

--- a/nats/tests/object_store.rs
+++ b/nats/tests/object_store.rs
@@ -207,6 +207,29 @@ fn object_names() {
 }
 
 #[test]
+fn object_info_modified() {
+    let server = nats_server::run_server("tests/configs/jetstream.conf");
+    let client = nats::connect(server.client_url()).unwrap();
+    let context = nats::jetstream::new(client);
+
+    let bucket = context
+        .create_object_store(&nats::object_store::Config {
+            bucket: "NAMES".to_string(),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let empty = Vec::new();
+
+    bucket.put("foo.bar", &mut empty.as_slice()).unwrap();
+
+    let info = bucket.info("foo.bar").unwrap();
+
+    // Make sure that modified is set
+    assert!(info.modified.unix_timestamp_nanos() > 0);
+}
+
+#[test]
 fn object_watch() {
     let server = nats_server::run_server("tests/configs/jetstream.conf");
     let client = nats::connect(server.client_url()).unwrap();


### PR DESCRIPTION
Renames the `modified` field to `mtime` for the legacy NATS client.