### PR TITLE
Downgrade serde

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -20,7 +20,7 @@ futures = { version = "0.3.28", default-features = false, features = ["std", "as
 nkeys = "0.3.0"
 once_cell = "1.18.0"
 regex = "1.9.1"
-serde = { version = "1.0.179", features = ["derive"] }
+serde = { version = "1.0.171", features = ["derive"] }
 serde_json = "1.0.104"
 serde_repr = "0.1.16"
 http = "0.2.9"


### PR DESCRIPTION
Serde v1.0.172 introduced precompiled serde derive macros, which in many use cases, is an unacceptable risk.

Until the situation is resolved, nats client will stick to the last serde version without the precompiled, nonreproducible blob built outside of visible and auditable processes.

More info: https://github.com/serde-rs/serde/issues/2538

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>