### PR TITLE
Clearer documentation for Context::get_object_store

### DIFF
--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -894,7 +894,7 @@ impl Context {
         })
     }
 
-    /// Creates a new object store bucket.
+    /// Get an existing object store bucket.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This is only a minor change which makes the comment on `Context::get_object_store` a bit clearer - the former comment was the same as on `create_object_store`.