### PR TITLE
Refactor ParseError

### DIFF
--- a/async-nats/src/error.rs
+++ b/async-nats/src/error.rs
@@ -73,7 +73,7 @@ where
 
 /// Enables wrapping source errors to the crate-specific error type
 /// by additionally specifying the kind of the target error.
-trait WithKind<Kind>
+pub(crate) trait WithKind<Kind>
 where
     Kind: Clone + Debug + Display + PartialEq,
     Self: Into<crate::Error>,

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -15,10 +15,11 @@
 
 #[cfg(feature = "server_2_10")]
 use std::collections::HashMap;
+use std::fmt::Formatter;
 use std::{
     fmt::{self, Debug, Display},
     future::IntoFuture,
-    io::{self, ErrorKind},
+    io::ErrorKind,
     pin::Pin,
     str::FromStr,
     task::Poll,
@@ -1311,31 +1312,64 @@ fn is_continuation(c: char) -> bool {
 }
 const HEADER_LINE: &str = "NATS/1.0";
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ParseHeadersErrorKind {
+    HeaderInfoMissing,
+    InvalidHeader,
+    InvalidVersionLine,
+    InvalidStatusCode,
+    MalformedHeader,
+}
+
+impl Display for ParseHeadersErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidHeader => write!(f, "invalid header"),
+            Self::InvalidStatusCode => write!(f, "invalid status code"),
+            Self::InvalidVersionLine => write!(f, "version line does not start with NATS/1.0"),
+            Self::HeaderInfoMissing => write!(f, "expected header information not found"),
+            Self::MalformedHeader => write!(f, "malformed header line"),
+        }
+    }
+}
+
+pub type ParseHeadersError = Error<ParseHeadersErrorKind>;
+
+impl From<ParseHeaderNameError> for ParseHeadersError {
+    fn from(e: ParseHeaderNameError) -> Self {
+        e.with_kind(ParseHeadersErrorKind::MalformedHeader)
+    }
+}
+
+impl From<ParseHeaderValueError> for ParseHeadersError {
+    fn from(e: ParseHeaderValueError) -> Self {
+        e.with_kind(ParseHeadersErrorKind::MalformedHeader)
+    }
+}
+
+impl From<InvalidStatusCode> for ParseHeadersError {
+    fn from(e: InvalidStatusCode) -> Self {
+        e.with_kind(ParseHeadersErrorKind::InvalidStatusCode)
+    }
+}
+
 #[allow(clippy::type_complexity)]
 fn parse_headers(
     buf: &[u8],
-) -> Result<(Option<HeaderMap>, Option<StatusCode>, Option<String>), crate::Error> {
+) -> Result<(Option<HeaderMap>, Option<StatusCode>, Option<String>), ParseHeadersError> {
     let mut headers = HeaderMap::new();
     let mut maybe_status: Option<StatusCode> = None;
     let mut maybe_description: Option<String> = None;
     let mut lines = if let Ok(line) = std::str::from_utf8(buf) {
         line.lines().peekable()
     } else {
-        return Err(Box::new(std::io::Error::new(
-            ErrorKind::Other,
-            "invalid header",
-        )));
+        return Err(ParseHeadersErrorKind::InvalidHeader.into());
     };
 
     if let Some(line) = lines.next() {
         let line = line
             .strip_prefix(HEADER_LINE)
-            .ok_or_else(|| {
-                Box::new(std::io::Error::new(
-                    ErrorKind::Other,
-                    "version line does not start with NATS/1.0",
-                ))
-            })?
+            .ok_or_else(|| ParseHeadersError::new(ParseHeadersErrorKind::InvalidHeader))?
             .trim();
 
         match line.split_once(' ') {
@@ -1355,10 +1389,7 @@ fn parse_headers(
             }
         }
     } else {
-        return Err(Box::new(std::io::Error::new(
-            ErrorKind::Other,
-            "expected header information not found",
-        )));
+        return Err(ParseHeadersErrorKind::HeaderInfoMissing.into());
     };
 
     while let Some(line) = lines.next() {
@@ -1373,16 +1404,9 @@ fn parse_headers(
                 s.push_str(v.trim());
             }
 
-            headers.insert(
-                HeaderName::from_str(k)?,
-                HeaderValue::from_str(&s)
-                    .map_err(|err| Box::new(io::Error::new(ErrorKind::Other, err)))?,
-            );
+            headers.insert(HeaderName::from_str(k)?, HeaderValue::from_str(&s)?);
         } else {
-            return Err(Box::new(std::io::Error::new(
-                ErrorKind::Other,
-                "malformed header line",
-            )));
+            return Err(ParseHeadersErrorKind::MalformedHeader.into());
         }
     }
 
@@ -1528,6 +1552,9 @@ pub struct External {
     pub delivery_prefix: Option<String>,
 }
 
+use crate::error::WithKind;
+use crate::header::{ParseHeaderNameError, ParseHeaderValueError};
+use crate::status::InvalidStatusCode;
 use std::marker::PhantomData;
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
This PR is a part of error specialization initiated by the https://github.com/nats-io/nats.rs/pull/1047

See the initial discussion of the change in this https://github.com/nats-io/nats.rs/pull/1081 (to be removed later, after processing the feedback by @Jarema and creating smaller PR-s from its commits).

This particular PR is created to follow-up [the discussion](https://github.com/nats-io/nats.rs/pull/1081/files#r1288033272)

---

In this PR instead of the `crate::Error`, the <private> method `stream::parse_headers` will return the specialized error with kind enumerating the possible causes of parsing errors. This change will help to specialize errors error returned by public methods.

Along this change, I also refactored 2 errors, namely the `ParseHeaderNameError` and the `ParseHeaderValueError` to convert them to specialization of generic `crate::error::Error<_>`.

These changes are collected in the same commit because all of them describe errors occurred during either building or parsing headers.