### PR TITLE
Remove unused dependency on http

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -23,7 +23,6 @@ regex = "1.9.1"
 serde = { version = "1.0.184", features = ["derive"] }
 serde_json = "1.0.104"
 serde_repr = "0.1.16"
-http = "0.2.9"
 tokio = { version = "1.29.0", features = ["macros", "rt", "fs", "net", "sync", "time", "io-util"] }
 url = { version = "2"}
 tokio-rustls = "0.24"

--- a/async-nats/dependencies.md
+++ b/async-nats/dependencies.md
@@ -7,7 +7,6 @@ This file lists the dependencies used in this repository.
 | base64 0.21.4             | Apache-2.0 OR MIT        |
 | bytes 1.5.0               | MIT                      |
 | futures 0.3.28            | Apache-2.0 OR MIT        |
-| http 0.2.9                | Apache-2.0 OR MIT        |
 | memchr 2.6.3              | MIT OR Unlicense         |
 | nkeys 0.3.2               | Apache-2.0               |
 | nuid 0.5.0                | Apache-2.0               |

--- a/async-nats/src/header.rs
+++ b/async-nats/src/header.rs
@@ -18,7 +18,7 @@
 // is coming from the derive, it didn't work to set it on the struct.
 #![allow(clippy::mutable_key_type)]
 
-//! NATS [Message][crate::Message] headers, modeled loosely after the [http::header] crate.
+//! NATS [Message][crate::Message] headers, modeled loosely after the `http::header` crate.
 
 use std::{collections::HashMap, fmt, slice::Iter, str::FromStr};
 
@@ -26,7 +26,7 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 /// A struct for handling NATS headers.
-/// Has a similar API to [http::header], but properly serializes and deserializes
+/// Has a similar API to `http::header`, but properly serializes and deserializes
 /// according to NATS requirements.
 ///
 /// # Examples


### PR DESCRIPTION
This was only used for generating a documentation link. I've changed it to not link to the `http::header` docs at all, but this could also be made a manual link to docs.rs if that's preferred.