### PR TITLE
Fix potentially ambiguous `.as_ref()`

### DIFF
--- a/async-nats/src/tls.rs
+++ b/async-nats/src/tls.rs
@@ -77,7 +77,7 @@ pub(crate) async fn config_tls(options: &ConnectorOptions) -> io::Result<rustls:
                 .into_iter()
                 .map(|cert| cert.0)
                 .collect::<Vec<Vec<u8>>>()
-                .as_ref(),
+                .as_slice(),
         );
     }
 


### PR DESCRIPTION
#1017 was reported as a breaking change made to `rustls`. This isn't really the case. The true culprit is this vague `.as_ref()` call.

In general, it is allowed to change a fn that used to take `T` to now take `impl Trait` where `T: Trait`. `AsRef` is an unfortunate example of a trait that is often misused like this.

There may be more of these cases, if possible they should be switched so that a new `AsRef` impl or change such as was made in `rustls` doesn't break downstreams again.