### PR TITLE
Switch dependency: json->serde_json in nats-server

### DIFF
--- a/nats-server/Cargo.toml
+++ b/nats-server/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 lazy_static = "1.4.0"
 regex = { version = "1.7.1", default-features = false, features = ["std", "unicode-perl"] }
 url = "2"
-json = "0.12"
+serde_json = "1.0.104"
 nuid = "0.5"
 rand = "0.8"
 tokio-retry = "0.3.0"

--- a/nats-server/src/lib.rs
+++ b/nats-server/src/lib.rs
@@ -22,6 +22,7 @@ use std::{thread, time::Duration};
 use lazy_static::lazy_static;
 use rand::Rng;
 use regex::Regex;
+use serde_json::{self, Value};
 
 pub struct Server {
     inner: Inner,
@@ -77,8 +78,8 @@ impl Server {
         let mut r = BufReader::with_capacity(1024, TcpStream::connect(addr).unwrap());
         let mut line = String::new();
         r.read_line(&mut line).expect("did not receive INFO");
-        let si = json::parse(&line["INFO".len()..]).unwrap();
-        let port = si["port"].as_u16().expect("could not parse port");
+        let si: Value = serde_json::from_str(&line["INFO".len()..]).expect("could not parse INFO");
+        let port = si["port"].as_u64().expect("could not parse port") as u16;
         let mut scheme = "nats://";
         if si["tls_required"].as_bool().unwrap_or(false) {
             scheme = "tls://";
@@ -91,8 +92,8 @@ impl Server {
         let mut r = BufReader::with_capacity(1024, TcpStream::connect(addr).unwrap());
         let mut line = String::new();
         r.read_line(&mut line).expect("did not receive INFO");
-        let si = json::parse(&line["INFO".len()..]).unwrap();
-        si["port"].as_u16().expect("could not parse port")
+        let si: Value = serde_json::from_str(&line["INFO".len()..]).expect("could not parse INFO");
+        si["port"].as_u64().expect("could not parse port") as u16
     }
 
     // Allow user/pass override.


### PR DESCRIPTION
This patch fixes the [cargo-deny](https://github.com/EmbarkStudios/cargo-deny)'s security warning for `nats-server` which is used by `async-nats`:

```shell
$ cargo-deny --exclude nats --exclude nats_test_server check
```

which reported:

```
   ┌─ ../nats.rs/Cargo.lock:83:1
   │
83 │ json 0.12.4 registry+https://github.com/rust-lang/crates.io-index
   │ ----------------------------------------------------------------- unmaintained advisory detected
   │
   = ID: RUSTSEC-2022-0081
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2022-0081
   = Last release was almost 3 years ago.

   The maintainer is unresponsive with outstanding issues.
```

After the fix `cargo-deny` got satisfied

```
advisories ok, bans ok, licenses ok, sources ok
```