### PR TITLE
Take `impl AsRef<Path>` instead of `PathBuf` in credentials APIs

### DIFF
--- a/async-nats/src/auth_utils.rs
+++ b/async-nats/src/auth_utils.rs
@@ -14,12 +14,12 @@
 use nkeys::KeyPair;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::{io, path::PathBuf};
+use std::{io, path::Path};
 
 /// Loads user credentials file with jwt and key. Return file contents.
 /// Uses tokio non-blocking io
-pub(crate) async fn load_creds(path: PathBuf) -> io::Result<String> {
-    tokio::fs::read_to_string(&path).await.map_err(|err| {
+pub(crate) async fn load_creds(path: &Path) -> io::Result<String> {
+    tokio::fs::read_to_string(path).await.map_err(|err| {
         io::Error::new(
             io::ErrorKind::Other,
             format!("loading creds file '{}': {}", path.display(), err),

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -18,7 +18,13 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::engine::Engine;
 use futures::Future;
 use std::fmt::Formatter;
-use std::{fmt, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
 use tokio::io;
 use tokio_rustls::rustls;
 
@@ -405,15 +411,15 @@ impl ConnectOptions {
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::ConnectError> {
-    /// let nc = async_nats::ConnectOptions::with_credentials_file("path/to/my.creds".into())
+    /// let nc = async_nats::ConnectOptions::with_credentials_file("path/to/my.creds")
     ///     .await?
     ///     .connect("connect.ngs.global")
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn with_credentials_file(path: PathBuf) -> io::Result<Self> {
-        let cred_file_contents = crate::auth_utils::load_creds(path).await?;
+    pub async fn with_credentials_file(path: impl AsRef<Path>) -> io::Result<Self> {
+        let cred_file_contents = crate::auth_utils::load_creds(path.as_ref()).await?;
         Self::with_credentials(&cred_file_contents)
     }
 
@@ -426,15 +432,15 @@ impl ConnectOptions {
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::ConnectError> {
     /// let nc = async_nats::ConnectOptions::new()
-    ///     .credentials_file("path/to/my.creds".into())
+    ///     .credentials_file("path/to/my.creds")
     ///     .await?
     ///     .connect("connect.ngs.global")
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn credentials_file(self, path: PathBuf) -> io::Result<Self> {
-        let cred_file_contents = crate::auth_utils::load_creds(path).await?;
+    pub async fn credentials_file(self, path: impl AsRef<Path>) -> io::Result<Self> {
+        let cred_file_contents = crate::auth_utils::load_creds(path.as_ref()).await?;
         self.credentials(&cred_file_contents)
     }
 


### PR DESCRIPTION
I don't know if this is documented anywhere but this is the style used by all APIs that deal with the filesystem. Sometimes it even gets used when a `PathBuf` would have been the better choice when it comes to heap allocations, because it's nicer to use.

The reason why this is the preferred method is that [a bunch of things implement `AsRef<Path>`](https://doc.rust-lang.org/nightly/std/path/struct.Path.html#trait-implementations), including `&str`, so it avoids the manual cast to `&Path` or memcpy to `PathBuf`.