### PR TITLE
Make object store structures more resilient

### DIFF
--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -129,9 +129,11 @@ impl ObjectStore {
                             let bucket = self
                                 .stream
                                 .context
-                                .get_object_store(&link_name)
+                                .get_object_store(&link.bucket)
                                 .await
-                                .map_err(|err| GetError::with_source(GetErrorKind::Other, err))?;
+                                .map_err(|err| {
+                                GetError::with_source(GetErrorKind::Other, err)
+                            })?;
                             let object = bucket.get(&link_name).await?;
                             return Ok(object);
                         }
@@ -348,7 +350,7 @@ impl ObjectStore {
             chunks: object_chunks,
             size: object_size,
             digest: Some(format!("SHA-256={}", URL_SAFE.encode(digest))),
-            modified: OffsetDateTime::now_utc(),
+            modified: Some(OffsetDateTime::now_utc()),
             deleted: false,
         };
 
@@ -711,7 +713,7 @@ impl ObjectStore {
             nuid: nuid::next().to_string(),
             size: 0,
             chunks: 0,
-            modified: OffsetDateTime::now_utc(),
+            modified: Some(OffsetDateTime::now_utc()),
             digest: None,
             deleted: false,
         };
@@ -774,7 +776,7 @@ impl ObjectStore {
             nuid: nuid::next().to_string(),
             size: 0,
             chunks: 0,
-            modified: OffsetDateTime::now_utc(),
+            modified: Some(OffsetDateTime::now_utc()),
             digest: None,
             deleted: false,
         };
@@ -1062,21 +1064,26 @@ pub struct ObjectInfo {
     /// Name of the object
     pub name: String,
     /// A short human readable description of the object.
+    #[serde(default)]
     pub description: Option<String>,
     /// Link this object points to, if any.
+    #[serde(default)]
     pub options: Option<ObjectOptions>,
     /// Name of the bucket the object is stored in.
     pub bucket: String,
     /// Unique identifier used to uniquely identify this version of the object.
+    #[serde(default)]
     pub nuid: String,
     /// Size in bytes of the object.
+    #[serde(default)]
     pub size: usize,
     /// Number of chunks the object is stored in.
+    #[serde(default)]
     pub chunks: usize,
     /// Date and time the object was last modified.
-    #[serde(with = "rfc3339")]
+    #[serde(default, with = "rfc3339::option")]
     #[serde(rename = "mtime")]
-    pub modified: time::OffsetDateTime,
+    pub modified: Option<time::OffsetDateTime>,
     /// Digest of the object stream.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub digest: Option<String>,


### PR DESCRIPTION
As some libraries might omit fields in structs when creating Object Store links, (as link and object have different always-filled fields, but they share the same schema) this change is to make it work with them.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>