### PR TITLE
Calculate average processing time as total time / # requests

### DIFF
--- a/async-nats/src/service/mod.rs
+++ b/async-nats/src/service/mod.rs
@@ -784,7 +784,10 @@ impl Request {
         let stats = stats.endpoints.get_mut(self.endpoint.as_str()).unwrap();
         stats.requests += 1;
         stats.processing_time += elapsed;
-        stats.average_processing_time = stats.processing_time.checked_div(2).unwrap();
+        stats.average_processing_time = {
+            let avg_nanos = (stats.processing_time.as_nanos() / stats.requests as u128) as u64;
+            Duration::from_nanos(avg_nanos)
+        };
         result
     }
 }


### PR DESCRIPTION
Proposed fix for https://github.com/nats-io/nats.rs/issues/1151.

I wasn't crazy about any of the options for dividing a `Duration`.

The problem w/ [checked_div](https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.checked_div) is that it only takes `u32` and total_requests is `usize`.

I considered div_f64, but just doing the calculation as nanos and converting back to a Duration seems fool-proof and panic-free.