### PR TITLE
[Refactoring] Use a generic error type instead of the macro `error_impls`

### DIFF
--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -621,19 +621,19 @@ pub enum RequestErrorKind {
     Other,
 }
 
-/// Error returned when a core NATS request fails.
-/// To be enumerate over the variants, call [RequestError::kind].
-pub type RequestError = NatsError<RequestErrorKind>;
-
-impl Display for RequestError {
+impl Display for RequestErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            RequestErrorKind::TimedOut => write!(f, "request timed out"),
-            RequestErrorKind::NoResponders => write!(f, "no responders"),
-            RequestErrorKind::Other => write!(f, "request failed: {:?}", self.kind),
+        match self {
+            Self::TimedOut => write!(f, "request timed out"),
+            Self::NoResponders => write!(f, "no responders"),
+            Self::Other => write!(f, "request failed"),
         }
     }
 }
+
+/// Error returned when a core NATS request fails.
+/// To be enumerate over the variants, call [RequestError::kind].
+pub type RequestError = NatsError<RequestErrorKind>;
 
 impl From<PublishError> for RequestError {
     fn from(e: PublishError) -> Self {
@@ -657,18 +657,13 @@ pub enum FlushErrorKind {
     FlushError,
 }
 
-pub type FlushError = NatsError<FlushErrorKind>;
-
-impl Display for FlushError {
+impl Display for FlushErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let source_info = self
-            .source
-            .as_ref()
-            .map(|e| e.to_string())
-            .unwrap_or_else(|| "no details".into());
-        match self.kind {
-            FlushErrorKind::SendError => write!(f, "failed to send flush request: {}", source_info),
-            FlushErrorKind::FlushError => write!(f, "flush failed: {}", source_info),
+        match self {
+            Self::SendError => write!(f, "failed to send flush request"),
+            Self::FlushError => write!(f, "flush failed"),
         }
     }
 }
+
+pub type FlushError = NatsError<FlushErrorKind>;

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -15,7 +15,7 @@ use crate::connection::State;
 use crate::ServerInfo;
 
 use super::{header::HeaderMap, status::StatusCode, Command, Message, Subscriber};
-use crate::nats_error::NatsError;
+use crate::error::Error;
 use bytes::Bytes;
 use futures::future::TryFutureExt;
 use futures::stream::StreamExt;
@@ -633,7 +633,7 @@ impl Display for RequestErrorKind {
 
 /// Error returned when a core NATS request fails.
 /// To be enumerate over the variants, call [RequestError::kind].
-pub type RequestError = NatsError<RequestErrorKind>;
+pub type RequestError = Error<RequestErrorKind>;
 
 impl From<PublishError> for RequestError {
     fn from(e: PublishError) -> Self {
@@ -666,4 +666,4 @@ impl Display for FlushErrorKind {
     }
 }
 
-pub type FlushError = NatsError<FlushErrorKind>;
+pub type FlushError = Error<FlushErrorKind>;

--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -26,9 +26,8 @@ use time::serde::rfc3339;
 use super::context::RequestError;
 use super::stream::ClusterInfo;
 use super::Context;
+use crate::error::Error;
 use crate::jetstream::consumer;
-use crate::nats_error::NatsError;
-use crate::Error;
 
 pub trait IntoConsumerConfig {
     fn into_consumer_config(self) -> Config;
@@ -120,7 +119,9 @@ impl<T: IntoConsumerConfig> Consumer<T> {
 /// [Push][crate::jetstream::consumer::push::Config] config. It validates if given config is
 /// a valid target one.
 pub trait FromConsumer {
-    fn try_from_consumer_config(config: crate::jetstream::consumer::Config) -> Result<Self, Error>
+    fn try_from_consumer_config(
+        config: crate::jetstream::consumer::Config,
+    ) -> Result<Self, crate::Error>
     where
         Self: Sized;
 }
@@ -344,7 +345,7 @@ impl IntoConsumerConfig for &Config {
 }
 
 impl FromConsumer for Config {
-    fn try_from_consumer_config(config: Config) -> Result<Self, Error>
+    fn try_from_consumer_config(config: Config) -> Result<Self, crate::Error>
     where
         Self: Sized,
     {
@@ -442,4 +443,4 @@ impl std::fmt::Display for StreamErrorKind {
     }
 }
 
-pub type StreamError = NatsError<StreamErrorKind>;
+pub type StreamError = Error<StreamErrorKind>;

--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -433,13 +433,13 @@ pub enum StreamErrorKind {
     Other,
 }
 
-pub type StreamError = NatsError<StreamErrorKind>;
-
-impl std::fmt::Display for StreamError {
+impl std::fmt::Display for StreamErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind() {
-            StreamErrorKind::TimedOut => write!(f, "timed out"),
-            StreamErrorKind::Other => write!(f, "failed: {}", self.format_source()),
+        match self {
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Other => write!(f, "failed"),
         }
     }
 }
+
+pub type StreamError = NatsError<StreamErrorKind>;

--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -27,6 +27,7 @@ use super::context::RequestError;
 use super::stream::ClusterInfo;
 use super::Context;
 use crate::jetstream::consumer;
+use crate::nats_error::NatsError;
 use crate::Error;
 
 pub trait IntoConsumerConfig {
@@ -426,12 +427,13 @@ fn is_default<T: Default + Eq>(t: &T) -> bool {
     t == &T::default()
 }
 
-#[derive(Debug)]
-pub struct StreamError {
-    kind: StreamErrorKind,
-    source: Option<crate::Error>,
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum StreamErrorKind {
+    TimedOut,
+    Other,
 }
-crate::error_impls!(StreamError, StreamErrorKind);
+
+pub type StreamError = NatsError<StreamErrorKind>;
 
 impl std::fmt::Display for StreamError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -440,10 +442,4 @@ impl std::fmt::Display for StreamError {
             StreamErrorKind::Other => write!(f, "failed: {}", self.format_source()),
         }
     }
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub enum StreamErrorKind {
-    TimedOut,
-    Other,
 }

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -2175,7 +2175,7 @@ pub enum BatchErrorKind {
 impl std::fmt::Display for BatchErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Pull => write!(f, "pull request failed:"),
+            Self::Pull => write!(f, "pull request failed"),
             Self::Flush => write!(f, "flush failed"),
             Self::Serialize => write!(f, "serialize failed"),
             Self::Subscribe => write!(f, "subscribe failed"),

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -27,15 +27,15 @@ use tracing::{debug, trace};
 
 use crate::{
     connection::State,
+    error::Error,
     jetstream::{self, Context},
-    Error, StatusCode, SubscribeError, Subscriber,
+    StatusCode, SubscribeError, Subscriber,
 };
 
 use super::{
     AckPolicy, Consumer, DeliverPolicy, FromConsumer, IntoConsumerConfig, ReplayPolicy,
     StreamError, StreamErrorKind,
 };
-use crate::nats_error::NatsError;
 use jetstream::consumer;
 
 impl Consumer<Config> {
@@ -366,7 +366,7 @@ impl<'a> Batch {
 }
 
 impl futures::Stream for Batch {
-    type Item = Result<jetstream::Message, Error>;
+    type Item = Result<jetstream::Message, crate::Error>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -672,7 +672,9 @@ impl From<OrderedConfig> for Config {
 }
 
 impl FromConsumer for OrderedConfig {
-    fn try_from_consumer_config(config: crate::jetstream::consumer::Config) -> Result<Self, Error>
+    fn try_from_consumer_config(
+        config: crate::jetstream::consumer::Config,
+    ) -> Result<Self, crate::Error>
     where
         Self: Sized,
     {
@@ -977,7 +979,7 @@ impl std::fmt::Display for OrderedErrorKind {
     }
 }
 
-pub type OrderedError = NatsError<OrderedErrorKind>;
+pub type OrderedError = Error<OrderedErrorKind>;
 
 impl From<MessagesError> for OrderedError {
     fn from(err: MessagesError) -> Self {
@@ -1024,7 +1026,7 @@ impl std::fmt::Display for MessagesErrorKind {
     }
 }
 
-pub type MessagesError = NatsError<MessagesErrorKind>;
+pub type MessagesError = Error<MessagesErrorKind>;
 
 impl futures::Stream for Stream {
     type Item = Result<jetstream::Message, MessagesError>;
@@ -2106,7 +2108,7 @@ impl IntoConsumerConfig for Config {
     }
 }
 impl FromConsumer for Config {
-    fn try_from_consumer_config(config: consumer::Config) -> Result<Self, Error> {
+    fn try_from_consumer_config(config: consumer::Config) -> Result<Self, crate::Error> {
         if config.deliver_subject.is_some() {
             return Err(Box::new(std::io::Error::new(
                 std::io::ErrorKind::Other,
@@ -2160,7 +2162,7 @@ impl std::fmt::Display for BatchRequestErrorKind {
     }
 }
 
-pub type BatchRequestError = NatsError<BatchRequestErrorKind>;
+pub type BatchRequestError = Error<BatchRequestErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BatchErrorKind {
@@ -2181,7 +2183,7 @@ impl std::fmt::Display for BatchErrorKind {
     }
 }
 
-pub type BatchError = NatsError<BatchErrorKind>;
+pub type BatchError = Error<BatchErrorKind>;
 
 impl From<SubscribeError> for BatchError {
     fn from(err: SubscribeError) -> Self {
@@ -2212,7 +2214,7 @@ impl std::fmt::Display for ConsumerRecreateErrorKind {
     }
 }
 
-pub type ConsumerRecreateError = NatsError<ConsumerRecreateErrorKind>;
+pub type ConsumerRecreateError = Error<ConsumerRecreateErrorKind>;
 
 async fn recreate_consumer_stream(
     context: Context,

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -964,22 +964,20 @@ pub enum OrderedErrorKind {
     Other,
 }
 
-pub type OrderedError = NatsError<OrderedErrorKind>;
-
-impl std::fmt::Display for OrderedError {
+impl std::fmt::Display for OrderedErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind() {
-            OrderedErrorKind::MissingHeartbeat => write!(f, "missed idle heartbeat"),
-            OrderedErrorKind::ConsumerDeleted => write!(f, "consumer deleted"),
-            OrderedErrorKind::Pull => {
-                write!(f, "pull request failed: {}", self.format_source())
-            }
-            OrderedErrorKind::Other => write!(f, "error: {}", self.format_source()),
-            OrderedErrorKind::PushBasedConsumer => write!(f, "cannot use with push consumer"),
-            OrderedErrorKind::Recreate => write!(f, "consumer recreation failed"),
+        match self {
+            Self::MissingHeartbeat => write!(f, "missed idle heartbeat"),
+            Self::ConsumerDeleted => write!(f, "consumer deleted"),
+            Self::Pull => write!(f, "pull request failed"),
+            Self::Other => write!(f, "error"),
+            Self::PushBasedConsumer => write!(f, "cannot use with push consumer"),
+            Self::Recreate => write!(f, "consumer recreation failed"),
         }
     }
 }
+
+pub type OrderedError = NatsError<OrderedErrorKind>;
 
 impl From<MessagesError> for OrderedError {
     fn from(err: MessagesError) -> Self {
@@ -1014,21 +1012,19 @@ pub enum MessagesErrorKind {
     Other,
 }
 
-pub type MessagesError = NatsError<MessagesErrorKind>;
-
-impl std::fmt::Display for MessagesError {
+impl std::fmt::Display for MessagesErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind() {
-            MessagesErrorKind::MissingHeartbeat => write!(f, "missed idle heartbeat"),
-            MessagesErrorKind::ConsumerDeleted => write!(f, "consumer deleted"),
-            MessagesErrorKind::Pull => {
-                write!(f, "pull request failed: {}", self.format_source())
-            }
-            MessagesErrorKind::Other => write!(f, "error: {}", self.format_source()),
-            MessagesErrorKind::PushBasedConsumer => write!(f, "cannot use with push consumer"),
+        match self {
+            Self::MissingHeartbeat => write!(f, "missed idle heartbeat"),
+            Self::ConsumerDeleted => write!(f, "consumer deleted"),
+            Self::Pull => write!(f, "pull request failed"),
+            Self::Other => write!(f, "error"),
+            Self::PushBasedConsumer => write!(f, "cannot use with push consumer"),
         }
     }
 }
+
+pub type MessagesError = NatsError<MessagesErrorKind>;
 
 impl futures::Stream for Stream {
     type Item = Result<jetstream::Message, MessagesError>;
@@ -2154,23 +2150,17 @@ pub enum BatchRequestErrorKind {
     Serialize,
 }
 
-pub type BatchRequestError = NatsError<BatchRequestErrorKind>;
-
-impl std::fmt::Display for BatchRequestError {
+impl std::fmt::Display for BatchRequestErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind() {
-            BatchRequestErrorKind::Publish => {
-                write!(f, "publish failed: {}", self.format_source())
-            }
-            BatchRequestErrorKind::Flush => {
-                write!(f, "flush failed: {}", self.format_source())
-            }
-            BatchRequestErrorKind::Serialize => {
-                write!(f, "serialize failed: {}", self.format_source())
-            }
+        match self {
+            Self::Publish => write!(f, "publish failed"),
+            Self::Flush => write!(f, "flush failed"),
+            Self::Serialize => write!(f, "serialize failed"),
         }
     }
 }
+
+pub type BatchRequestError = NatsError<BatchRequestErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BatchErrorKind {
@@ -2180,24 +2170,18 @@ pub enum BatchErrorKind {
     Serialize,
 }
 
-pub type BatchError = NatsError<BatchErrorKind>;
-
-impl std::fmt::Display for BatchError {
+impl std::fmt::Display for BatchErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind() {
-            BatchErrorKind::Pull => {
-                write!(f, "pull request failed: {}", self.format_source())
-            }
-            BatchErrorKind::Flush => {
-                write!(f, "flush failed: {}", self.format_source())
-            }
-            BatchErrorKind::Serialize => {
-                write!(f, "serialize failed: {}", self.format_source())
-            }
-            BatchErrorKind::Subscribe => write!(f, "subscribe failed: {}", self.format_source()),
+        match self {
+            Self::Pull => write!(f, "pull request failed:"),
+            Self::Flush => write!(f, "flush failed"),
+            Self::Serialize => write!(f, "serialize failed"),
+            Self::Subscribe => write!(f, "subscribe failed"),
         }
     }
 }
+
+pub type BatchError = NatsError<BatchErrorKind>;
 
 impl From<SubscribeError> for BatchError {
     fn from(err: SubscribeError) -> Self {
@@ -2218,21 +2202,17 @@ pub enum ConsumerRecreateErrorKind {
     TimedOut,
 }
 
-pub type ConsumerRecreateError = NatsError<ConsumerRecreateErrorKind>;
-
-impl std::fmt::Display for ConsumerRecreateError {
+impl std::fmt::Display for ConsumerRecreateErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind() {
-            ConsumerRecreateErrorKind::GetStream => {
-                write!(f, "error getting stream: {}", self.format_source())
-            }
-            ConsumerRecreateErrorKind::Recreate => {
-                write!(f, "consumer creation failed: {}", self.format_source())
-            }
-            ConsumerRecreateErrorKind::TimedOut => write!(f, "timed out"),
+        match self {
+            Self::GetStream => write!(f, "error getting stream"),
+            Self::Recreate => write!(f, "consumer creation failed"),
+            Self::TimedOut => write!(f, "timed out"),
         }
     }
 }
+
+pub type ConsumerRecreateError = NatsError<ConsumerRecreateErrorKind>;
 
 async fn recreate_consumer_stream(
     context: Context,

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -17,11 +17,11 @@ use super::{
 };
 use crate::{
     connection::State,
+    error::Error,
     jetstream::{self, Context, Message},
-    Error, StatusCode, Subscriber,
+    StatusCode, Subscriber,
 };
 
-use crate::nats_error::NatsError;
 use bytes::Bytes;
 use futures::{future::BoxFuture, FutureExt};
 use serde::{Deserialize, Serialize};
@@ -277,7 +277,7 @@ pub struct Config {
 }
 
 impl FromConsumer for Config {
-    fn try_from_consumer_config(config: super::Config) -> Result<Self, Error> {
+    fn try_from_consumer_config(config: super::Config) -> Result<Self, crate::Error> {
         if config.deliver_subject.is_none() {
             return Err(Box::new(io::Error::new(
                 ErrorKind::Other,
@@ -405,7 +405,9 @@ pub struct OrderedConfig {
 }
 
 impl FromConsumer for OrderedConfig {
-    fn try_from_consumer_config(config: crate::jetstream::consumer::Config) -> Result<Self, Error>
+    fn try_from_consumer_config(
+        config: crate::jetstream::consumer::Config,
+    ) -> Result<Self, crate::Error>
     where
         Self: Sized,
     {
@@ -758,7 +760,7 @@ impl std::fmt::Display for OrderedErrorKind {
     }
 }
 
-pub type OrderedError = NatsError<OrderedErrorKind>;
+pub type OrderedError = Error<OrderedErrorKind>;
 
 impl From<MessagesError> for OrderedError {
     fn from(err: MessagesError) -> Self {
@@ -799,7 +801,7 @@ impl std::fmt::Display for MessagesErrorKind {
     }
 }
 
-pub type MessagesError = NatsError<MessagesErrorKind>;
+pub type MessagesError = Error<MessagesErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ConsumerRecreateErrorKind {
@@ -820,7 +822,7 @@ impl std::fmt::Display for ConsumerRecreateErrorKind {
     }
 }
 
-pub type ConsumerRecreateError = NatsError<ConsumerRecreateErrorKind>;
+pub type ConsumerRecreateError = Error<ConsumerRecreateErrorKind>;
 
 async fn recreate_consumer_and_subscription(
     context: Context,

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -746,19 +746,19 @@ pub enum OrderedErrorKind {
     Other,
 }
 
-pub type OrderedError = NatsError<OrderedErrorKind>;
-
-impl std::fmt::Display for OrderedError {
+impl std::fmt::Display for OrderedErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind() {
-            OrderedErrorKind::MissingHeartbeat => write!(f, "missed idle heartbeat"),
-            OrderedErrorKind::ConsumerDeleted => write!(f, "consumer deleted"),
-            OrderedErrorKind::Other => write!(f, "error: {}", self.format_source()),
-            OrderedErrorKind::PullBasedConsumer => write!(f, "cannot use with push consumer"),
-            OrderedErrorKind::Recreate => write!(f, "consumer recreation failed"),
+        match self {
+            Self::MissingHeartbeat => write!(f, "missed idle heartbeat"),
+            Self::ConsumerDeleted => write!(f, "consumer deleted"),
+            Self::Other => write!(f, "error"),
+            Self::PullBasedConsumer => write!(f, "cannot use with push consumer"),
+            Self::Recreate => write!(f, "consumer recreation failed"),
         }
     }
 }
+
+pub type OrderedError = NatsError<OrderedErrorKind>;
 
 impl From<MessagesError> for OrderedError {
     fn from(err: MessagesError) -> Self {
@@ -780,7 +780,7 @@ impl From<MessagesError> for OrderedError {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MessagesErrorKind {
     MissingHeartbeat,
     ConsumerDeleted,
@@ -788,18 +788,18 @@ pub enum MessagesErrorKind {
     Other,
 }
 
-pub type MessagesError = NatsError<MessagesErrorKind>;
-
-impl std::fmt::Display for MessagesError {
+impl std::fmt::Display for MessagesErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind() {
-            MessagesErrorKind::MissingHeartbeat => write!(f, "missed idle heartbeat"),
-            MessagesErrorKind::ConsumerDeleted => write!(f, "consumer deleted"),
-            MessagesErrorKind::Other => write!(f, "error: {}", self.format_source()),
-            MessagesErrorKind::PullBasedConsumer => write!(f, "cannot use with pull consumer"),
+        match self {
+            Self::MissingHeartbeat => write!(f, "missed idle heartbeat"),
+            Self::ConsumerDeleted => write!(f, "consumer deleted"),
+            Self::Other => write!(f, "error"),
+            Self::PullBasedConsumer => write!(f, "cannot use with pull consumer"),
         }
     }
 }
+
+pub type MessagesError = NatsError<MessagesErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ConsumerRecreateErrorKind {
@@ -809,22 +809,18 @@ pub enum ConsumerRecreateErrorKind {
     TimedOut,
 }
 
-pub type ConsumerRecreateError = NatsError<ConsumerRecreateErrorKind>;
-
-impl std::fmt::Display for ConsumerRecreateError {
+impl std::fmt::Display for ConsumerRecreateErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind() {
-            ConsumerRecreateErrorKind::GetStream => {
-                write!(f, "error getting stream: {}", self.format_source())
-            }
-            ConsumerRecreateErrorKind::Recreate => {
-                write!(f, "consumer creation failed: {}", self.format_source())
-            }
-            ConsumerRecreateErrorKind::TimedOut => write!(f, "timed out"),
-            ConsumerRecreateErrorKind::Subscription => write!(f, "failed to resubscribe"),
+        match self {
+            Self::GetStream => write!(f, "error getting stream"),
+            Self::Recreate => write!(f, "consumer creation failed"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Subscription => write!(f, "failed to resubscribe"),
         }
     }
 }
+
+pub type ConsumerRecreateError = NatsError<ConsumerRecreateErrorKind>;
 
 async fn recreate_consumer_and_subscription(
     context: Context,

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -964,21 +964,20 @@ pub enum PublishErrorKind {
     Other,
 }
 
-pub type PublishError = NatsError<PublishErrorKind>;
-
-impl Display for PublishError {
+impl Display for PublishErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let source = self.format_source();
-        match self.kind {
-            PublishErrorKind::StreamNotFound => write!(f, "no stream found for given subject"),
-            PublishErrorKind::TimedOut => write!(f, "timed out: didn't receive ack in time"),
-            PublishErrorKind::Other => write!(f, "publish failed: {}", source),
-            PublishErrorKind::BrokenPipe => write!(f, "broken pipe"),
-            PublishErrorKind::WrongLastMessageId => write!(f, "wrong last message id"),
-            PublishErrorKind::WrongLastSequence => write!(f, "wrong last sequence"),
+        match self {
+            Self::StreamNotFound => write!(f, "no stream found for given subject"),
+            Self::TimedOut => write!(f, "timed out: didn't receive ack in time"),
+            Self::Other => write!(f, "publish failed"),
+            Self::BrokenPipe => write!(f, "broken pipe"),
+            Self::WrongLastMessageId => write!(f, "wrong last message id"),
+            Self::WrongLastSequence => write!(f, "wrong last sequence"),
         }
     }
 }
+
+pub type PublishError = NatsError<PublishErrorKind>;
 
 #[derive(Debug)]
 pub struct PublishAckFuture {
@@ -1260,20 +1259,17 @@ pub enum RequestErrorKind {
     Other,
 }
 
-pub type RequestError = NatsError<RequestErrorKind>;
-
-impl Display for RequestError {
+impl Display for RequestErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let source = self.format_source();
-        match &self.kind {
-            RequestErrorKind::TimedOut => write!(f, "timed out"),
-            RequestErrorKind::Other => write!(f, "request failed: {}", source),
-            RequestErrorKind::NoResponders => {
-                write!(f, "requested JetStream resource does not exist: {}", source)
-            }
+        match self {
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Other => write!(f, "request failed"),
+            Self::NoResponders => write!(f, "requested JetStream resource does not exist"),
         }
     }
 }
+
+pub type RequestError = NatsError<RequestErrorKind>;
 
 impl From<crate::RequestError> for RequestError {
     fn from(error: crate::RequestError) -> Self {
@@ -1309,30 +1305,22 @@ pub enum CreateStreamErrorKind {
     ResponseParse,
 }
 
-pub type CreateStreamError = NatsError<CreateStreamErrorKind>;
-
-impl Display for CreateStreamError {
+impl Display for CreateStreamErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind {
-            CreateStreamErrorKind::EmptyStreamName => write!(f, "stream name cannot be empty"),
-            CreateStreamErrorKind::InvalidStreamName => {
-                write!(f, "stream name cannot contain `.`, `_`")
-            }
-            CreateStreamErrorKind::DomainAndExternalSet => {
-                write!(f, "domain and external are both set")
-            }
-            CreateStreamErrorKind::JetStream(err) => {
-                write!(f, "jetstream error: {}", err)
-            }
-            CreateStreamErrorKind::TimedOut => write!(f, "jetstream request timed out"),
-            CreateStreamErrorKind::JetStreamUnavailable => write!(f, "jetstream unavailable"),
-            CreateStreamErrorKind::ResponseParse => write!(f, "failed to parse server response"),
-            CreateStreamErrorKind::Response => {
-                write!(f, "response error: {}", self.format_source())
-            }
+        match self {
+            Self::EmptyStreamName => write!(f, "stream name cannot be empty"),
+            Self::InvalidStreamName => write!(f, "stream name cannot contain `.`, `_`"),
+            Self::DomainAndExternalSet => write!(f, "domain and external are both set"),
+            Self::JetStream(err) => write!(f, "jetstream error: {}", err),
+            Self::TimedOut => write!(f, "jetstream request timed out"),
+            Self::JetStreamUnavailable => write!(f, "jetstream unavailable"),
+            Self::ResponseParse => write!(f, "failed to parse server response"),
+            Self::Response => write!(f, "response error"),
         }
     }
 }
+
+pub type CreateStreamError = NatsError<CreateStreamErrorKind>;
 
 impl From<super::errors::Error> for CreateStreamError {
     fn from(error: super::errors::Error) -> Self {
@@ -1361,19 +1349,17 @@ pub enum GetStreamErrorKind {
     JetStream(super::errors::Error),
 }
 
-pub type GetStreamError = NatsError<GetStreamErrorKind>;
-
-impl Display for GetStreamError {
+impl Display for GetStreamErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind() {
-            GetStreamErrorKind::EmptyName => write!(f, "empty name cannot be empty"),
-            GetStreamErrorKind::Request => {
-                write!(f, "request error: {}", self.format_source())
-            }
-            GetStreamErrorKind::JetStream(err) => write!(f, "jetstream error: {}", err),
+        match self {
+            Self::EmptyName => write!(f, "empty name cannot be empty"),
+            Self::Request => write!(f, "request error"),
+            Self::JetStream(err) => write!(f, "jetstream error: {}", err),
         }
     }
 }
+
+pub type GetStreamError = NatsError<GetStreamErrorKind>;
 
 pub type UpdateStreamError = CreateStreamError;
 pub type UpdateStreamErrorKind = CreateStreamErrorKind;
@@ -1387,19 +1373,17 @@ pub enum KeyValueErrorKind {
     JetStream,
 }
 
-pub type KeyValueError = NatsError<KeyValueErrorKind>;
-
-impl Display for KeyValueError {
+impl Display for KeyValueErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind() {
-            KeyValueErrorKind::InvalidStoreName => write!(f, "invalid Key Value Store name"),
-            KeyValueErrorKind::GetBucket => write!(f, "failed to get the bucket"),
-            KeyValueErrorKind::JetStream => {
-                write!(f, "JetStream error: {}", self.format_source())
-            }
+        match self {
+            Self::InvalidStoreName => write!(f, "invalid Key Value Store name"),
+            Self::GetBucket => write!(f, "failed to get the bucket"),
+            Self::JetStream => write!(f, "JetStream error"),
         }
     }
 }
+
+pub type KeyValueError = NatsError<KeyValueErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CreateKeyValueErrorKind {
@@ -1410,24 +1394,19 @@ pub enum CreateKeyValueErrorKind {
     TimedOut,
 }
 
-pub type CreateKeyValueError = NatsError<CreateKeyValueErrorKind>;
-
-impl Display for CreateKeyValueError {
+impl Display for CreateKeyValueErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let source = self.format_source();
-        match self.kind() {
-            CreateKeyValueErrorKind::InvalidStoreName => write!(f, "invalid Key Value Store name"),
-            CreateKeyValueErrorKind::TooLongHistory => write!(f, "too long history"),
-            CreateKeyValueErrorKind::JetStream => {
-                write!(f, "JetStream error: {}", source)
-            }
-            CreateKeyValueErrorKind::BucketCreate => {
-                write!(f, "bucket creation failed: {}", source)
-            }
-            CreateKeyValueErrorKind::TimedOut => write!(f, "timed out"),
+        match self {
+            Self::InvalidStoreName => write!(f, "invalid Key Value Store name"),
+            Self::TooLongHistory => write!(f, "too long history"),
+            Self::JetStream => write!(f, "JetStream error"),
+            Self::BucketCreate => write!(f, "bucket creation failed"),
+            Self::TimedOut => write!(f, "timed out"),
         }
     }
 }
+
+pub type CreateKeyValueError = NatsError<CreateKeyValueErrorKind>;
 
 pub type CreateObjectStoreError = CreateKeyValueError;
 pub type CreateObjectStoreErrorKind = CreateKeyValueErrorKind;
@@ -1438,18 +1417,16 @@ pub enum ObjectStoreErrorKind {
     GetStore,
 }
 
-pub type ObjectStoreError = NatsError<ObjectStoreErrorKind>;
-
-impl Display for ObjectStoreError {
+impl Display for ObjectStoreErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind() {
-            ObjectStoreErrorKind::InvalidBucketName => {
-                write!(f, "invalid Object Store bucket name")
-            }
-            ObjectStoreErrorKind::GetStore => write!(f, "failed to get Object Store"),
+        match self {
+            Self::InvalidBucketName => write!(f, "invalid Object Store bucket name"),
+            Self::GetStore => write!(f, "failed to get Object Store"),
         }
     }
 }
+
+pub type ObjectStoreError = NatsError<ObjectStoreErrorKind>;
 
 pub type DeleteObjectStore = ObjectStoreError;
 pub type DeleteObjectStoreKind = ObjectStoreErrorKind;
@@ -1462,18 +1439,18 @@ pub enum AccountErrorKind {
     Other,
 }
 
-pub type AccountError = NatsError<AccountErrorKind>;
-
-impl Display for AccountError {
+impl Display for AccountErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind {
-            AccountErrorKind::TimedOut => write!(f, "timed out"),
-            AccountErrorKind::JetStream(err) => write!(f, "JetStream error: {}", err),
-            AccountErrorKind::Other => write!(f, "error: {}", self.format_source()),
-            AccountErrorKind::JetStreamUnavailable => write!(f, "JetStream unavailable"),
+        match self {
+            Self::TimedOut => write!(f, "timed out"),
+            Self::JetStream(err) => write!(f, "JetStream error: {}", err),
+            Self::Other => write!(f, "error"),
+            Self::JetStreamUnavailable => write!(f, "JetStream unavailable"),
         }
     }
 }
+
+pub type AccountError = NatsError<AccountErrorKind>;
 
 impl From<RequestError> for AccountError {
     fn from(err: RequestError) -> Self {

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -13,11 +13,11 @@
 //
 //! Manage operations on [Context], create/delete/update [Stream][crate::jetstream::stream::Stream]
 
+use crate::error::Error;
 use crate::header::{IntoHeaderName, IntoHeaderValue};
 use crate::jetstream::account::Account;
 use crate::jetstream::publish::PublishAck;
 use crate::jetstream::response::Response;
-use crate::nats_error::NatsError;
 use crate::{header, Client, Command, HeaderMap, HeaderValue, StatusCode};
 use bytes::Bytes;
 use futures::future::BoxFuture;
@@ -724,7 +724,7 @@ impl Context {
             .await
     }
 
-    // pub async fn update_key_value<C: Borrow<kv::Config>>(&self, config: C) -> Result<(), Error> {
+    // pub async fn update_key_value<C: Borrow<kv::Config>>(&self, config: C) -> Result<(), crate::Error> {
     //     let config = config.borrow();
     //     if !crate::jetstream::kv::is_valid_bucket_name(&config.bucket) {
     //         return Err(Box::new(std::io::Error::new(
@@ -977,7 +977,7 @@ impl Display for PublishErrorKind {
     }
 }
 
-pub type PublishError = NatsError<PublishErrorKind>;
+pub type PublishError = Error<PublishErrorKind>;
 
 #[derive(Debug)]
 pub struct PublishAckFuture {
@@ -1269,7 +1269,7 @@ impl Display for RequestErrorKind {
     }
 }
 
-pub type RequestError = NatsError<RequestErrorKind>;
+pub type RequestError = Error<RequestErrorKind>;
 
 impl From<crate::RequestError> for RequestError {
     fn from(error: crate::RequestError) -> Self {
@@ -1320,7 +1320,7 @@ impl Display for CreateStreamErrorKind {
     }
 }
 
-pub type CreateStreamError = NatsError<CreateStreamErrorKind>;
+pub type CreateStreamError = Error<CreateStreamErrorKind>;
 
 impl From<super::errors::Error> for CreateStreamError {
     fn from(error: super::errors::Error) -> Self {
@@ -1359,7 +1359,7 @@ impl Display for GetStreamErrorKind {
     }
 }
 
-pub type GetStreamError = NatsError<GetStreamErrorKind>;
+pub type GetStreamError = Error<GetStreamErrorKind>;
 
 pub type UpdateStreamError = CreateStreamError;
 pub type UpdateStreamErrorKind = CreateStreamErrorKind;
@@ -1383,7 +1383,7 @@ impl Display for KeyValueErrorKind {
     }
 }
 
-pub type KeyValueError = NatsError<KeyValueErrorKind>;
+pub type KeyValueError = Error<KeyValueErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CreateKeyValueErrorKind {
@@ -1406,7 +1406,7 @@ impl Display for CreateKeyValueErrorKind {
     }
 }
 
-pub type CreateKeyValueError = NatsError<CreateKeyValueErrorKind>;
+pub type CreateKeyValueError = Error<CreateKeyValueErrorKind>;
 
 pub type CreateObjectStoreError = CreateKeyValueError;
 pub type CreateObjectStoreErrorKind = CreateKeyValueErrorKind;
@@ -1426,7 +1426,7 @@ impl Display for ObjectStoreErrorKind {
     }
 }
 
-pub type ObjectStoreError = NatsError<ObjectStoreErrorKind>;
+pub type ObjectStoreError = Error<ObjectStoreErrorKind>;
 
 pub type DeleteObjectStore = ObjectStoreError;
 pub type DeleteObjectStoreKind = ObjectStoreErrorKind;
@@ -1450,7 +1450,7 @@ impl Display for AccountErrorKind {
     }
 }
 
-pub type AccountError = NatsError<AccountErrorKind>;
+pub type AccountError = Error<AccountErrorKind>;
 
 impl From<RequestError> for AccountError {
     fn from(err: RequestError) -> Self {

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -29,6 +29,7 @@ use regex::Regex;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::debug;
 
+use crate::nats_error::NatsError;
 use crate::{header, Message};
 
 use self::bucket::Status;
@@ -1023,19 +1024,13 @@ pub struct Entry {
     pub operation: Operation,
 }
 
-#[derive(Debug)]
-pub struct StatusError {
-    kind: StatusErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum StatusErrorKind {
     JetStream(crate::jetstream::Error),
     TimedOut,
 }
 
-crate::error_impls!(StatusError, StatusErrorKind);
+pub type StatusError = NatsError<StatusErrorKind>;
 
 impl Display for StatusError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1048,20 +1043,14 @@ impl Display for StatusError {
     }
 }
 
-#[derive(Debug)]
-pub struct PutError {
-    kind: PutErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PutErrorKind {
     InvalidKey,
     Publish,
     Ack,
 }
 
-crate::error_impls!(PutError, PutErrorKind);
+pub type PutError = NatsError<PutErrorKind>;
 
 impl Display for PutError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1075,20 +1064,15 @@ impl Display for PutError {
     }
 }
 
-#[derive(Debug)]
-pub struct EntryError {
-    kind: EntryErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EntryErrorKind {
     InvalidKey,
     TimedOut,
     Other,
 }
 
-crate::error_impls!(EntryError, EntryErrorKind);
+pub type EntryError = NatsError<EntryErrorKind>;
+
 crate::from_with_timeout!(
     EntryError,
     EntryErrorKind,
@@ -1106,13 +1090,7 @@ impl Display for EntryError {
     }
 }
 
-#[derive(Debug)]
-pub struct WatchError {
-    kind: WatchErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WatchErrorKind {
     InvalidKey,
     TimedOut,
@@ -1120,7 +1098,8 @@ pub enum WatchErrorKind {
     Other,
 }
 
-crate::error_impls!(WatchError, WatchErrorKind);
+pub type WatchError = NatsError<WatchErrorKind>;
+
 crate::from_with_timeout!(WatchError, WatchErrorKind, ConsumerError, ConsumerErrorKind);
 crate::from_with_timeout!(WatchError, WatchErrorKind, StreamError, StreamErrorKind);
 
@@ -1141,20 +1120,15 @@ impl Display for WatchError {
     }
 }
 
-#[derive(Debug)]
-pub struct UpdateError {
-    kind: UpdateErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum UpdateErrorKind {
     InvalidKey,
     TimedOut,
     Other,
 }
 
-crate::error_impls!(UpdateError, UpdateErrorKind);
+pub type UpdateError = NatsError<UpdateErrorKind>;
+
 crate::from_with_timeout!(UpdateError, UpdateErrorKind, PublishError, PublishErrorKind);
 
 impl Display for UpdateError {
@@ -1167,17 +1141,13 @@ impl Display for UpdateError {
     }
 }
 
-#[derive(Debug)]
-pub struct WatcherError {
-    kind: WatcherErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WatcherErrorKind {
     Consumer,
     Other,
 }
+
+pub type WatcherError = NatsError<WatcherErrorKind>;
 
 impl Display for WatcherError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1189,8 +1159,6 @@ impl Display for WatcherError {
         }
     }
 }
-
-crate::error_impls!(WatcherError, WatcherErrorKind);
 
 impl From<OrderedError> for WatcherError {
     fn from(err: OrderedError) -> Self {

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -1030,18 +1030,16 @@ pub enum StatusErrorKind {
     TimedOut,
 }
 
-pub type StatusError = NatsError<StatusErrorKind>;
-
-impl Display for StatusError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind.clone() {
-            StatusErrorKind::JetStream(err) => {
-                write!(f, "jetstream request failed: {}", err)
-            }
-            StatusErrorKind::TimedOut => write!(f, "timed out"),
+impl Display for StatusErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::JetStream(err) => write!(f, "jetstream request failed: {}", err),
+            Self::TimedOut => write!(f, "timed out"),
         }
     }
 }
+
+pub type StatusError = NatsError<StatusErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PutErrorKind {
@@ -1050,25 +1048,33 @@ pub enum PutErrorKind {
     Ack,
 }
 
-pub type PutError = NatsError<PutErrorKind>;
-
-impl Display for PutError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            PutErrorKind::Publish => {
-                write!(f, "failed to put key into store: {}", self.format_source())
-            }
-            PutErrorKind::Ack => write!(f, "ack error: {}", self.format_source()),
-            PutErrorKind::InvalidKey => write!(f, "key cannot be empty or start/end with `.`"),
+impl Display for PutErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Publish => write!(f, "failed to put key into store"),
+            Self::Ack => write!(f, "ack error"),
+            Self::InvalidKey => write!(f, "key cannot be empty or start/end with `.`"),
         }
     }
 }
+
+pub type PutError = NatsError<PutErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EntryErrorKind {
     InvalidKey,
     TimedOut,
     Other,
+}
+
+impl Display for EntryErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidKey => write!(f, "key cannot be empty or start/end with `.`"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Other => write!(f, "failed getting entry"),
+        }
+    }
 }
 
 pub type EntryError = NatsError<EntryErrorKind>;
@@ -1080,16 +1086,6 @@ crate::from_with_timeout!(
     DirectGetErrorKind
 );
 
-impl Display for EntryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            EntryErrorKind::InvalidKey => write!(f, "key cannot be empty or start/end with `.`"),
-            EntryErrorKind::TimedOut => write!(f, "timed out"),
-            EntryErrorKind::Other => write!(f, "failed getting entry: {}", self.format_source()),
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WatchErrorKind {
     InvalidKey,
@@ -1098,27 +1094,21 @@ pub enum WatchErrorKind {
     Other,
 }
 
+impl Display for WatchErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConsumerCreate => write!(f, "watch consumer creation failed"),
+            Self::Other => write!(f, "watch failed"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::InvalidKey => write!(f, "key cannot be empty or start/end with `.`"),
+        }
+    }
+}
+
 pub type WatchError = NatsError<WatchErrorKind>;
 
 crate::from_with_timeout!(WatchError, WatchErrorKind, ConsumerError, ConsumerErrorKind);
 crate::from_with_timeout!(WatchError, WatchErrorKind, StreamError, StreamErrorKind);
-
-impl Display for WatchError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            WatchErrorKind::ConsumerCreate => {
-                write!(
-                    f,
-                    "watch consumer creation failed: {}",
-                    self.format_source()
-                )
-            }
-            WatchErrorKind::Other => write!(f, "watch failed: {}", self.format_source()),
-            WatchErrorKind::TimedOut => write!(f, "timed out"),
-            WatchErrorKind::InvalidKey => write!(f, "key cannot be empty or start/end with `.`"),
-        }
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum UpdateErrorKind {
@@ -1127,19 +1117,19 @@ pub enum UpdateErrorKind {
     Other,
 }
 
-pub type UpdateError = NatsError<UpdateErrorKind>;
-
-crate::from_with_timeout!(UpdateError, UpdateErrorKind, PublishError, PublishErrorKind);
-
-impl Display for UpdateError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            UpdateErrorKind::InvalidKey => write!(f, "key cannot be empty or start/end with `.`"),
-            UpdateErrorKind::TimedOut => write!(f, "timed out"),
-            UpdateErrorKind::Other => write!(f, "failed getting entry: {}", self.format_source()),
+impl Display for UpdateErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidKey => write!(f, "key cannot be empty or start/end with `.`"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Other => write!(f, "failed getting entry"),
         }
     }
 }
+
+pub type UpdateError = NatsError<UpdateErrorKind>;
+
+crate::from_with_timeout!(UpdateError, UpdateErrorKind, PublishError, PublishErrorKind);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WatcherErrorKind {
@@ -1147,18 +1137,16 @@ pub enum WatcherErrorKind {
     Other,
 }
 
-pub type WatcherError = NatsError<WatcherErrorKind>;
-
-impl Display for WatcherError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            WatcherErrorKind::Consumer => {
-                write!(f, "watcher consumer error: {}", self.format_source())
-            }
-            WatcherErrorKind::Other => write!(f, "watcher error: {}", self.format_source()),
+impl Display for WatcherErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Consumer => write!(f, "watcher consumer error"),
+            Self::Other => write!(f, "watcher error"),
         }
     }
 }
+
+pub type WatcherError = NatsError<WatcherErrorKind>;
 
 impl From<OrderedError> for WatcherError {
     fn from(err: OrderedError) -> Self {

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -29,7 +29,7 @@ use regex::Regex;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::debug;
 
-use crate::nats_error::NatsError;
+use crate::error::Error;
 use crate::{header, Message};
 
 use self::bucket::Status;
@@ -1039,7 +1039,7 @@ impl Display for StatusErrorKind {
     }
 }
 
-pub type StatusError = NatsError<StatusErrorKind>;
+pub type StatusError = Error<StatusErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PutErrorKind {
@@ -1058,7 +1058,7 @@ impl Display for PutErrorKind {
     }
 }
 
-pub type PutError = NatsError<PutErrorKind>;
+pub type PutError = Error<PutErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EntryErrorKind {
@@ -1077,7 +1077,7 @@ impl Display for EntryErrorKind {
     }
 }
 
-pub type EntryError = NatsError<EntryErrorKind>;
+pub type EntryError = Error<EntryErrorKind>;
 
 crate::from_with_timeout!(
     EntryError,
@@ -1105,7 +1105,7 @@ impl Display for WatchErrorKind {
     }
 }
 
-pub type WatchError = NatsError<WatchErrorKind>;
+pub type WatchError = Error<WatchErrorKind>;
 
 crate::from_with_timeout!(WatchError, WatchErrorKind, ConsumerError, ConsumerErrorKind);
 crate::from_with_timeout!(WatchError, WatchErrorKind, StreamError, StreamErrorKind);
@@ -1127,7 +1127,7 @@ impl Display for UpdateErrorKind {
     }
 }
 
-pub type UpdateError = NatsError<UpdateErrorKind>;
+pub type UpdateError = Error<UpdateErrorKind>;
 
 crate::from_with_timeout!(UpdateError, UpdateErrorKind, PublishError, PublishErrorKind);
 
@@ -1146,7 +1146,7 @@ impl Display for WatcherErrorKind {
     }
 }
 
-pub type WatcherError = NatsError<WatcherErrorKind>;
+pub type WatcherError = Error<WatcherErrorKind>;
 
 impl From<OrderedError> for WatcherError {
     fn from(err: OrderedError) -> Self {

--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -34,7 +34,7 @@ use super::consumer::{StreamError, StreamErrorKind};
 use super::context::{PublishError, PublishErrorKind};
 use super::stream::{ConsumerError, ConsumerErrorKind, PurgeError, PurgeErrorKind};
 use super::{consumer::push::Ordered, stream::StorageType};
-use crate::nats_error::NatsError;
+use crate::error::Error;
 use time::{serde::rfc3339, OffsetDateTime};
 
 const DEFAULT_CHUNK_SIZE: usize = 128 * 1024;
@@ -761,7 +761,7 @@ impl Display for InfoErrorKind {
     }
 }
 
-pub type InfoError = NatsError<InfoErrorKind>;
+pub type InfoError = Error<InfoErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GetErrorKind {
@@ -784,7 +784,7 @@ impl Display for GetErrorKind {
     }
 }
 
-pub type GetError = NatsError<GetErrorKind>;
+pub type GetError = Error<GetErrorKind>;
 
 crate::from_with_timeout!(GetError, GetErrorKind, ConsumerError, ConsumerErrorKind);
 crate::from_with_timeout!(GetError, GetErrorKind, StreamError, StreamErrorKind);
@@ -823,7 +823,7 @@ impl Display for DeleteErrorKind {
     }
 }
 
-pub type DeleteError = NatsError<DeleteErrorKind>;
+pub type DeleteError = Error<DeleteErrorKind>;
 
 impl From<InfoError> for DeleteError {
     fn from(err: InfoError) -> Self {
@@ -864,7 +864,7 @@ impl Display for PutErrorKind {
     }
 }
 
-pub type PutError = NatsError<PutErrorKind>;
+pub type PutError = Error<PutErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WatchErrorKind {
@@ -883,7 +883,7 @@ impl Display for WatchErrorKind {
     }
 }
 
-pub type WatchError = NatsError<WatchErrorKind>;
+pub type WatchError = Error<WatchErrorKind>;
 
 crate::from_with_timeout!(WatchError, WatchErrorKind, ConsumerError, ConsumerErrorKind);
 crate::from_with_timeout!(WatchError, WatchErrorKind, StreamError, StreamErrorKind);
@@ -910,7 +910,7 @@ impl Display for SealErrorKind {
     }
 }
 
-pub type SealError = NatsError<SealErrorKind>;
+pub type SealError = Error<SealErrorKind>;
 
 impl From<super::context::UpdateStreamError> for SealError {
     fn from(err: super::context::UpdateStreamError) -> Self {
@@ -938,7 +938,7 @@ impl Display for WatcherErrorKind {
     }
 }
 
-pub type WatcherError = NatsError<WatcherErrorKind>;
+pub type WatcherError = Error<WatcherErrorKind>;
 
 impl From<OrderedError> for WatcherError {
     fn from(err: OrderedError) -> Self {

--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -34,6 +34,7 @@ use super::consumer::{StreamError, StreamErrorKind};
 use super::context::{PublishError, PublishErrorKind};
 use super::stream::{ConsumerError, ConsumerErrorKind, PurgeError, PurgeErrorKind};
 use super::{consumer::push::Ordered, stream::StorageType};
+use crate::nats_error::NatsError;
 use time::{serde::rfc3339, OffsetDateTime};
 
 const DEFAULT_CHUNK_SIZE: usize = 128 * 1024;
@@ -741,19 +742,15 @@ impl From<&str> for ObjectMeta {
     }
 }
 
-#[derive(Debug)]
-pub struct InfoError {
-    kind: InfoErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum InfoErrorKind {
     InvalidName,
     NotFound,
     Other,
     TimedOut,
 }
+
+pub type InfoError = NatsError<InfoErrorKind>;
 
 impl Display for InfoError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -766,14 +763,7 @@ impl Display for InfoError {
     }
 }
 
-crate::error_impls!(InfoError, InfoErrorKind);
-
-#[derive(Debug)]
-pub struct GetError {
-    kind: GetErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GetErrorKind {
     InvalidName,
     ConsumerCreate,
@@ -781,7 +771,9 @@ pub enum GetErrorKind {
     Other,
     TimedOut,
 }
-crate::error_impls!(GetError, GetErrorKind);
+
+pub type GetError = NatsError<GetErrorKind>;
+
 crate::from_with_timeout!(GetError, GetErrorKind, ConsumerError, ConsumerErrorKind);
 crate::from_with_timeout!(GetError, GetErrorKind, StreamError, StreamErrorKind);
 
@@ -814,13 +806,7 @@ impl Display for GetError {
     }
 }
 
-#[derive(Debug)]
-pub struct DeleteError {
-    kind: DeleteErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DeleteErrorKind {
     TimedOut,
     NotFound,
@@ -829,6 +815,8 @@ pub enum DeleteErrorKind {
     Chunks,
     Other,
 }
+
+pub type DeleteError = NatsError<DeleteErrorKind>;
 
 impl Display for DeleteError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -856,17 +844,10 @@ impl From<InfoError> for DeleteError {
     }
 }
 
-crate::error_impls!(DeleteError, DeleteErrorKind);
 crate::from_with_timeout!(DeleteError, DeleteErrorKind, PublishError, PublishErrorKind);
 crate::from_with_timeout!(DeleteError, DeleteErrorKind, PurgeError, PurgeErrorKind);
 
-#[derive(Debug)]
-pub struct PutError {
-    kind: PutErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PutErrorKind {
     InvalidName,
     ReadChunks,
@@ -877,7 +858,7 @@ pub enum PutErrorKind {
     Other,
 }
 
-crate::error_impls!(PutError, PutErrorKind);
+pub type PutError = NatsError<PutErrorKind>;
 
 impl Display for PutError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -907,20 +888,15 @@ impl Display for PutError {
     }
 }
 
-#[derive(Debug)]
-pub struct WatchError {
-    kind: WatchErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WatchErrorKind {
     TimedOut,
     ConsumerCreate,
     Other,
 }
 
-crate::error_impls!(WatchError, WatchErrorKind);
+pub type WatchError = NatsError<WatchErrorKind>;
+
 crate::from_with_timeout!(WatchError, WatchErrorKind, ConsumerError, ConsumerErrorKind);
 crate::from_with_timeout!(WatchError, WatchErrorKind, StreamError, StreamErrorKind);
 
@@ -943,13 +919,7 @@ impl Display for WatchError {
 pub type ListError = WatchError;
 pub type ListErrorKind = WatchErrorKind;
 
-#[derive(Debug)]
-pub struct SealError {
-    kind: SealErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SealErrorKind {
     TimedOut,
     Other,
@@ -957,7 +927,7 @@ pub enum SealErrorKind {
     Update,
 }
 
-crate::error_impls!(SealError, SealErrorKind);
+pub type SealError = NatsError<SealErrorKind>;
 
 impl Display for SealError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -987,17 +957,13 @@ impl From<super::context::UpdateStreamError> for SealError {
     }
 }
 
-#[derive(Debug)]
-pub struct WatcherError {
-    kind: WatcherErrorKind,
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WatcherErrorKind {
     ConsumerError,
     Other,
 }
+
+pub type WatcherError = NatsError<WatcherErrorKind>;
 
 impl Display for WatcherError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1009,8 +975,6 @@ impl Display for WatcherError {
         }
     }
 }
-
-crate::error_impls!(WatcherError, WatcherErrorKind);
 
 impl From<OrderedError> for WatcherError {
     fn from(err: OrderedError) -> Self {

--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -750,18 +750,18 @@ pub enum InfoErrorKind {
     TimedOut,
 }
 
-pub type InfoError = NatsError<InfoErrorKind>;
-
-impl Display for InfoError {
+impl Display for InfoErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            InfoErrorKind::InvalidName => write!(f, "invalid object name"),
-            InfoErrorKind::Other => write!(f, "getting info failed: {}", self.format_source()),
-            InfoErrorKind::NotFound => write!(f, "not found"),
-            InfoErrorKind::TimedOut => write!(f, "timed out"),
+        match self {
+            Self::InvalidName => write!(f, "invalid object name"),
+            Self::Other => write!(f, "getting info failed"),
+            Self::NotFound => write!(f, "not found"),
+            Self::TimedOut => write!(f, "timed out"),
         }
     }
 }
+
+pub type InfoError = NatsError<InfoErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GetErrorKind {
@@ -770,6 +770,18 @@ pub enum GetErrorKind {
     NotFound,
     Other,
     TimedOut,
+}
+
+impl Display for GetErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConsumerCreate => write!(f, "failed creating consumer for fetching object"),
+            Self::Other => write!(f, "failed getting object"),
+            Self::NotFound => write!(f, "object not found"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::InvalidName => write!(f, "invalid object name"),
+        }
+    }
 }
 
 pub type GetError = NatsError<GetErrorKind>;
@@ -788,24 +800,6 @@ impl From<InfoError> for GetError {
     }
 }
 
-impl Display for GetError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind() {
-            GetErrorKind::ConsumerCreate => {
-                write!(
-                    f,
-                    "failed creating consumer for fetching object: {}",
-                    self.format_source()
-                )
-            }
-            GetErrorKind::Other => write!(f, "failed getting object: {}", self.format_source()),
-            GetErrorKind::NotFound => write!(f, "object not found"),
-            GetErrorKind::TimedOut => write!(f, "timed out"),
-            GetErrorKind::InvalidName => write!(f, "invalid object name"),
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DeleteErrorKind {
     TimedOut,
@@ -816,22 +810,20 @@ pub enum DeleteErrorKind {
     Other,
 }
 
-pub type DeleteError = NatsError<DeleteErrorKind>;
-
-impl Display for DeleteError {
+impl Display for DeleteErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind() {
-            DeleteErrorKind::TimedOut => write!(f, "timed out"),
-            DeleteErrorKind::Metadata => {
-                write!(f, "failed rolling up metadata: {}", self.format_source())
-            }
-            DeleteErrorKind::Chunks => write!(f, "failed purging chunks: {}", self.format_source()),
-            DeleteErrorKind::Other => write!(f, "delete failed: {}", self.format_source()),
-            DeleteErrorKind::NotFound => write!(f, "object not found"),
-            DeleteErrorKind::InvalidName => write!(f, "invalid object name"),
+        match self {
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Metadata => write!(f, "failed rolling up metadata"),
+            Self::Chunks => write!(f, "failed purging chunks"),
+            Self::Other => write!(f, "delete failed"),
+            Self::NotFound => write!(f, "object not found"),
+            Self::InvalidName => write!(f, "invalid object name"),
         }
     }
 }
+
+pub type DeleteError = NatsError<DeleteErrorKind>;
 
 impl From<InfoError> for DeleteError {
     fn from(err: InfoError) -> Self {
@@ -858,35 +850,21 @@ pub enum PutErrorKind {
     Other,
 }
 
-pub type PutError = NatsError<PutErrorKind>;
-
-impl Display for PutError {
+impl Display for PutErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind() {
-            PutErrorKind::PublishChunks => {
-                write!(
-                    f,
-                    "failed publishing object chunks: {}",
-                    self.format_source()
-                )
-            }
-            PutErrorKind::PublishMetadata => {
-                write!(f, "failed publishing metadata: {}", self.format_source())
-            }
-            PutErrorKind::PurgeOldChunks => {
-                write!(f, "falied purging old chunks: {}", self.format_source())
-            }
-            PutErrorKind::TimedOut => write!(f, "timed out"),
-            PutErrorKind::Other => write!(f, "error: {}", self.format_source()),
-            PutErrorKind::InvalidName => write!(f, "invalid object name"),
-            PutErrorKind::ReadChunks => write!(
-                f,
-                "error while reading the buffer: {}",
-                self.format_source()
-            ),
+        match self {
+            Self::PublishChunks => write!(f, "failed publishing object chunks:"),
+            Self::PublishMetadata => write!(f, "failed publishing metadata"),
+            Self::PurgeOldChunks => write!(f, "failed purging old chunks:"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Other => write!(f, "error"),
+            Self::InvalidName => write!(f, "invalid object name"),
+            Self::ReadChunks => write!(f, "error while reading the buffer"),
         }
     }
 }
+
+pub type PutError = NatsError<PutErrorKind>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WatchErrorKind {
@@ -895,26 +873,20 @@ pub enum WatchErrorKind {
     Other,
 }
 
+impl Display for WatchErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConsumerCreate => write!(f, "watch consumer creation failed"),
+            Self::Other => write!(f, "watch failed"),
+            Self::TimedOut => write!(f, "timed out"),
+        }
+    }
+}
+
 pub type WatchError = NatsError<WatchErrorKind>;
 
 crate::from_with_timeout!(WatchError, WatchErrorKind, ConsumerError, ConsumerErrorKind);
 crate::from_with_timeout!(WatchError, WatchErrorKind, StreamError, StreamErrorKind);
-
-impl Display for WatchError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            WatchErrorKind::ConsumerCreate => {
-                write!(
-                    f,
-                    "watch consumer creation failed: {}",
-                    self.format_source()
-                )
-            }
-            WatchErrorKind::Other => write!(f, "watch failed: {}", self.format_source()),
-            WatchErrorKind::TimedOut => write!(f, "timed out"),
-        }
-    }
-}
 
 pub type ListError = WatchError;
 pub type ListErrorKind = WatchErrorKind;
@@ -927,24 +899,18 @@ pub enum SealErrorKind {
     Update,
 }
 
-pub type SealError = NatsError<SealErrorKind>;
-
-impl Display for SealError {
+impl Display for SealErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            SealErrorKind::TimedOut => write!(f, "timed out"),
-            SealErrorKind::Other => write!(f, "seal failed: {}", self.format_source()),
-            SealErrorKind::Info => write!(
-                f,
-                "failed getting stream info before sealing bucket: {}",
-                self.format_source()
-            ),
-            SealErrorKind::Update => {
-                write!(f, "failed sealing the bucket: {}", self.format_source())
-            }
+        match self {
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Other => write!(f, "seal failed"),
+            Self::Info => write!(f, "failed getting stream info before sealing bucket"),
+            Self::Update => write!(f, "failed sealing the bucket"),
         }
     }
 }
+
+pub type SealError = NatsError<SealErrorKind>;
 
 impl From<super::context::UpdateStreamError> for SealError {
     fn from(err: super::context::UpdateStreamError) -> Self {
@@ -963,18 +929,16 @@ pub enum WatcherErrorKind {
     Other,
 }
 
-pub type WatcherError = NatsError<WatcherErrorKind>;
-
-impl Display for WatcherError {
+impl Display for WatcherErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            WatcherErrorKind::ConsumerError => {
-                write!(f, "watcher consumer error: {}", self.format_source())
-            }
-            WatcherErrorKind::Other => write!(f, "watcher error: {}", self.format_source()),
+        match self {
+            Self::ConsumerError => write!(f, "watcher consumer error"),
+            Self::Other => write!(f, "watcher error"),
         }
     }
 }
+
+pub type WatcherError = NatsError<WatcherErrorKind>;
 
 impl From<OrderedError> for WatcherError {
     fn from(err: OrderedError) -> Self {

--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -853,9 +853,9 @@ pub enum PutErrorKind {
 impl Display for PutErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::PublishChunks => write!(f, "failed publishing object chunks:"),
+            Self::PublishChunks => write!(f, "failed publishing object chunks"),
             Self::PublishMetadata => write!(f, "failed publishing metadata"),
-            Self::PurgeOldChunks => write!(f, "failed purging old chunks:"),
+            Self::PurgeOldChunks => write!(f, "failed purging old chunks"),
             Self::TimedOut => write!(f, "timed out"),
             Self::Other => write!(f, "error"),
             Self::InvalidName => write!(f, "invalid object name"),

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -55,25 +55,22 @@ pub enum DirectGetErrorKind {
     Other,
 }
 
-pub type DirectGetError = NatsError<DirectGetErrorKind>;
-
-impl Display for DirectGetError {
+impl Display for DirectGetErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let source = self.format_source();
-        match self.kind() {
-            DirectGetErrorKind::InvalidSubject => write!(f, "invalid subject"),
-            DirectGetErrorKind::NotFound => write!(f, "message not found"),
-            DirectGetErrorKind::ErrorResponse(status, description) => {
+        match self {
+            Self::InvalidSubject => write!(f, "invalid subject"),
+            Self::NotFound => write!(f, "message not found"),
+            Self::ErrorResponse(status, description) => {
                 write!(f, "unable to get message: {} {}", status, description)
             }
-            DirectGetErrorKind::Other => {
-                write!(f, "error getting message: {}", source)
-            }
-            DirectGetErrorKind::TimedOut => write!(f, "timed out"),
-            DirectGetErrorKind::Request => write!(f, "request failed: {}", source),
+            Self::Other => write!(f, "error getting message"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Request => write!(f, "request failed"),
         }
     }
 }
+
+pub type DirectGetError = NatsError<DirectGetErrorKind>;
 
 impl From<crate::RequestError> for DirectGetError {
     fn from(err: crate::RequestError) -> Self {
@@ -100,18 +97,17 @@ pub enum DeleteMessageErrorKind {
     JetStream(super::errors::Error),
 }
 
-pub type DeleteMessageError = NatsError<DeleteMessageErrorKind>;
-
-impl Display for DeleteMessageError {
+impl Display for DeleteMessageErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let source = self.format_source();
-        match &self.kind {
-            DeleteMessageErrorKind::Request => write!(f, "request failed: {}", source),
-            DeleteMessageErrorKind::TimedOut => write!(f, "timed out"),
-            DeleteMessageErrorKind::JetStream(err) => write!(f, "JetStream error: {}", err),
+        match self {
+            Self::Request => write!(f, "request failed"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::JetStream(err) => write!(f, "JetStream error: {}", err),
         }
     }
 }
+
+pub type DeleteMessageError = NatsError<DeleteMessageErrorKind>;
 
 /// Handle to operations that can be performed on a `Stream`.
 #[derive(Debug, Clone)]
@@ -1534,18 +1530,17 @@ pub enum PurgeErrorKind {
     JetStream(super::errors::Error),
 }
 
-pub type PurgeError = NatsError<PurgeErrorKind>;
-
-impl Display for PurgeError {
+impl Display for PurgeErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let source = self.format_source();
-        match &self.kind {
-            PurgeErrorKind::Request => write!(f, "request failed: {}", source),
-            PurgeErrorKind::TimedOut => write!(f, "timed out"),
-            PurgeErrorKind::JetStream(err) => write!(f, "JetStream error: {}", err),
+        match self {
+            Self::Request => write!(f, "request failed"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::JetStream(err) => write!(f, "JetStream error: {}", err),
         }
     }
 }
+
+pub type PurgeError = NatsError<PurgeErrorKind>;
 
 impl<'a, S, K> IntoFuture for Purge<'a, S, K>
 where
@@ -1751,23 +1746,17 @@ pub enum LastRawMessageErrorKind {
     Other,
 }
 
-pub type LastRawMessageError = NatsError<LastRawMessageErrorKind>;
-
-impl fmt::Display for LastRawMessageError {
+impl Display for LastRawMessageErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.kind {
-            LastRawMessageErrorKind::NoMessageFound => write!(f, "no message found"),
-            LastRawMessageErrorKind::Other => write!(
-                f,
-                "failed to get last raw message: {}",
-                self.format_source()
-            ),
-            LastRawMessageErrorKind::JetStream(err) => {
-                write!(f, "JetStream error: {}", err)
-            }
+        match self {
+            Self::NoMessageFound => write!(f, "no message found"),
+            Self::Other => write!(f, "failed to get last raw message"),
+            Self::JetStream(err) => write!(f, "JetStream error: {}", err),
         }
     }
 }
+
+pub type LastRawMessageError = NatsError<LastRawMessageErrorKind>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ConsumerErrorKind {
@@ -1779,22 +1768,19 @@ pub enum ConsumerErrorKind {
     Other,
 }
 
-pub type ConsumerError = NatsError<ConsumerErrorKind>;
-
-impl Display for ConsumerError {
+impl Display for ConsumerErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let source = self.format_source();
-        match &self.kind() {
-            ConsumerErrorKind::TimedOut => write!(f, "timed out"),
-            ConsumerErrorKind::Request => write!(f, "request failed: {}", source),
-            ConsumerErrorKind::JetStream(err) => write!(f, "JetStream error: {}", err),
-            ConsumerErrorKind::Other => write!(f, "consumer error: {}", source),
-            ConsumerErrorKind::InvalidConsumerType => {
-                write!(f, "invalid consumer type: {}", source)
-            }
+        match self {
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Request => write!(f, "request failed"),
+            Self::JetStream(err) => write!(f, "JetStream error: {}", err),
+            Self::Other => write!(f, "consumer error"),
+            Self::InvalidConsumerType => write!(f, "invalid consumer type"),
         }
     }
 }
+
+pub type ConsumerError = NatsError<ConsumerErrorKind>;
 
 impl From<super::context::RequestError> for ConsumerError {
     fn from(err: super::context::RequestError) -> Self {

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -857,30 +857,23 @@ pub enum ConnectErrorKind {
     Io,
 }
 
-/// Returned when initial connection fails.
-/// To be enumerate over the variants, call [ConnectError::kind].
-pub type ConnectError = NatsError<ConnectErrorKind>;
-
-impl Display for ConnectError {
+impl Display for ConnectErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let source_info = self
-            .source
-            .as_ref()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "no details".to_string());
-        match self.kind {
-            ConnectErrorKind::ServerParse => {
-                write!(f, "failed to parse server or server list: {}", source_info)
-            }
-            ConnectErrorKind::Dns => write!(f, "DNS error: {}", source_info),
-            ConnectErrorKind::Authentication => write!(f, "failed signing nonce"),
-            ConnectErrorKind::AuthorizationViolation => write!(f, "authorization violation"),
-            ConnectErrorKind::TimedOut => write!(f, "timed out"),
-            ConnectErrorKind::Tls => write!(f, "TLS error: {}", source_info),
-            ConnectErrorKind::Io => write!(f, "{}", source_info),
+        match self {
+            Self::ServerParse => write!(f, "failed to parse server or server list"),
+            Self::Dns => write!(f, "DNS error"),
+            Self::Authentication => write!(f, "failed signing nonce"),
+            Self::AuthorizationViolation => write!(f, "authorization violation"),
+            Self::TimedOut => write!(f, "timed out"),
+            Self::Tls => write!(f, "TLS error:"),
+            Self::Io => write!(f, "IO error"),
         }
     }
 }
+
+/// Returned when initial connection fails.
+/// To be enumerate over the variants, call [ConnectError::kind].
+pub type ConnectError = NatsError<ConnectErrorKind>;
 
 impl From<std::io::Error> for ConnectError {
     fn from(err: std::io::Error) -> Self {

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1323,49 +1323,6 @@ macro_rules! from_with_timeout {
 use crate::nats_error::NatsError;
 pub(crate) use from_with_timeout;
 
-// TODO: rewrite into derivable proc macro.
-macro_rules! error_impls {
-    ($t:ty, $k:ty) => {
-        impl $t {
-            #[allow(dead_code)]
-            #[allow(unreachable_pub)]
-            pub(crate) fn new(kind: $k) -> $t {
-                Self { kind, source: None }
-            }
-            #[allow(dead_code)]
-            #[allow(unreachable_pub)]
-            pub(crate) fn with_source<S>(kind: $k, source: S) -> $t
-            where
-                S: Into<crate::Error>,
-            {
-                Self {
-                    kind,
-                    source: Some(source.into()),
-                }
-            }
-            #[allow(dead_code)]
-            #[allow(unreachable_pub)]
-            pub fn kind(&self) -> $k {
-                // ALmost all `kind` types implement `Copy`, so it's almost always copy.
-                // We need to clone, as some more complex one may have nested other errors, that
-                // implement Clone only.
-                self.kind.clone()
-            }
-            #[allow(dead_code)]
-            #[allow(unreachable_pub)]
-            pub(crate) fn format_source(&self) -> String {
-                self.source
-                    .as_ref()
-                    .map(|err| err.to_string())
-                    .unwrap_or("unknown".to_string())
-            }
-        }
-        impl std::error::Error for $t {}
-    };
-}
-
-pub(crate) use error_impls;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -176,6 +176,7 @@ pub use options::{AuthError, ConnectOptions};
 pub mod header;
 pub mod jetstream;
 pub mod message;
+pub mod nats_error;
 #[cfg(feature = "service")]
 pub mod service;
 pub mod status;

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -859,11 +859,7 @@ pub enum ConnectErrorKind {
 
 /// Returned when initial connection fails.
 /// To be enumerate over the variants, call [ConnectError::kind].
-#[derive(Debug, Error)]
-pub struct ConnectError {
-    kind: ConnectErrorKind,
-    source: Option<crate::Error>,
-}
+pub type ConnectError = NatsError<ConnectErrorKind>;
 
 impl Display for ConnectError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -883,24 +879,6 @@ impl Display for ConnectError {
             ConnectErrorKind::Tls => write!(f, "TLS error: {}", source_info),
             ConnectErrorKind::Io => write!(f, "{}", source_info),
         }
-    }
-}
-
-impl ConnectError {
-    fn with_source<E>(kind: ConnectErrorKind, source: E) -> ConnectError
-    where
-        E: Into<crate::Error>,
-    {
-        ConnectError {
-            kind,
-            source: Some(source.into()),
-        }
-    }
-    fn new(kind: ConnectErrorKind) -> ConnectError {
-        ConnectError { kind, source: None }
-    }
-    pub fn kind(&self) -> ConnectErrorKind {
-        self.kind
     }
 }
 
@@ -1342,6 +1320,7 @@ macro_rules! from_with_timeout {
         }
     };
 }
+use crate::nats_error::NatsError;
 pub(crate) use from_with_timeout;
 
 // TODO: rewrite into derivable proc macro.

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -173,10 +173,10 @@ pub use auth::Auth;
 pub use client::{Client, PublishError, Request, RequestError, RequestErrorKind, SubscribeError};
 pub use options::{AuthError, ConnectOptions};
 
+pub mod error;
 pub mod header;
 pub mod jetstream;
 pub mod message;
-pub mod nats_error;
 #[cfg(feature = "service")]
 pub mod service;
 pub mod status;
@@ -873,10 +873,10 @@ impl Display for ConnectErrorKind {
 
 /// Returned when initial connection fails.
 /// To be enumerate over the variants, call [ConnectError::kind].
-pub type ConnectError = NatsError<ConnectErrorKind>;
+pub type ConnectError = error::Error<ConnectErrorKind>;
 
-impl From<std::io::Error> for ConnectError {
-    fn from(err: std::io::Error) -> Self {
+impl From<io::Error> for ConnectError {
+    fn from(err: io::Error) -> Self {
         ConnectError::with_source(ConnectErrorKind::Io, err)
     }
 }
@@ -1313,7 +1313,6 @@ macro_rules! from_with_timeout {
         }
     };
 }
-use crate::nats_error::NatsError;
 pub(crate) use from_with_timeout;
 
 #[cfg(test)]

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -865,7 +865,7 @@ impl Display for ConnectErrorKind {
             Self::Authentication => write!(f, "failed signing nonce"),
             Self::AuthorizationViolation => write!(f, "authorization violation"),
             Self::TimedOut => write!(f, "timed out"),
-            Self::Tls => write!(f, "TLS error:"),
+            Self::Tls => write!(f, "TLS error"),
             Self::Io => write!(f, "IO error"),
         }
     }

--- a/async-nats/src/nats_error.rs
+++ b/async-nats/src/nats_error.rs
@@ -1,0 +1,159 @@
+use std::error::Error;
+use std::fmt::{Debug, Display};
+
+/// The error type for the NATS client, generic by the kind of error.
+#[derive(Debug)]
+pub struct NatsError<Kind>
+where
+    Kind: Clone + Debug + PartialEq,
+{
+    pub(crate) kind: Kind,
+    pub(crate) source: Option<crate::Error>,
+}
+
+impl<Kind> NatsError<Kind>
+where
+    Kind: Clone + Debug + PartialEq,
+{
+    pub(crate) fn new(kind: Kind) -> Self {
+        Self { kind, source: None }
+    }
+
+    pub(crate) fn with_source<S>(kind: Kind, source: S) -> Self
+    where
+        S: Into<crate::Error>,
+    {
+        Self {
+            kind,
+            source: Some(source.into()),
+        }
+    }
+
+    // TODO: shouldn't this method to be pub(crate) ?
+    //       or maybe it is better to expose the source error?
+    pub fn format_source(&self) -> String {
+        self.source
+            .as_ref()
+            .map(|err| err.to_string())
+            .unwrap_or("unknown".to_string())
+    }
+
+    pub fn kind(&self) -> Kind {
+        self.kind.clone()
+    }
+}
+
+impl<Kind> Error for NatsError<Kind>
+where
+    Kind: PartialEq + Clone + Debug,
+    NatsError<Kind>: Debug + Display,
+{
+}
+
+impl<Kind> From<Kind> for NatsError<Kind>
+where
+    Kind: PartialEq + Clone + Debug,
+{
+    fn from(kind: Kind) -> Self {
+        Self { kind, source: None }
+    }
+}
+
+/// Enables wrapping source errors to the crate-specific error type
+/// by additionally specifying the kind of the target error.
+trait WithKind<Kind>
+where
+    Kind: Clone + Debug + PartialEq,
+    Self: Into<crate::Error>,
+{
+    fn with_kind(self, kind: Kind) -> NatsError<Kind> {
+        NatsError::<Kind> {
+            kind,
+            source: Some(self.into()),
+        }
+    }
+}
+
+impl<E, Kind> WithKind<Kind> for E
+where
+    Kind: Clone + Debug + PartialEq,
+    E: Into<crate::Error>,
+{
+}
+
+#[cfg(test)]
+mod test {
+    #![allow(dead_code)]
+
+    use super::*;
+    use std::fmt::Formatter;
+
+    // Define a custom error kind as a public enum
+    #[derive(Clone, Debug, PartialEq)]
+    enum FooErrorKind {
+        Bar,
+        Baz,
+    }
+
+    // Define a custom error type as a public struct
+    type FooError = NatsError<FooErrorKind>;
+
+    // Implement the Display trait for the custom error type
+    // to unlock the implementation of the Error trait.
+    impl Display for FooError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "foo error")
+        }
+    }
+
+    #[test]
+    fn new() {
+        let error = FooError::new(FooErrorKind::Bar);
+        assert_eq!(error.kind(), FooErrorKind::Bar);
+        assert!(error.source().is_none());
+    }
+
+    #[test]
+    fn with_source() {
+        let source = std::io::Error::new(std::io::ErrorKind::Other, "foo");
+        let error = FooError::with_source(FooErrorKind::Bar, source);
+        assert_eq!(error.kind(), FooErrorKind::Bar);
+        assert_eq!(error.source.unwrap().to_string(), "foo");
+    }
+
+    #[test]
+    fn kind() {
+        let error: FooError = FooErrorKind::Bar.into();
+        let kind = error.kind();
+        let _ = error.kind(); // ensure the kind can be invoked multiple times
+        assert_eq!(kind, FooErrorKind::Bar);
+    }
+
+    #[test]
+    fn format_source_with_source() {
+        let source = std::io::Error::new(std::io::ErrorKind::Other, "foo");
+        let error = FooError::with_source(FooErrorKind::Bar, source);
+        assert_eq!(error.format_source(), "foo");
+    }
+
+    #[test]
+    fn format_source_without_source() {
+        let error: FooError = FooErrorKind::Bar.into();
+        assert_eq!(error.format_source(), "unknown");
+    }
+
+    #[test]
+    fn from() {
+        let error: FooError = FooErrorKind::Bar.into();
+        assert_eq!(error.kind(), FooErrorKind::Bar);
+        assert!(error.source().is_none());
+    }
+
+    #[test]
+    fn with_kind() {
+        let source = std::io::Error::new(std::io::ErrorKind::Other, "foo");
+        let error: FooError = source.with_kind(FooErrorKind::Baz);
+        assert_eq!(error.kind(), FooErrorKind::Baz);
+        assert!(error.source.unwrap().to_string().contains("foo"));
+    }
+}


### PR DESCRIPTION
While trying to recognize how the gem works I found this [TODO](https://github.com/nats-io/nats.rs/blob/main/async-nats/src/lib.rs#L1346) and decided to implement it (well, this is how I learn things).

But at the moment the implementation got ready, I asked myself, why the same functionality cannot be expressed better with generic structs, and found no answer. That's why instead of implementing another macro (derive or attribute), I restarted my refactoring from scratch and removed the very necessity of the macro in favor of `NatsError<T>`.

This type represents any error to be raised by the crate. It is generic over the enum representing the kind of the error.

Unlike the previous code where binding between the kind and the error used to be provided by the macro `error_impls`, this definition makes the corresponding error bound to the kind more idiomatically.

The previous syntax:

```rust
#[derive(Clone, Debug, PartialEq)]
pub enum FooErrorKind {
  Bar,
  Baz,
}

#[derive(Debug)]
pub struct FooError {
  kind: FooErrorKind,
  source: Box<dyn Error + Send + Sync + 'static>,
}

error_impls!("FooError", "FooErrorKind");
```

The new definition:

```rust
#[derive(Clone, Debug, PartialEq)]
pub enum FooErrorKind {
  Bar,
  Baz,
}

pub type FooError = NatsError<FooErrorKind>;
```

In addition to being more expressive (which is, I agree, too opinionated), the new syntax lets IDE-s to understand the code better (most of them cannot analyze the code inside the macro).