### PR TITLE
Bump `actions/checkout` to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache rust
         uses: actions/cache@v3
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Rust
         run: |
@@ -115,7 +115,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up rust
         run: |
@@ -139,7 +139,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up rust
         run: |
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@v1
@@ -177,7 +177,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check minimum supported rust Version
         run: |
@@ -201,7 +201,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up go
         uses: actions/setup-go@v2
@@ -233,7 +233,7 @@ jobs:
             restore-keys: |
               ${{ runner.os }}-
         - name: Check out repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Set up rust
           run: |


### PR DESCRIPTION
GitHub was complaining about the action being out of date.