### PR TITLE
Depend directly on rustls

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.25.0", features = ["macros", "rt", "fs", "net", "sync", "
 itoa = "1"
 url = { version = "2"}
 tokio-rustls = "0.24"
+rustls = "0.21.5"
 rustls-pemfile = "1.0.2"
 nuid = "0.3.2"
 serde_nanos = "0.1.3"

--- a/async-nats/src/tls.rs
+++ b/async-nats/src/tls.rs
@@ -13,10 +13,10 @@
 
 use crate::connector::ConnectorOptions;
 use crate::tls;
+use rustls::{self, Certificate, OwnedTrustAnchor, PrivateKey};
 use std::fs::File;
 use std::io::{self, BufReader, ErrorKind};
 use std::path::PathBuf;
-use tokio_rustls::rustls::{self, Certificate, OwnedTrustAnchor, PrivateKey};
 use webpki::TrustAnchor;
 
 /// Loads client certificates from a `.pem` file.
@@ -63,7 +63,7 @@ pub(crate) async fn load_key(path: PathBuf) -> io::Result<PrivateKey> {
 }
 
 pub(crate) async fn config_tls(options: &ConnectorOptions) -> io::Result<rustls::ClientConfig> {
-    let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
+    let mut root_store = rustls::RootCertStore::empty();
     // load native system certs only if user did not specify them.
     if options.tls_client_config.is_some() || options.certificates.is_empty() {
         root_store.add_parsable_certificates(


### PR DESCRIPTION
Until now, we did depend on tokio-rustls re-export of rustls.
Re-export is ^0.21.0, so patch releases are allowed.

However, as rustls released 0.21.4, it introduced
a breaking change in patch release, breaking the async-nats client build.

To avoid that in the future, we do not use re-export, but bind directly to rustls explicit version.

When rustls reaches 1.0.0, we can reconsider binding to ^1.0.0.

Related issues: #1017 #1018 


Signed-off-by: Tomasz Pietrek <tomasz@nats.io>