### PR TITLE
fix/doc: Typo in ping_interval example

### DIFF
--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -597,7 +597,7 @@ impl ConnectOptions {
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::ConnectError> {
     /// async_nats::ConnectOptions::new()
-    ///     .flush_interval(Duration::from_millis(100))
+    ///     .ping_interval(Duration::from_secs(24))
     ///     .connect("demo.nats.io")
     ///     .await?;
     /// # Ok(())


### PR DESCRIPTION
Issue: ping_interval example was calling flush_interval
Also, Use duration::from_secs