### PR TITLE
Add TLS first support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,16 +42,8 @@ jobs:
         uses: actions/setup-go@v4 # v4 uses caching out of the box
         with:
           go-version: '1.20'
-      - name: Cache nats-server on ${{ matrix.os }}
-        id:   cache-nats-server
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.go-bin }}
-          key:  ${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-nats-server
       - name: Install nats-server
-        if:   steps.cache-nats-server.outputs.cache-hit != 'true'
         run:  go install github.com/nats-io/nats-server/v2@main
-
       - name: Install stable Rust on ${{ matrix.os }}
         id:   install-rust
         uses: dtolnay/rust-toolchain@stable
@@ -111,7 +103,7 @@ jobs:
 
       - name: Run linter
         run: cargo clippy --benches --tests --examples --all-features -- --deny clippy::all
-  
+
   check_docs:
     name: check docs (ubuntu-latest / stable)
     runs-on: ubuntu-latest

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -794,6 +794,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
             client_key: options.client_key,
             client_cert: options.client_cert,
             tls_client_config: options.tls_client_config,
+            tls_first: options.tls_first,
             auth: options.auth,
             no_echo: options.no_echo,
             connection_timeout: options.connection_timeout,

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -51,6 +51,7 @@ pub struct ConnectOptions {
     pub(crate) connection_timeout: Duration,
     pub(crate) auth: Auth,
     pub(crate) tls_required: bool,
+    pub(crate) tls_first: bool,
     pub(crate) certificates: Vec<PathBuf>,
     pub(crate) client_cert: Option<PathBuf>,
     pub(crate) client_key: Option<PathBuf>,
@@ -83,6 +84,7 @@ impl fmt::Debug for ConnectOptions {
             .entry(&"client_cert", &self.client_cert)
             .entry(&"client_key", &self.client_key)
             .entry(&"tls_client_config", &"XXXXXXXX")
+            .entry(&"tls_first", &self.tls_first)
             .entry(&"ping_interval", &self.ping_interval)
             .entry(&"sender_capacity", &self.sender_capacity)
             .entry(&"inbox_prefix", &self.inbox_prefix)
@@ -102,6 +104,7 @@ impl Default for ConnectOptions {
             max_reconnects: Some(60),
             connection_timeout: Duration::from_secs(5),
             tls_required: false,
+            tls_first: false,
             certificates: Vec::new(),
             client_cert: None,
             client_key: None,
@@ -562,6 +565,15 @@ impl ConnectOptions {
     /// ```
     pub fn require_tls(mut self, is_required: bool) -> ConnectOptions {
         self.tls_required = is_required;
+        self
+    }
+
+    /// Changes how tls connection is established. If `tls_first` is set,
+    /// client will try to establish tls before getting info from the server.
+    /// That requires the server to enable `handshake_first` option in the config.
+    pub fn tls_first(mut self) -> ConnectOptions {
+        self.tls_first = true;
+        self.tls_required = true;
         self
     }
 

--- a/async-nats/tests/configs/tls_first.conf
+++ b/async-nats/tests/configs/tls_first.conf
@@ -1,0 +1,17 @@
+# this needs to be here for testing localhost tls.
+listen: localhost:4545
+
+tls {
+  cert_file:  "./tests/configs/certs/server-cert.pem"
+  key_file:   "./tests/configs/certs/server-key.pem"
+  ca_file:    "./tests/configs/certs/rootCA.pem"
+  verify :    true
+  timeout:    2
+  handshake_first: true
+}
+
+authorization {
+  user:     derek
+  password: porkchop
+  timeout:  1
+}

--- a/async-nats/tests/configs/tls_first_auto.conf
+++ b/async-nats/tests/configs/tls_first_auto.conf
@@ -1,0 +1,17 @@
+# this needs to be here for testing localhost tls.
+listen: localhost:4545
+
+tls {
+  cert_file:  "./tests/configs/certs/server-cert.pem"
+  key_file:   "./tests/configs/certs/server-key.pem"
+  ca_file:    "./tests/configs/certs/rootCA.pem"
+  verify :    true
+  timeout:    2
+  handshake_first: 300ms
+}
+
+authorization {
+  user:     derek
+  password: porkchop
+  timeout:  1
+}


### PR DESCRIPTION
NATS server used to send INFO when client connected, before establishing TLS.
As server added support to establish TLS before getting any INFO, this commit adds `tls_first` option to be able to used that feature.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>