### PR TITLE
Derive `Clone` for `Message`

### DIFF
--- a/async-nats/src/jetstream/message.rs
+++ b/async-nats/src/jetstream/message.rs
@@ -20,7 +20,7 @@ use futures::StreamExt;
 use std::time::Duration;
 use time::OffsetDateTime;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Message {
     pub message: crate::Message,
     pub context: Context,

--- a/async-nats/src/message.rs
+++ b/async-nats/src/message.rs
@@ -17,7 +17,7 @@ use crate::status::StatusCode;
 use bytes::Bytes;
 
 /// A Core NATS message.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Message {
     /// Subject to which message is published to.
     pub subject: String,


### PR DESCRIPTION
To have ability to send a message via channels like [tokio::sync::broadcast](https://docs.rs/tokio/latest/tokio/sync/broadcast/fn.channel.html).