### PR TITLE
Specify num indirect dependency min version

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -54,6 +54,9 @@ async-nats = {path = ".", features = ["experimental"]}
 reqwest = "0.11.18"
 jsonschema = "0.17.1"
 
+# for -Z minimal-versions
+num = "0.4.1"
+
 
 [features]
 default = ["server_2_10"]


### PR DESCRIPTION
Num is used by fraction, which in used by json-schema, which we use in testing.
In 4.0, signatures were a bit different, so it failed to compile.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>