### PR TITLE
Fix ordered-consumer example

### DIFF
--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -531,7 +531,6 @@ impl<'a> Consumer<OrderedConfig> {
     /// let mut messages = consumer.messages().await?.take(100);
     /// while let Some(Ok(message)) = messages.next().await {
     ///     println!("got message {:?}", message);
-    ///     message.ack().await?;
     /// }
     /// Ok(())
     /// # }


### PR DESCRIPTION
Ordered consumer does not need to deliver an ACK (uses AckNone).