### PR TITLE
Mark `pull_sequence` as a slow test

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1154,6 +1154,7 @@ mod jetstream {
             .unwrap();
     }
 
+    #[cfg(feature = "slow_tests")]
     #[tokio::test]
     async fn pull_sequence() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");


### PR DESCRIPTION
This tests takes 40 minutes on my Linux machine and is very slow on my mac (M2) as well.