### PR TITLE
Check min versions of transitive depencencies in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,3 +210,31 @@ jobs:
 
       - name: Check spelling
         run: cargo spellcheck --code 1
+
+  check_min_versions:
+    name: check minimal versions of transitive dependencies (ubuntu-latest / stable)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install nightly for -Zminimal-versions
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Lock minimal versions
+        # Update openssl-sys to not depend on the stale libssl-dev package.
+        run: |
+          cargo +nightly update -Zminimal-versions
+          cargo +nightly update -p openssl-sys -p openssl
+
+      - name: Install stable
+        id:   install-stable-rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Restore cached build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ steps.install-stable-rust.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
+      - name: Run the check
+        env:
+          RUST_BACKTRACE: 1
+        # cannot check against all packages because min versions of nats@0.16.0 are broken
+        run: cargo +${{ steps.install-stable-rust.outputs.name }} check --package async-nats --locked --all-features --all-targets


### PR DESCRIPTION
To prevent problems like https://github.com/nats-io/nats.rs/issues/1090 maybe it makes sense to check transitive dependencies in the CI.

I also had to fix another dependency `openssl` restricted from `0.10.29` -> `0.10.36` (the latest one is `0.10.55`)