### PR TITLE
Fix minimal versions

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["network-programming", "api-bindings"]
 memchr = "2.4"
 bytes = { version = "1.4.0", features = ["serde"] }
 futures = { version = "0.3.28", default-features = false, features = ["std", "async-await"] }
-nkeys = "0.3.0"
+nkeys = "0.3.1"
 once_cell = "1.18.0"
 regex = "1.9.1"
 serde = { version = "1.0.184", features = ["derive"] }

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -41,6 +41,9 @@ ring = "0.16"
 rand = "0.8"
 webpki = { package = "rustls-webpki", version = "0.101.2", features = ["alloc", "std"] }
 
+# for -Z minimal-versions
+rustls = "0.21.6" # used by tokio-rustls 0.24.0
+
 [dev-dependencies]
 criterion =  { version = "0.5", features = ["async_tokio"]}
 nats-server = { path = "../nats-server" }


### PR DESCRIPTION
Here I checked and then fixed minimal versions for transitive dependencies of the `async-nats`.

```shell
cargo +nightly update -Zminimal-versions
cargo check --package async-nats --all-targets
```

After the fixes it got green.

See detailed explanations in the commit messages