### PR TITLE
fix(ObjectStore): Fix compatibility issue with Go implementation

### DIFF
--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -893,6 +893,7 @@ impl Context {
                 num_replicas: config.num_replicas,
                 discard: DiscardPolicy::New,
                 allow_rollup: true,
+                allow_direct: true,
                 ..Default::default()
             })
             .await?;


### PR DESCRIPTION
When trying to share an object store between *Rust* & *Go*, it fails with `stream name already in use`. This is caused by a different configuration, here a missing `allow_direct`

Equivalent code in go :
https://github.com/nats-io/nats.go/blob/main/object.go#L282