### PR TITLE
Make `ClientOp` private

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -264,7 +264,7 @@ pub enum Command {
 
 /// `ClientOp` represents all actions of `Client`.
 #[derive(Debug)]
-pub enum ClientOp {
+pub(crate) enum ClientOp {
     Publish {
         subject: String,
         payload: Bytes,


### PR DESCRIPTION
This type is just used internally to communicate with the internal connection handler and not publicly useful to anyone.