### PR TITLE
correct spelling mistake in jetstream/consumer/pull

### DIFF
--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -398,7 +398,7 @@ impl futures::Stream for Batch {
             Poll::Ready(maybe_message) => match maybe_message {
                 Some(message) => match message.status.unwrap_or(StatusCode::OK) {
                     StatusCode::TIMEOUT => {
-                        debug!("recived timeout. Iterator done.");
+                        debug!("received timeout. Iterator done.");
                         self.terminated = true;
                         Poll::Ready(None)
                     }


### PR DESCRIPTION
sorry, this was bugging me 😅 