### PR TITLE
Specialize errors

### DIFF
--- a/async-nats/src/error.rs
+++ b/async-nats/src/error.rs
@@ -73,7 +73,7 @@ where
 
 /// Enables wrapping source errors to the crate-specific error type
 /// by additionally specifying the kind of the target error.
-trait WithKind<Kind>
+pub(crate) trait WithKind<Kind>
 where
     Kind: Clone + Debug + Display + PartialEq,
     Self: Into<crate::Error>,

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -29,7 +29,7 @@ use crate::{
     connection::State,
     error::Error,
     jetstream::{self, Context},
-    StatusCode, SubscribeError, Subscriber,
+    RequestError, RequestErrorKind, StatusCode, Subscriber,
 };
 
 use super::{
@@ -2181,9 +2181,14 @@ impl std::fmt::Display for BatchErrorKind {
 
 pub type BatchError = Error<BatchErrorKind>;
 
-impl From<SubscribeError> for BatchError {
-    fn from(err: SubscribeError) -> Self {
-        BatchError::with_source(BatchErrorKind::Subscribe, err)
+impl From<RequestError> for BatchError {
+    fn from(err: RequestError) -> Self {
+        match err.kind {
+            RequestErrorKind::SubscriptionFailed => {
+                BatchError::with_source(BatchErrorKind::Subscribe, err)
+            }
+            _ => panic!("Cannot convert error"),
+        }
     }
 }
 

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -1280,9 +1280,7 @@ impl From<crate::RequestError> for RequestError {
             crate::RequestErrorKind::NoResponders => {
                 RequestError::new(RequestErrorKind::NoResponders)
             }
-            crate::RequestErrorKind::Other => {
-                RequestError::with_source(RequestErrorKind::Other, error)
-            }
+            _ => RequestError::with_source(RequestErrorKind::Other, error),
         }
     }
 }

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -141,21 +141,21 @@ impl FromStr for Operation {
             KV_OPERATION_DELETE => Ok(Operation::Delete),
             KV_OPERATION_PURGE => Ok(Operation::Purge),
             KV_OPERATION_PUT => Ok(Operation::Put),
-            _ => Err(ParseOperationError),
+            _ => Err(ParseOperationError::new(ParseOperationErrorKind)),
         }
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ParseOperationError;
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParseOperationErrorKind;
 
-impl fmt::Display for ParseOperationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for ParseOperationErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "invalid value found for operation (value can only be {KV_OPERATION_PUT}, {KV_OPERATION_PURGE} or {KV_OPERATION_DELETE}")
     }
 }
 
-impl std::error::Error for ParseOperationError {}
+pub type ParseOperationError = Error<ParseOperationErrorKind>;
 
 /// A struct used as a handle for the bucket.
 #[derive(Debug, Clone)]

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -78,9 +78,7 @@ impl From<crate::RequestError> for DirectGetError {
         match err.kind() {
             crate::RequestErrorKind::TimedOut => DirectGetError::new(DirectGetErrorKind::TimedOut),
             crate::RequestErrorKind::NoResponders => DirectGetError::new(DirectGetErrorKind::Other),
-            crate::RequestErrorKind::Other => {
-                DirectGetError::with_source(DirectGetErrorKind::Other, err)
-            }
+            _ => DirectGetError::with_source(DirectGetErrorKind::Other, err),
         }
     }
 }

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -171,7 +171,7 @@ mod options;
 
 pub use auth::Auth;
 pub use client::{Client, PublishError, Request, RequestError, RequestErrorKind, SubscribeError};
-pub use options::{AuthError, ConnectOptions};
+pub use options::{AuthError, AuthErrorKind, ConnectOptions};
 
 pub mod error;
 pub mod header;
@@ -878,6 +878,12 @@ pub type ConnectError = error::Error<ConnectErrorKind>;
 impl From<io::Error> for ConnectError {
     fn from(err: io::Error) -> Self {
         ConnectError::with_source(ConnectErrorKind::Io, err)
+    }
+}
+
+impl From<AuthError> for ConnectError {
+    fn from(value: AuthError) -> Self {
+        value.with_kind(ConnectErrorKind::Authentication)
     }
 }
 

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -12,12 +12,13 @@
 // limitations under the License.
 
 use crate::auth::Auth;
-use crate::connector;
+use crate::error::{Error, WithKind};
+use crate::{connector};
 use crate::{Client, ConnectError, Event, ToServerAddrs};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::engine::Engine;
 use futures::Future;
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 use std::{
     fmt,
     path::{Path, PathBuf},
@@ -340,7 +341,7 @@ impl ConnectOptions {
     /// let jwt = load_jwt().await?;
     /// let nc = async_nats::ConnectOptions::with_jwt(jwt, move |nonce| {
     ///     let key_pair = key_pair.clone();
-    ///     async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }
+    ///     async move { key_pair.sign(&nonce) }
     /// })
     /// .connect("localhost")
     /// .await?;
@@ -374,7 +375,7 @@ impl ConnectOptions {
     /// let nc = async_nats::ConnectOptions::new()
     ///     .jwt(jwt, move |nonce| {
     ///         let key_pair = key_pair.clone();
-    ///         async move { key_pair.sign(&nonce).map_err(async_nats::AuthError::new) }
+    ///         async move { key_pair.sign(&nonce) }
     ///     })
     ///     .connect("localhost")
     ///     .await?;
@@ -393,7 +394,7 @@ impl ConnectOptions {
             Box::pin(async move {
                 let sig = sign_cb(nonce.as_bytes().to_vec())
                     .await
-                    .map_err(AuthError::new)?;
+                    .map_err(|e| e.with_kind(AuthErrorKind::InvalidSignature))?;
                 Ok(URL_SAFE_NO_PAD.encode(sig))
             })
         }));
@@ -509,7 +510,11 @@ impl ConnectOptions {
 
         Ok(self.jwt(jwt.to_owned(), move |nonce| {
             let key_pair = key_pair.clone();
-            async move { key_pair.sign(&nonce).map_err(AuthError::new) }
+            async move {
+                key_pair
+                    .sign(&nonce)
+                    .map_err(|e| e.with_kind(AuthErrorKind::InvalidKeyPair))
+            }
         }))
     }
 
@@ -923,27 +928,20 @@ impl<A, T> fmt::Debug for CallbackArg1<A, T> {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AuthErrorKind {
+    InvalidKeyPair,
+    InvalidSignature,
+}
+
+impl Display for AuthErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidKeyPair => f.write_str("invalid keypair"),
+            Self::InvalidSignature => f.write_str("invalid signature"),
+        }
+    }
+}
+
 /// Error report from signing callback.
-// This was needed because std::io::Error isn't Send.
-#[derive(Clone, PartialEq)]
-pub struct AuthError(String);
-
-impl AuthError {
-    pub fn new(s: impl ToString) -> Self {
-        Self(s.to_string())
-    }
-}
-
-impl std::fmt::Display for AuthError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(&format!("AuthError({})", &self.0))
-    }
-}
-
-impl std::fmt::Debug for AuthError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(&format!("AuthError({})", &self.0))
-    }
-}
-
-impl std::error::Error for AuthError {}
+pub type AuthError = Error<AuthErrorKind>;

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -756,7 +756,7 @@ mod client {
     async fn publish_error_should_be_nameable() {
         let server = nats_server::run_basic_server();
         let client = async_nats::connect(server.client_url()).await.unwrap();
-        let _error: Result<(), async_nats::PublishError> =
+        let _error: Result<(), async_nats::RequestError> =
             client.publish("foo".into(), "data".into()).await;
     }
 


### PR DESCRIPTION
This is a continuation of the previous PR https://github.com/nats-io/nats.rs/pull/1010

In this one I converted all crate-specific errors to specialized versions of the generic `errors::Error<T>`. Among other improvements I also converted `PublishError`, `SubscribeError` and `UnsubscribeError` into different variants of the same `RequestError` (which is `crate::error::Error<RequestErrorKind>`) to make it easier further improvement to return concrete errors instead of `Box<dyn crate::Error>` in jetstream and service