### PR TITLE
feat(message): Makes `Message` serialize/deserialize

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["network-programming", "api-bindings"]
 
 [dependencies]
 memchr = "2.4"
-bytes = "1.4.0"
+bytes = { version = "1.4.0", features = ["serde"] }
 futures = { version = "0.3.26", default-features = false, features = ["std", "async-await"] }
 nkeys = "0.3.0"
 once_cell = "1.17.1"

--- a/async-nats/src/message.rs
+++ b/async-nats/src/message.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 The NATS Authors
+// Copyright 2020-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,12 +12,14 @@
 // limitations under the License.
 
 //! A Core NATS message.
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
 use crate::header::HeaderMap;
 use crate::status::StatusCode;
-use bytes::Bytes;
 
 /// A Core NATS message.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Message {
     /// Subject to which message is published to.
     pub subject: String,

--- a/async-nats/src/status.rs
+++ b/async-nats/src/status.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 The NATS Authors
+// Copyright 2020-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,6 +20,8 @@ use std::error::Error;
 use std::fmt;
 use std::num::NonZeroU16;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 
 /// A possible error value when converting a `StatusCode` from a `u16` or `&str`
 ///
@@ -63,7 +65,7 @@ impl InvalidStatusCode {
 /// assert_eq!(StatusCode::OK.as_u16(), 200);
 /// assert!(StatusCode::OK.is_success());
 /// ```
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct StatusCode(NonZeroU16);
 
 impl StatusCode {


### PR DESCRIPTION
This change makes it so an entire message can be serialized/deserialized via serde. Specifically, this addresses the use case of wanting to capture messages and write them to disk for later inspection and/or use