### PR TITLE
Canonicalize `header::NATS_LAST_STREAM`

### DIFF
--- a/async-nats/src/header.rs
+++ b/async-nats/src/header.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, fmt, slice, str::FromStr};
 
 use serde::Serialize;
 
-pub const NATS_LAST_STREAM: &str = "nats-last-stream";
+pub const NATS_LAST_STREAM: &str = "Nats-Last-Stream";
 pub const NATS_LAST_CONSUMER: &str = "Nats-Last-Consumer";
 
 /// Direct Get headers


### PR DESCRIPTION
Closes #947 