### PR TITLE
Remove dev branch tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,17 +19,12 @@ defaults:
 
 jobs:
   test_matrix:
-    name: test (${{ matrix.os }}, nats-${{ matrix.nats_server }})
+    name: test (${{ matrix.os }}, nats-main
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        nats_server: [main, dev]
-        include:
-          - nats_server: dev
-            features: server_2_10
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -69,7 +64,7 @@ jobs:
           go-version: '1.20'
 
       - name: Install nats-server
-        run: go install github.com/nats-io/nats-server/v2@${{ matrix.nats_server }}
+        run: go install github.com/nats-io/nats-server/v2@main
 
       - name: Setup deno for service tests
         if: ${{ matrix.os }} != windows-latest
@@ -213,7 +208,7 @@ jobs:
           rustup install stable
 
       - name: Install nats-server
-        run: go install github.com/nats-io/nats-server/v2@dev
+        run: go install github.com/nats-io/nats-server/v2@main
       - name: Check examples
         env:
           RUST_LOG: trace


### PR DESCRIPTION
Dev branch has been made obsolete after 2.10 release. New release model will not have dev branch.