### PR TITLE
Refactor connection handling

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["network-programming", "api-bindings"]
 [dependencies]
 memchr = "2.4"
 bytes = { version = "1.4.0", features = ["serde"] }
-futures = { version = "0.3.28", default-features = false, features = ["std", "async-await"] }
+futures = { version = "0.3.28", default-features = false, features = ["std"] }
 nkeys = "0.3.1"
 once_cell = "1.18.0"
 regex = "1.9.1"
@@ -48,6 +48,7 @@ criterion =  { version = "0.5", features = ["async_tokio"]}
 nats-server = { path = "../nats-server" }
 rand = "0.8"
 tokio = { version = "1.25.0", features = ["rt-multi-thread"] }
+futures = { version = "0.3.28", default-features = false, features = ["std", "async-await"] }
 tracing-subscriber = "0.3"
 async-nats = {path = ".", features = ["experimental"]}
 reqwest = "0.11.18"

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -25,7 +25,6 @@ serde_json = "1.0.104"
 serde_repr = "0.1.16"
 http = "0.2.9"
 tokio = { version = "1.29.0", features = ["macros", "rt", "fs", "net", "sync", "time", "io-util"] }
-itoa = "1"
 url = { version = "2"}
 tokio-rustls = "0.24"
 rustls-pemfile = "1.0.2"

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -346,9 +346,6 @@ impl Client {
                 }
                 None => self.publish_with_reply(subject, inbox, payload).await?,
             }
-            self.flush()
-                .await
-                .map_err(|err| RequestError::with_source(RequestErrorKind::Other, err))?;
             let request = match timeout {
                 Some(timeout) => {
                     tokio::time::timeout(timeout, sub.next())

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -517,12 +517,11 @@ impl Client {
     pub async fn flush(&self) -> Result<(), FlushError> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.sender
-            .send(Command::Flush { result: tx })
+            .send(Command::Flush { observer: tx })
             .await
             .map_err(|err| FlushError::with_source(FlushErrorKind::SendError, err))?;
-        // first question mark is an error from rx itself, second for error from flush.
+
         rx.await
-            .map_err(|err| FlushError::with_source(FlushErrorKind::FlushError, err))?
             .map_err(|err| FlushError::with_source(FlushErrorKind::FlushError, err))?;
         Ok(())
     }

--- a/async-nats/src/connection.rs
+++ b/async-nats/src/connection.rs
@@ -14,7 +14,7 @@
 //! This module provides a connection implementation for communicating with a NATS server.
 
 use std::collections::VecDeque;
-use std::fmt::Display;
+use std::fmt::{self, Display, Write as _};
 use std::future::{self, Future};
 use std::pin::Pin;
 use std::str::{self, FromStr};
@@ -28,7 +28,11 @@ use crate::status::StatusCode;
 use crate::{ClientOp, ServerError, ServerOp};
 
 /// Soft limit for the amount of bytes in [`Connection::write_buf`]
+/// and [`Connection::flattened_writes`].
 const SOFT_WRITE_BUF_LIMIT: usize = 65535;
+/// How big a single buffer must be before it's written separately
+/// instead of being flattened.
+const WRITE_FLATTEN_THRESHOLD: usize = 4096;
 
 /// Supertrait enabling trait object for containing both TLS and non TLS `TcpStream` connection.
 pub(crate) trait AsyncReadWrite: AsyncWrite + AsyncRead + Send + Unpin {}
@@ -60,6 +64,7 @@ pub(crate) struct Connection {
     read_buf: BytesMut,
     write_buf: VecDeque<Bytes>,
     write_buf_len: usize,
+    flattened_writes: BytesMut,
     can_flush: bool,
 }
 
@@ -72,6 +77,7 @@ impl Connection {
             read_buf: BytesMut::with_capacity(read_buffer_capacity),
             write_buf: VecDeque::new(),
             write_buf_len: 0,
+            flattened_writes: BytesMut::new(),
             can_flush: false,
         }
     }
@@ -83,7 +89,7 @@ impl Connection {
 
     /// Returns `true` if [`Self::poll_flush`] should be polled.
     pub(crate) fn should_flush(&self) -> bool {
-        self.can_flush && self.write_buf.is_empty()
+        self.can_flush && self.write_buf.is_empty() && self.flattened_writes.is_empty()
     }
 
     /// Attempts to read a server operation from the read buffer.
@@ -402,6 +408,12 @@ impl Connection {
 
     /// Writes a client operation to the write buffer.
     pub(crate) fn enqueue_write_op(&mut self, item: &ClientOp) {
+        macro_rules! small_write {
+            ($dst:expr) => {
+                write!(self.small_write(), $dst).expect("do small write to Connection");
+            };
+        }
+
         match item {
             ClientOp::Connect(connect_info) => {
                 let json = serde_json::to_vec(&connect_info).expect("serialize `ConnectInfo`");
@@ -416,17 +428,15 @@ impl Connection {
                 respond,
                 headers,
             } => {
-                self.write(match headers.as_ref() {
-                    Some(headers) if !headers.is_empty() => "HPUB ",
-                    _ => "PUB ",
-                });
+                let verb = match headers.as_ref() {
+                    Some(headers) if !headers.is_empty() => "HPUB",
+                    _ => "PUB",
+                };
 
-                self.write(Bytes::copy_from_slice(subject.as_bytes()));
-                self.write(" ");
+                small_write!("{verb} {subject} ");
 
                 if let Some(respond) = respond {
-                    self.write(Bytes::copy_from_slice(respond.as_bytes()));
-                    self.write(" ");
+                    small_write!("{respond} ");
                 }
 
                 match headers {
@@ -435,12 +445,12 @@ impl Connection {
 
                         let headers_len = headers.len();
                         let total_len = headers_len + payload.len();
-                        self.write(format!("{headers_len} {total_len}\r\n"));
+                        small_write!("{headers_len} {total_len}\r\n");
                         self.write(headers);
                     }
                     _ => {
                         let payload_len = payload.len();
-                        self.write(format!("{payload_len}\r\n"));
+                        small_write!("{payload_len}\r\n");
                     }
                 }
 
@@ -452,23 +462,23 @@ impl Connection {
                 sid,
                 subject,
                 queue_group,
-            } => {
-                self.write(match queue_group {
-                    Some(queue_group) => {
-                        format!("SUB {subject} {queue_group} {sid}\r\n")
-                    }
-                    None => {
-                        format!("SUB {subject} {sid}\r\n")
-                    }
-                });
-            }
+            } => match queue_group {
+                Some(queue_group) => {
+                    small_write!("SUB {subject} {queue_group} {sid}\r\n");
+                }
+                None => {
+                    small_write!("SUB {subject} {sid}\r\n");
+                }
+            },
 
-            ClientOp::Unsubscribe { sid, max } => {
-                self.write(match max {
-                    Some(max) => format!("UNSUB {sid} {max}\r\n"),
-                    None => format!("UNSUB {sid}\r\n"),
-                });
-            }
+            ClientOp::Unsubscribe { sid, max } => match max {
+                Some(max) => {
+                    small_write!("UNSUB {sid} {max}\r\n");
+                }
+                None => {
+                    small_write!("UNSUB {sid}\r\n");
+                }
+            },
             ClientOp::Ping => {
                 self.write("PING\r\n");
             }
@@ -492,8 +502,9 @@ impl Connection {
     ///   may do a partial write before failing.
     pub(crate) fn poll_write(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         loop {
-            let buf = match self.write_buf.front_mut() {
-                Some(buf) => buf,
+            let buf = match self.write_buf.front() {
+                Some(buf) => &**buf,
+                None if !self.flattened_writes.is_empty() => &self.flattened_writes,
                 None => return Poll::Ready(Ok(())),
             };
 
@@ -505,10 +516,16 @@ impl Connection {
                     self.write_buf_len -= n;
                     self.can_flush = true;
 
-                    if n < buf.len() {
-                        buf.advance(n);
-                    } else {
-                        self.write_buf.pop_front();
+                    match self.write_buf.front_mut() {
+                        Some(buf) if n < buf.len() => {
+                            buf.advance(n);
+                        }
+                        Some(_buf) => {
+                            self.write_buf.pop_front();
+                        }
+                        None => {
+                            self.flattened_writes.advance(n);
+                        }
                     }
                     continue;
                 }
@@ -519,6 +536,9 @@ impl Connection {
 
     /// Write `buf` into the writes buffer
     ///
+    /// If `buf` is smaller than [`WRITE_FLATTEN_THRESHOLD`]
+    /// flattens it, otherwise appends it to the chunks queue.
+    ///
     /// Empty `buf`s are a no-op.
     fn write(&mut self, buf: impl Into<Bytes>) {
         let buf = buf.into();
@@ -527,7 +547,32 @@ impl Connection {
         }
 
         self.write_buf_len += buf.len();
-        self.write_buf.push_back(buf);
+        if buf.len() < WRITE_FLATTEN_THRESHOLD {
+            self.flattened_writes.extend_from_slice(&buf);
+        } else {
+            if !self.flattened_writes.is_empty() {
+                let buf = self.flattened_writes.split().freeze();
+                self.write_buf.push_back(buf);
+            }
+
+            self.write_buf.push_back(buf);
+        }
+    }
+
+    /// Obtain an [`fmt::Write`]r for the small writes buffer.
+    fn small_write(&mut self) -> impl fmt::Write + '_ {
+        struct Writer<'a> {
+            this: &'a mut Connection,
+        }
+
+        impl<'a> fmt::Write for Writer<'a> {
+            fn write_str(&mut self, s: &str) -> fmt::Result {
+                self.this.write_buf_len += s.len();
+                self.this.flattened_writes.write_str(s)
+            }
+        }
+
+        Writer { this: self }
     }
 
     /// Flush the write buffer, sending all pending data down the current write stream.

--- a/async-nats/src/connection.rs
+++ b/async-nats/src/connection.rs
@@ -372,14 +372,21 @@ impl Connection {
         }
     }
 
-    pub(crate) async fn write_op<'a>(&mut self, item: &'a ClientOp) -> io::Result<()> {
-        self.enqueue_write_op(item);
+    pub(crate) async fn easy_write_and_flush<'a>(
+        &mut self,
+        items: impl Iterator<Item = &'a ClientOp>,
+    ) -> io::Result<()> {
+        for item in items {
+            self.enqueue_write_op(item);
+        }
 
-        future::poll_fn(|cx| self.poll_write(cx)).await
+        future::poll_fn(|cx| self.poll_write(cx)).await?;
+        future::poll_fn(|cx| self.poll_flush(cx)).await?;
+        Ok(())
     }
 
     /// Writes a client operation to the write buffer.
-    fn enqueue_write_op<'a>(&mut self, item: &'a ClientOp) {
+    pub(crate) fn enqueue_write_op(&mut self, item: &ClientOp) {
         match item {
             ClientOp::Connect(connect_info) => {
                 let json = serde_json::to_vec(&connect_info).expect("serialize `ConnectInfo`");
@@ -468,7 +475,7 @@ impl Connection {
     /// * `Poll::Ready(Err(err))` means that writing to the stream failed.
     ///   Compared to [`AsyncWrite::poll_write`], this implementation
     ///   may do a partial write before failing.
-    fn poll_write(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    pub(crate) fn poll_write(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         loop {
             let buf = match self.write_buf.front_mut() {
                 Some(buf) => buf,
@@ -495,7 +502,7 @@ impl Connection {
     }
 
     /// Write `buf` into the writes buffer
-    /// 
+    ///
     /// Empty `buf`s are a no-op.
     fn write(&mut self, buf: impl Into<Bytes>) {
         let buf = buf.into();
@@ -505,11 +512,6 @@ impl Connection {
 
         self.write_buf_len += buf.len();
         self.write_buf.push_back(buf);
-    }
-
-    /// Flush the write buffer, sending all pending data down the current write stream.
-    pub(crate) fn flush(&mut self) -> impl Future<Output = io::Result<()>> + '_ {
-        future::poll_fn(|cx| self.poll_flush(cx))
     }
 
     /// Flush the write buffer, sending all pending data down the current write stream.
@@ -817,15 +819,17 @@ mod write_op {
         let mut connection = Connection::new(Box::new(stream), 0);
 
         connection
-            .write_op(&ClientOp::Publish {
-                subject: "FOO.BAR".into(),
-                payload: "Hello World".into(),
-                respond: None,
-                headers: None,
-            })
+            .easy_write_and_flush(
+                [ClientOp::Publish {
+                    subject: "FOO.BAR".into(),
+                    payload: "Hello World".into(),
+                    respond: None,
+                    headers: None,
+                }]
+                .iter(),
+            )
             .await
             .unwrap();
-        connection.flush().await.unwrap();
 
         let mut buffer = String::new();
         let mut reader = BufReader::new(server);
@@ -834,15 +838,17 @@ mod write_op {
         assert_eq!(buffer, "PUB FOO.BAR 11\r\nHello World\r\n");
 
         connection
-            .write_op(&ClientOp::Publish {
-                subject: "FOO.BAR".into(),
-                payload: "Hello World".into(),
-                respond: Some("INBOX.67".into()),
-                headers: None,
-            })
+            .easy_write_and_flush(
+                [ClientOp::Publish {
+                    subject: "FOO.BAR".into(),
+                    payload: "Hello World".into(),
+                    respond: Some("INBOX.67".into()),
+                    headers: None,
+                }]
+                .iter(),
+            )
             .await
             .unwrap();
-        connection.flush().await.unwrap();
 
         buffer.clear();
         reader.read_line(&mut buffer).await.unwrap();
@@ -850,18 +856,20 @@ mod write_op {
         assert_eq!(buffer, "PUB FOO.BAR INBOX.67 11\r\nHello World\r\n");
 
         connection
-            .write_op(&ClientOp::Publish {
-                subject: "FOO.BAR".into(),
-                payload: "Hello World".into(),
-                respond: Some("INBOX.67".into()),
-                headers: Some(HeaderMap::from_iter([(
-                    "Header".parse().unwrap(),
-                    "X".parse().unwrap(),
-                )])),
-            })
+            .easy_write_and_flush(
+                [ClientOp::Publish {
+                    subject: "FOO.BAR".into(),
+                    payload: "Hello World".into(),
+                    respond: Some("INBOX.67".into()),
+                    headers: Some(HeaderMap::from_iter([(
+                        "Header".parse().unwrap(),
+                        "X".parse().unwrap(),
+                    )])),
+                }]
+                .iter(),
+            )
             .await
             .unwrap();
-        connection.flush().await.unwrap();
 
         buffer.clear();
         reader.read_line(&mut buffer).await.unwrap();
@@ -880,14 +888,16 @@ mod write_op {
         let mut connection = Connection::new(Box::new(stream), 0);
 
         connection
-            .write_op(&ClientOp::Subscribe {
-                sid: 11,
-                subject: "FOO.BAR".into(),
-                queue_group: None,
-            })
+            .easy_write_and_flush(
+                [ClientOp::Subscribe {
+                    sid: 11,
+                    subject: "FOO.BAR".into(),
+                    queue_group: None,
+                }]
+                .iter(),
+            )
             .await
             .unwrap();
-        connection.flush().await.unwrap();
 
         let mut buffer = String::new();
         let mut reader = BufReader::new(server);
@@ -895,14 +905,16 @@ mod write_op {
         assert_eq!(buffer, "SUB FOO.BAR 11\r\n");
 
         connection
-            .write_op(&ClientOp::Subscribe {
-                sid: 11,
-                subject: "FOO.BAR".into(),
-                queue_group: Some("QUEUE.GROUP".into()),
-            })
+            .easy_write_and_flush(
+                [ClientOp::Subscribe {
+                    sid: 11,
+                    subject: "FOO.BAR".into(),
+                    queue_group: Some("QUEUE.GROUP".into()),
+                }]
+                .iter(),
+            )
             .await
             .unwrap();
-        connection.flush().await.unwrap();
 
         buffer.clear();
         reader.read_line(&mut buffer).await.unwrap();
@@ -915,10 +927,9 @@ mod write_op {
         let mut connection = Connection::new(Box::new(stream), 0);
 
         connection
-            .write_op(&ClientOp::Unsubscribe { sid: 11, max: None })
+            .easy_write_and_flush([ClientOp::Unsubscribe { sid: 11, max: None }].iter())
             .await
             .unwrap();
-        connection.flush().await.unwrap();
 
         let mut buffer = String::new();
         let mut reader = BufReader::new(server);
@@ -926,13 +937,15 @@ mod write_op {
         assert_eq!(buffer, "UNSUB 11\r\n");
 
         connection
-            .write_op(&ClientOp::Unsubscribe {
-                sid: 11,
-                max: Some(2),
-            })
+            .easy_write_and_flush(
+                [ClientOp::Unsubscribe {
+                    sid: 11,
+                    max: Some(2),
+                }]
+                .iter(),
+            )
             .await
             .unwrap();
-        connection.flush().await.unwrap();
 
         buffer.clear();
         reader.read_line(&mut buffer).await.unwrap();
@@ -947,8 +960,10 @@ mod write_op {
         let mut reader = BufReader::new(server);
         let mut buffer = String::new();
 
-        connection.write_op(&ClientOp::Ping).await.unwrap();
-        connection.flush().await.unwrap();
+        connection
+            .easy_write_and_flush([ClientOp::Ping].iter())
+            .await
+            .unwrap();
 
         reader.read_line(&mut buffer).await.unwrap();
 
@@ -963,8 +978,10 @@ mod write_op {
         let mut reader = BufReader::new(server);
         let mut buffer = String::new();
 
-        connection.write_op(&ClientOp::Pong).await.unwrap();
-        connection.flush().await.unwrap();
+        connection
+            .easy_write_and_flush([ClientOp::Pong].iter())
+            .await
+            .unwrap();
 
         reader.read_line(&mut buffer).await.unwrap();
 
@@ -980,27 +997,29 @@ mod write_op {
         let mut buffer = String::new();
 
         connection
-            .write_op(&ClientOp::Connect(ConnectInfo {
-                verbose: false,
-                pedantic: false,
-                user_jwt: None,
-                nkey: None,
-                signature: None,
-                name: None,
-                echo: false,
-                lang: "Rust".into(),
-                version: "1.0.0".into(),
-                protocol: Protocol::Dynamic,
-                tls_required: false,
-                user: None,
-                pass: None,
-                auth_token: None,
-                headers: false,
-                no_responders: false,
-            }))
+            .easy_write_and_flush(
+                [ClientOp::Connect(ConnectInfo {
+                    verbose: false,
+                    pedantic: false,
+                    user_jwt: None,
+                    nkey: None,
+                    signature: None,
+                    name: None,
+                    echo: false,
+                    lang: "Rust".into(),
+                    version: "1.0.0".into(),
+                    protocol: Protocol::Dynamic,
+                    tls_required: false,
+                    user: None,
+                    pass: None,
+                    auth_token: None,
+                    headers: false,
+                    no_responders: false,
+                })]
+                .iter(),
+            )
             .await
             .unwrap();
-        connection.flush().await.unwrap();
 
         reader.read_line(&mut buffer).await.unwrap();
         assert_eq!(

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -40,7 +40,6 @@ use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::BufWriter;
 use tokio::io::ErrorKind;
 use tokio::net::TcpStream;
 use tokio::time::sleep;
@@ -296,7 +295,7 @@ impl Connector {
         tcp_stream.set_nodelay(true)?;
 
         let mut connection = Connection::new(
-            Box::new(BufWriter::new(tcp_stream)),
+            Box::new(tcp_stream),
             self.options.read_buffer_capacity.into(),
         );
 

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -101,10 +101,10 @@ impl Connector {
         })
     }
 
-    pub(crate) async fn connect(&mut self) -> Result<(ServerInfo, Connection), io::Error> {
+    pub(crate) async fn connect(&mut self) -> (ServerInfo, Connection) {
         loop {
             match self.try_connect().await {
-                Ok(inner) => return Ok(inner),
+                Ok(inner) => return inner,
                 Err(error) => {
                     self.events_tx
                         .send(Event::ClientError(ClientError::Other(error.to_string())))

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -237,10 +237,10 @@ impl Connector {
                         }
 
                         connection
-                            .write_op(&ClientOp::Connect(connect_info))
+                            .easy_write_and_flush(
+                                [ClientOp::Connect(connect_info), ClientOp::Ping].iter(),
+                            )
                             .await?;
-                        connection.write_op(&ClientOp::Ping).await?;
-                        connection.flush().await?;
 
                         match connection.read_op().await? {
                             Some(ServerOp::Error(err)) => match err {

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -153,11 +153,6 @@ impl Consumer<Config> {
             .publish_with_reply(subject, inbox, payload.into())
             .await
             .map_err(|err| BatchRequestError::with_source(BatchRequestErrorKind::Publish, err))?;
-        self.context
-            .client
-            .flush()
-            .await
-            .map_err(|err| BatchRequestError::with_source(BatchRequestErrorKind::Flush, err))?;
         debug!("batch request sent");
         Ok(())
     }
@@ -924,9 +919,6 @@ impl Stream {
                         .publish_with_reply(subject.clone(), inbox.clone(), request.clone())
                         .await
                         .map(|_| pending_reset);
-                    if let Err(err) = consumer.context.client.flush().await {
-                        debug!("flush failed: {err:?}");
-                    }
                     // TODO: add tracing instead of ignoring this.
                     request_result_tx
                         .send(result.map(|_| pending_reset).map_err(|err| {

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -682,7 +682,6 @@ impl<'a> futures::Stream for Ordered<'a> {
                                                 .publish(subject, Bytes::from_static(b""))
                                                 .await
                                                 .ok();
-                                            client.flush().await.ok();
                                         });
                                     }
                                     continue;

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -18,7 +18,7 @@ use crate::header::{IntoHeaderName, IntoHeaderValue};
 use crate::jetstream::account::Account;
 use crate::jetstream::publish::PublishAck;
 use crate::jetstream::response::Response;
-use crate::{header, Client, Command, HeaderMap, HeaderValue, StatusCode};
+use crate::{header, Client, HeaderMap, HeaderValue, StatusCode};
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::{Future, StreamExt, TryFutureExt};
@@ -987,7 +987,6 @@ pub struct PublishAckFuture {
 
 impl PublishAckFuture {
     async fn next_with_timeout(mut self) -> Result<PublishAck, PublishError> {
-        self.subscription.sender.send(Command::TryFlush).await.ok();
         let next = tokio::time::timeout(self.timeout, self.subscription.next())
             .await
             .map_err(|_| PublishError::new(PublishErrorKind::TimedOut))?;

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1058,7 +1058,6 @@ impl Subscriber {
     ///
     /// let mut subscriber = client.subscribe("test".into()).await?;
     /// subscriber.unsubscribe_after(3).await?;
-    /// client.flush().await?;
     ///
     /// for _ in 0..3 {
     ///     client.publish("test".into(), "data".into()).await?;

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -340,7 +340,6 @@ pub(crate) struct ConnectionHandler {
     pending_pings: usize,
     info_sender: tokio::sync::watch::Sender<ServerInfo>,
     ping_interval: Interval,
-    flush_interval: Interval,
     is_flushing: bool,
     flush_observers: Vec<oneshot::Sender<()>>,
 }
@@ -351,13 +350,9 @@ impl ConnectionHandler {
         connector: Connector,
         info_sender: tokio::sync::watch::Sender<ServerInfo>,
         ping_period: Duration,
-        flush_period: Duration,
     ) -> ConnectionHandler {
         let mut ping_interval = interval(ping_period);
         ping_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
-        let mut flush_interval = interval(flush_period);
-        flush_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         ConnectionHandler {
             connection,
@@ -367,7 +362,6 @@ impl ConnectionHandler {
             pending_pings: 0,
             info_sender,
             ping_interval,
-            flush_interval,
             is_flushing: false,
             flush_observers: Vec::new(),
         }
@@ -491,7 +485,7 @@ impl ConnectionHandler {
                 }
 
                 if !self.handler.is_flushing && self.handler.connection.should_flush() {
-                    self.handler.is_flushing = self.handler.flush_interval.poll_tick(cx).is_ready();
+                    self.handler.is_flushing = true;
                 }
 
                 if self.handler.is_flushing {
@@ -499,7 +493,6 @@ impl ConnectionHandler {
                         Poll::Pending => {}
                         Poll::Ready(Ok(())) => {
                             self.handler.is_flushing = false;
-                            self.handler.flush_interval.reset();
 
                             for observer in self.handler.flush_observers.drain(..) {
                                 let _ = observer.send(());
@@ -790,7 +783,6 @@ pub async fn connect_with_options<A: ToServerAddrs>(
     options: ConnectOptions,
 ) -> Result<Client, ConnectError> {
     let ping_period = options.ping_interval;
-    let flush_period = options.flush_interval;
 
     let (events_tx, mut events_rx) = mpsc::channel(128);
     let (state_tx, state_rx) = tokio::sync::watch::channel(State::Pending);
@@ -852,13 +844,8 @@ pub async fn connect_with_options<A: ToServerAddrs>(
             connection = Some(connection_ok);
         }
         let connection = connection.unwrap();
-        let mut connection_handler = ConnectionHandler::new(
-            connection,
-            connector,
-            info_sender,
-            ping_period,
-            flush_period,
-        );
+        let mut connection_handler =
+            ConnectionHandler::new(connection, connector, info_sender, ping_period);
         connection_handler.process(&mut receiver).await
     });
 

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -122,15 +122,16 @@
 
 use thiserror::Error;
 
-use futures::future::FutureExt;
-use futures::select;
 use futures::stream::Stream;
+use tokio::sync::oneshot;
 use tracing::{debug, error};
 
 use core::fmt;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::future::Future;
 use std::iter;
+use std::mem;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::option;
 use std::pin::Pin;
@@ -145,7 +146,7 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use tokio::io;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tokio::task;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -372,80 +373,171 @@ impl ConnectionHandler {
         }
     }
 
-    pub(crate) async fn process(
-        &mut self,
-        mut receiver: mpsc::Receiver<Command>,
-    ) -> Result<(), io::Error> {
-        loop {
-            select! {
-                _ = self.ping_interval.tick().fuse() => {
-                    self.pending_pings += 1;
+    pub(crate) async fn process<'a>(&'a mut self, receiver: &'a mut mpsc::Receiver<Command>) {
+        struct ProcessFut<'a> {
+            handler: &'a mut ConnectionHandler,
+            receiver: &'a mut mpsc::Receiver<Command>,
+        }
 
-                    if self.pending_pings > MAX_PENDING_PINGS {
-                        debug!(
-                            "pending pings {}, max pings {}. disconnecting",
-                            self.pending_pings, MAX_PENDING_PINGS
-                        );
-                        self.handle_disconnect().await?;
-                    }
+        enum ExitReason {
+            Disconnected(Option<io::Error>),
+            Closed,
+        }
 
-                    self.connection.enqueue_write_op(&ClientOp::Ping);
+        impl<'a> ProcessFut<'a> {
+            #[cold]
+            fn ping(&mut self) -> Poll<ExitReason> {
+                self.handler.pending_pings += 1;
 
-                },
-                _ = self.flush_interval.tick().fuse() => {
-                    if let Err(_err) = self.handle_flush().await {
-                        self.handle_disconnect().await?;
-                    }
-                },
-                maybe_command = receiver.recv().fuse() => {
-                    match maybe_command {
-                        Some(command) => {
-                            self.handle_command(command);
+                if self.handler.pending_pings > MAX_PENDING_PINGS {
+                    debug!(
+                        "pending pings {}, max pings {}. disconnecting",
+                        self.handler.pending_pings, MAX_PENDING_PINGS
+                    );
 
-                            if self.is_flushing {
-                                if let Err(_err) = self.handle_flush().await {
-                                    self.handle_disconnect().await?;
-                                }
-                            }
-                        }
-                        None => {
-                            break;
-                        }
-                    }
-                }
+                    Poll::Ready(ExitReason::Disconnected(None))
+                } else {
+                    self.handler.connection.enqueue_write_op(&ClientOp::Ping);
+                    self.handler.is_flushing = true;
 
-                maybe_op_result = self.connection.read_op().fuse() => {
-                    match maybe_op_result {
-                        Ok(Some(server_op)) => if let Err(err) = self.handle_server_op(server_op).await {
-                            error!("error handling operation {}", err);
-                        }
-                        Ok(None) => {
-                            if let Err(err) = self.handle_disconnect().await {
-                                error!("error handling operation {}", err);
-                            }
-                        }
-                        Err(op_err) => {
-                            if let Err(err) = self.handle_disconnect().await {
-                                error!("error reconnecting {}. original error={}", err, op_err);
-                            }
-                        },
-                    }
+                    Poll::Pending
                 }
             }
         }
 
-        self.handle_flush().await?;
+        impl<'a> Future for ProcessFut<'a> {
+            type Output = ExitReason;
 
-        Ok(())
+            /// Drives the connection forward.
+            ///
+            /// Returns one of the following:
+            ///
+            /// * `Poll::Pending` means that the connection
+            ///   is blocked on all fronts or there are
+            ///   no commands to send or receive
+            /// * `Poll::Ready(ExitReason::Disconnected(_))` means
+            ///   that an I/O operation failed and the connection
+            ///   is considered dead.
+            /// * `Poll::Ready(ExitReason::Closed)` means that
+            ///   [`Self::receiver`] was closed, so there's nothing
+            ///   more for us to do than to exit the client.
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+                if self.handler.ping_interval.poll_tick(cx).is_ready() {
+                    if let Poll::Ready(exit) = self.ping() {
+                        return Poll::Ready(exit);
+                    }
+                }
+
+                loop {
+                    match self.handler.connection.poll_read_op(cx) {
+                        Poll::Pending => break,
+                        Poll::Ready(Ok(Some(server_op))) => {
+                            self.handler.handle_server_op(server_op);
+                        }
+                        Poll::Ready(Ok(None)) => {
+                            return Poll::Ready(ExitReason::Disconnected(None))
+                        }
+                        Poll::Ready(Err(err)) => {
+                            return Poll::Ready(ExitReason::Disconnected(Some(err)))
+                        }
+                    }
+                }
+
+                // WARNING: after the following loop `handle_command`,
+                // or other functions which call `enqueue_write_op`,
+                // cannot be called anymore. Runtime wakeups won't
+                // trigger a call to `poll_write`
+
+                let mut made_progress = true;
+                loop {
+                    while !self.handler.connection.is_write_buf_full() {
+                        match self.receiver.poll_recv(cx) {
+                            Poll::Pending => break,
+                            Poll::Ready(Some(cmd)) => {
+                                made_progress = true;
+                                self.handler.handle_command(cmd);
+                            }
+                            Poll::Ready(None) => return Poll::Ready(ExitReason::Closed),
+                        }
+                    }
+
+                    // The first round will poll both from
+                    // the `receiver` and the writer, giving
+                    // them both a chance to make progress
+                    // and register `Waker`s.
+                    //
+                    // If writing is `Poll::Pending` we exit.
+                    //
+                    // If writing is completed we can repeat the entire
+                    // cycle as long as the `receiver` doesn't end-up
+                    // `Poll::Pending` immediately.
+                    if !mem::take(&mut made_progress) {
+                        break;
+                    }
+
+                    match self.handler.connection.poll_write(cx) {
+                        Poll::Pending => {
+                            // Write buffer couldn't be fully emptied
+                            break;
+                        }
+                        Poll::Ready(Ok(())) => {
+                            // Write buffer is empty
+                            continue;
+                        }
+                        Poll::Ready(Err(err)) => {
+                            return Poll::Ready(ExitReason::Disconnected(Some(err)))
+                        }
+                    }
+                }
+
+                if !self.handler.is_flushing && self.handler.connection.should_flush() {
+                    self.handler.is_flushing = self.handler.flush_interval.poll_tick(cx).is_ready();
+                }
+
+                if self.handler.is_flushing {
+                    match self.handler.connection.poll_flush(cx) {
+                        Poll::Pending => {}
+                        Poll::Ready(Ok(())) => {
+                            self.handler.is_flushing = false;
+                            self.handler.flush_interval.reset();
+
+                            for observer in self.handler.flush_observers.drain(..) {
+                                let _ = observer.send(());
+                            }
+                        }
+                        Poll::Ready(Err(err)) => {
+                            return Poll::Ready(ExitReason::Disconnected(Some(err)))
+                        }
+                    }
+                }
+
+                Poll::Pending
+            }
+        }
+
+        loop {
+            let process = ProcessFut {
+                handler: self,
+                receiver,
+            };
+            match process.await {
+                ExitReason::Disconnected(err) => {
+                    debug!(?err, "disconnected");
+
+                    self.handle_disconnect().await;
+                    debug!("reconnected");
+                }
+                ExitReason::Closed => break,
+            }
+        }
     }
 
-    async fn handle_server_op(&mut self, server_op: ServerOp) -> Result<(), io::Error> {
+    fn handle_server_op(&mut self, server_op: ServerOp) {
         self.ping_interval.reset();
 
         match server_op {
             ServerOp::Ping => {
                 self.connection.enqueue_write_op(&ClientOp::Pong);
-                self.handle_flush().await?;
             }
             ServerOp::Pong => {
                 debug!("received PONG");
@@ -495,8 +587,7 @@ impl ConnectionHandler {
                         Err(mpsc::error::TrySendError::Full(_)) => {
                             self.connector
                                 .events_tx
-                                .send(Event::SlowConsumer(sid))
-                                .await
+                                .try_send(Event::SlowConsumer(sid))
                                 .ok();
                         }
                         Err(mpsc::error::TrySendError::Closed(_)) => {
@@ -530,11 +621,7 @@ impl ConnectionHandler {
             // TODO: we should probably update advertised server list here too.
             ServerOp::Info(info) => {
                 if info.lame_duck_mode {
-                    self.connector
-                        .events_tx
-                        .send(Event::LameDuckMode)
-                        .await
-                        .ok();
+                    self.connector.events_tx.try_send(Event::LameDuckMode).ok();
                 }
             }
 
@@ -542,20 +629,6 @@ impl ConnectionHandler {
                 // TODO: don't ignore.
             }
         }
-
-        Ok(())
-    }
-
-    async fn handle_flush(&mut self) -> io::Result<()> {
-        self.connection.easy_write_and_flush([].iter()).await?;
-
-        self.flush_interval.reset();
-        self.is_flushing = false;
-
-        for observer in self.handler.flush_observers.drain(..) {
-            let _ = observer.send(());
-        }
-        Ok(())
     }
 
     fn handle_command(&mut self, command: Command) {
@@ -661,24 +734,18 @@ impl ConnectionHandler {
         }
     }
 
-    async fn handle_disconnect(&mut self) -> io::Result<()> {
+    async fn handle_disconnect(&mut self) {
         self.pending_pings = 0;
         self.connector.events_tx.try_send(Event::Disconnected).ok();
         self.connector.state_tx.send(State::Disconnected).ok();
-        self.handle_reconnect().await?;
 
-        Ok(())
+        self.handle_reconnect().await;
     }
 
-    async fn handle_reconnect(&mut self) -> Result<(), io::Error> {
-        let (info, connection) = self.connector.connect().await?;
+    async fn handle_reconnect(&mut self) {
+        let (info, connection) = self.connector.connect().await;
         self.connection = connection;
-        self.info_sender.send(info).map_err(|err| {
-            std::io::Error::new(
-                ErrorKind::Other,
-                format!("failed to send info update: {err}"),
-            )
-        })?;
+        let _ = self.info_sender.send(info);
 
         self.subscriptions
             .retain(|_, subscription| !subscription.sender.is_closed());
@@ -700,8 +767,6 @@ impl ConnectionHandler {
         }
 
         self.connector.events_tx.try_send(Event::Connected).ok();
-
-        Ok(())
     }
 }
 
@@ -763,7 +828,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
     }
 
     let (info_sender, info_watcher) = tokio::sync::watch::channel(info);
-    let (sender, receiver) = mpsc::channel(options.sender_capacity);
+    let (sender, mut receiver) = mpsc::channel(options.sender_capacity);
 
     let client = Client::new(
         info_watcher,
@@ -782,7 +847,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
 
     task::spawn(async move {
         if connection.is_none() && options.retry_on_initial_connect {
-            let (info, connection_ok) = connector.connect().await.unwrap();
+            let (info, connection_ok) = connector.connect().await;
             info_sender.send(info).ok();
             connection = Some(connection_ok);
         }
@@ -794,7 +859,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
             ping_period,
             flush_period,
         );
-        connection_handler.process(receiver).await
+        connection_handler.process(&mut receiver).await
     });
 
     Ok(client)

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -55,7 +55,6 @@ pub struct ConnectOptions {
     pub(crate) client_cert: Option<PathBuf>,
     pub(crate) client_key: Option<PathBuf>,
     pub(crate) tls_client_config: Option<rustls::ClientConfig>,
-    pub(crate) flush_interval: Duration,
     pub(crate) ping_interval: Duration,
     pub(crate) subscription_capacity: usize,
     pub(crate) sender_capacity: usize,
@@ -84,7 +83,6 @@ impl fmt::Debug for ConnectOptions {
             .entry(&"client_cert", &self.client_cert)
             .entry(&"client_key", &self.client_key)
             .entry(&"tls_client_config", &"XXXXXXXX")
-            .entry(&"flush_interval", &self.flush_interval)
             .entry(&"ping_interval", &self.ping_interval)
             .entry(&"sender_capacity", &self.sender_capacity)
             .entry(&"inbox_prefix", &self.inbox_prefix)
@@ -108,7 +106,6 @@ impl Default for ConnectOptions {
             client_cert: None,
             client_key: None,
             tls_client_config: None,
-            flush_interval: Duration::from_millis(1),
             ping_interval: Duration::from_secs(60),
             sender_capacity: 128,
             subscription_capacity: 4096,
@@ -565,27 +562,6 @@ impl ConnectOptions {
     /// ```
     pub fn require_tls(mut self, is_required: bool) -> ConnectOptions {
         self.tls_required = is_required;
-        self
-    }
-
-    /// Sets the interval for flushing. NATS connection will send buffered data to the NATS Server
-    /// whenever buffer limit is reached, but it is also necessary to flush once in a while if
-    /// client is sending rarely and small messages. Flush interval allows to modify that interval.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use tokio::time::Duration;
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), async_nats::ConnectError> {
-    /// async_nats::ConnectOptions::new()
-    ///     .flush_interval(Duration::from_millis(100))
-    ///     .connect("demo.nats.io")
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn flush_interval(mut self, flush_interval: Duration) -> ConnectOptions {
-        self.flush_interval = flush_interval;
         self
     }
 

--- a/async-nats/tests/kv_tests.rs
+++ b/async-nats/tests/kv_tests.rs
@@ -335,7 +335,7 @@ mod kv {
             .await
             .unwrap();
 
-        let context = async_nats::jetstream::new(client);
+        let context = async_nats::jetstream::new(client.clone());
 
         let kv = context
             .create_key_value(async_nats::jetstream::kv::Config {
@@ -352,6 +352,7 @@ mod kv {
         // check if we get only updated values. This should not pop up in watcher.
         kv.put("foo", 22.to_string().into()).await.unwrap();
         let mut watch = kv.watch("foo").await.unwrap().enumerate();
+        client.flush().await.unwrap();
 
         tokio::task::spawn({
             let kv = kv.clone();


### PR DESCRIPTION
This is an attempt at refactoring `Connection`  and `ConnectionHandler` to use `poll` instead of `async` `.await` syntax.

Advantages:

1. Ability to continue reading while in the middle of writing: previously a write operation would block read operations from happening. Now as soon as an operation returns `Poll::Pending` the other operations can be polled
2. Ability to continue reading and writing while in the middle of flushing: previously flushing blocked everything else until it completed
3. Easier control of connection state and reduced error branches because of centralized connection error handling
4. Removal of `select!` from a very critical path. The issues with it are the following:
    * It relies on the `Future`s polled by it's branches to be _cancel safe_. Cancel safety requires `Drop`ping of a `Future` to be a no-op. While this seemed to be true it's easy to get wrong.
    * Execution of the expression blocks all other operations (see point 1 and 2)
5. No more flush interval
6. Higher write performance thanks to flattening of small writes (buffering them ourselves) and vectored writes when possible

Left to implement:

* [x] Flush interval
* [x] Vectored writes
* [x] Disconnect handling
* [x] Write backpressure
* [x] Reimplement `flush`
* [x] Cleanup commits
* [x] Benchmarks

Fixes #905
Fixes #923
Fixes #582 
Closes #869
Closes #935
Closes #971 
Closes #1070