### PR TITLE
Fix KV update so that it works properly with a JS domain

### DIFF
--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -568,7 +568,13 @@ impl Store {
                 "invalid key",
             )));
         }
-        let subject = format!("{}{}", self.prefix.as_str(), key.as_ref());
+        let mut subject = String::new();
+        if self.use_jetstream_prefix {
+            subject.push_str(&self.stream.context.prefix);
+            subject.push('.');
+        }
+        subject.push_str(self.put_prefix.as_ref().unwrap_or(&self.prefix));
+        subject.push_str(key.as_ref());
 
         let mut headers = crate::HeaderMap::default();
         headers.insert(


### PR DESCRIPTION
It looks like the code for calling update on a KV bucket doesn't include the JS domain on it, so it gives you an error when attempting to make that call.