### PR TITLE
Use muxed inbox to handle jetstream publishes

### DIFF
--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -53,7 +53,7 @@ impl From<tokio::sync::mpsc::error::SendError<Command>> for PublishError {
 pub struct Client {
     info: tokio::sync::watch::Receiver<ServerInfo>,
     pub(crate) state: tokio::sync::watch::Receiver<State>,
-    sender: mpsc::Sender<Command>,
+    pub(crate) sender: mpsc::Sender<Command>,
     next_subscription_id: Arc<AtomicU64>,
     subscription_capacity: usize,
     inbox_prefix: String,


### PR DESCRIPTION
This makes Jetstream publishes re-use the muxed subscriber logic from #1069.

I'm not really happy with the implementation, but the current internal API is quite strict on what it allowed.