### PR TITLE
Make the current `Error` type work with anyhow

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -127,7 +127,7 @@ use tokio::io;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task;
 
-pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const LANG: &str = "rust";


### PR DESCRIPTION
This makes the `Error` type work with `anyhow` (and I guess a few more crates) that [need the error to be `'static`](https://docs.rs/anyhow/1.0.71/anyhow/struct.Error.html#impl-AsRef%3Cdyn+Error+%2B+Sync+%2B+Send+%2B+'static%3E-for-Error)