### PR TITLE
Bump serde to 1.0.184

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -20,7 +20,7 @@ futures = { version = "0.3.28", default-features = false, features = ["std", "as
 nkeys = "0.3.0"
 once_cell = "1.18.0"
 regex = "1.9.1"
-serde = { version = "1.0.179", features = ["derive"] }
+serde = { version = "1.0.184", features = ["derive"] }
 serde_json = "1.0.104"
 serde_repr = "0.1.16"
 http = "0.2.9"


### PR DESCRIPTION
This bump is done to avoid relying on serde 1.0.172 release, which had precompiled binary included, that has been reverted in 1.0.184

1.0.184 release: https://github.com/serde-rs/serde/releases/tag/v1.0.184
fix: https://github.com/serde-rs/serde/pull/2590
context: https://github.com/serde-rs/serde/issues/2538

supersedes: #1092 

 Signed-off-by: Tomasz Pietrek <tomasz@nats.io>