### PR TITLE
Remove error on lint warnings for legacy client

### DIFF
--- a/async-nats/src/service/mod.rs
+++ b/async-nats/src/service/mod.rs
@@ -694,7 +694,7 @@ impl Request {
         let elapsed = self.issued.elapsed();
         let mut stats = self.stats.lock().unwrap();
         // let mut stats = stats.endpoints.entry(key)
-        let mut stats = stats.endpoints.get_mut(self.endpoint.as_str()).unwrap();
+        let stats = stats.endpoints.get_mut(self.endpoint.as_str()).unwrap();
         stats.requests += 1;
         stats.processing_time += elapsed;
         stats.average_processing_time = stats.processing_time.checked_div(2).unwrap();

--- a/nats/src/lib.rs
+++ b/nats/src/lib.rs
@@ -187,7 +187,9 @@
     clippy::wildcard_enum_match_arm,
     clippy::module_name_repetitions
 )]
-
+// As this is a deprecated client, we don't want warnings from new lints to make CI red.
+#![allow(clippy::all)]
+#![allow(warnings)]
 /// Async-enabled NATS client.
 pub mod asynk;
 

--- a/nats/src/lib.rs
+++ b/nats/src/lib.rs
@@ -114,7 +114,6 @@
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(test, deny(warnings))]
 #![cfg_attr(
     feature = "fault_injection",
     deny(


### PR DESCRIPTION
 Signed-off-by: Tomasz Pietrek <tomasz@nats.io>