### PR TITLE
Fix Service::stop

### DIFF
--- a/async-nats/tests/service_tests.rs
+++ b/async-nats/tests/service_tests.rs
@@ -553,6 +553,24 @@ mod service {
     }
 
     #[tokio::test]
+    async fn stop() {
+        let server = nats_server::run_basic_server();
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+
+        let service = client
+            .service_builder()
+            .start("service", "1.0.0")
+            .await
+            .unwrap();
+
+        let mut endpoint = service.endpoint("products").await.unwrap();
+
+        service.stop().await.unwrap();
+        client.publish("products", "data".into()).await.unwrap();
+        assert!(endpoint.next().await.is_none());
+    }
+
+    #[tokio::test]
     #[cfg(not(target_os = "windows"))]
     async fn cross_clients_tests() {
         use std::process::Command;


### PR DESCRIPTION
There were 2 issues in the stop system for services :
- On the first poll of the stream, the shutdown future was not polled, thus stopping the service would never wake this task
- After the shutdown future is resolved, the next poll will still poll the shutdown future, which is not allowed