### PR TITLE
Remove useless use of `Option` around `HeaderMap`

### DIFF
--- a/async-nats/src/connection.rs
+++ b/async-nats/src/connection.rs
@@ -431,10 +431,7 @@ impl Connection {
                 respond,
                 headers,
             } => {
-                let verb = match headers.as_ref() {
-                    Some(headers) if !headers.is_empty() => "HPUB",
-                    _ => "PUB",
-                };
+                let verb = if !headers.is_empty() { "HPUB" } else { "PUB" };
 
                 small_write!("{verb} {subject} ");
 
@@ -442,19 +439,16 @@ impl Connection {
                     small_write!("{respond} ");
                 }
 
-                match headers {
-                    Some(headers) if !headers.is_empty() => {
-                        let headers = headers.to_bytes();
+                if !headers.is_empty() {
+                    let headers = headers.to_bytes();
 
-                        let headers_len = headers.len();
-                        let total_len = headers_len + payload.len();
-                        small_write!("{headers_len} {total_len}\r\n");
-                        self.write(headers);
-                    }
-                    _ => {
-                        let payload_len = payload.len();
-                        small_write!("{payload_len}\r\n");
-                    }
+                    let headers_len = headers.len();
+                    let total_len = headers_len + payload.len();
+                    small_write!("{headers_len} {total_len}\r\n");
+                    self.write(headers);
+                } else {
+                    let payload_len = payload.len();
+                    small_write!("{payload_len}\r\n");
                 }
 
                 self.write(Bytes::clone(payload));
@@ -954,7 +948,7 @@ mod write_op {
                     subject: "FOO.BAR".into(),
                     payload: "Hello World".into(),
                     respond: None,
-                    headers: None,
+                    headers: HeaderMap::new(),
                 }]
                 .iter(),
             )
@@ -973,7 +967,7 @@ mod write_op {
                     subject: "FOO.BAR".into(),
                     payload: "Hello World".into(),
                     respond: Some("INBOX.67".into()),
-                    headers: None,
+                    headers: HeaderMap::new(),
                 }]
                 .iter(),
             )
@@ -991,10 +985,10 @@ mod write_op {
                     subject: "FOO.BAR".into(),
                     payload: "Hello World".into(),
                     respond: Some("INBOX.67".into()),
-                    headers: Some(HeaderMap::from_iter([(
+                    headers: HeaderMap::from_iter([(
                         "Header".parse().unwrap(),
                         "X".parse().unwrap(),
-                    )])),
+                    )]),
                 }]
                 .iter(),
             )

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -1179,7 +1179,7 @@ impl futures::Stream for Streams<'_> {
 #[derive(Default, Clone, Debug)]
 pub struct Publish {
     payload: Bytes,
-    headers: Option<header::HeaderMap>,
+    headers: header::HeaderMap,
 }
 impl Publish {
     /// Creates a new custom Publish struct to be used with.
@@ -1194,14 +1194,12 @@ impl Publish {
     }
     /// Adds headers to the message.
     pub fn headers(mut self, headers: HeaderMap) -> Self {
-        self.headers = Some(headers);
+        self.headers = headers;
         self
     }
     /// A shorthand to add a single header.
     pub fn header<N: IntoHeaderName, V: IntoHeaderValue>(mut self, name: N, value: V) -> Self {
-        self.headers
-            .get_or_insert(header::HeaderMap::new())
-            .insert(name, value);
+        self.headers.insert(name, value);
         self
     }
     /// Sets the `Nats-Msg-Id` header, that is used by stream deduplicate window.

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -270,13 +270,13 @@ pub(crate) enum Command {
         subject: Subject,
         payload: Bytes,
         respond: Option<Subject>,
-        headers: Option<HeaderMap>,
+        headers: HeaderMap,
     },
     Request {
         subject: Subject,
         payload: Bytes,
         respond: Subject,
-        headers: Option<HeaderMap>,
+        headers: HeaderMap,
         sender: oneshot::Sender<Message>,
     },
     Subscribe {
@@ -301,7 +301,7 @@ pub(crate) enum ClientOp {
         subject: Subject,
         payload: Bytes,
         respond: Option<Subject>,
-        headers: Option<HeaderMap>,
+        headers: HeaderMap,
     },
     Subscribe {
         sid: u64,


### PR DESCRIPTION
Calling `HeaderMap::new` doesn't allocate, but instead creates an [empty hashmap](https://doc.rust-lang.org/nightly/std/collections/hash_map/struct.HashMap.html#method.new).

Considering that code already has to check whether there really were any headers inside of the `HeaderMap` when the variant is `Some`, the `Option` around it didn't make sense.