### PR TITLE
Remove println

### DIFF
--- a/async-nats/src/service/mod.rs
+++ b/async-nats/src/service/mod.rs
@@ -849,7 +849,6 @@ impl EndpointBuilder {
             subject = format!("{}.{}", prefix, subject);
         }
         let endpoint_name = self.name.clone().unwrap_or_else(|| subject.clone());
-        println!("endpoint name: {}", endpoint_name);
         let name = self
             .name
             .clone()


### PR DESCRIPTION
Removes an accidentally committed `println!` in the service initialization code.