### PR TITLE
Drop subscription on object read done

### DIFF
--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -651,7 +651,7 @@ impl<'a> futures::Stream for Ordered<'a> {
                                                 }
                                             }
                                         }
-                                        if let Some(subject) = message.reply {
+                                        if let Some(subject) = message.reply.clone() {
                                             warn!("got message with reply subject for ordered consumer");
                                             // TODO store pending_publish as a future and return errors from it
                                             let client = self.context.client.clone();


### PR DESCRIPTION
A quick fix for ordered push consumer not being dropped as soon as object from Object Store is read.
`Object` might be valid for quite some time, so the subscription is running for no reason.