### PR TITLE
Don't expose BoxFuture in public API

### DIFF
--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -420,15 +420,15 @@ impl futures::Stream for Batch {
     }
 }
 
-pub struct Sequence<'a> {
+pub struct Sequence {
     context: Context,
     subject: String,
     request: Bytes,
     pending_messages: usize,
-    next: Option<BoxFuture<'a, Result<Batch, MessagesError>>>,
+    next: Option<BoxFuture<'static, Result<Batch, MessagesError>>>,
 }
 
-impl<'a> futures::Stream for Sequence<'a> {
+impl futures::Stream for Sequence {
     type Item = Result<Batch, MessagesError>;
 
     fn poll_next(
@@ -490,7 +490,7 @@ impl<'a> futures::Stream for Sequence<'a> {
     }
 }
 
-impl<'a> Consumer<OrderedConfig> {
+impl Consumer<OrderedConfig> {
     /// Returns a stream of messages for Ordered Pull Consumer.
     ///
     /// Ordered consumers uses single replica ephemeral consumer, no matter the replication factor of the
@@ -535,7 +535,7 @@ impl<'a> Consumer<OrderedConfig> {
     /// Ok(())
     /// # }
     /// ```
-    pub async fn messages(self) -> Result<Ordered<'a>, StreamError> {
+    pub async fn messages(self) -> Result<Ordered, StreamError> {
         let config = Consumer {
             config: self.config.clone().into(),
             context: self.context.clone(),
@@ -719,18 +719,18 @@ impl IntoConsumerConfig for OrderedConfig {
     }
 }
 
-pub struct Ordered<'a> {
+pub struct Ordered {
     context: Context,
     stream_name: String,
     consumer: OrderedConfig,
     consumer_name: String,
     stream: Option<Stream>,
-    create_stream: Option<BoxFuture<'a, Result<Stream, ConsumerRecreateError>>>,
+    create_stream: Option<BoxFuture<'static, Result<Stream, ConsumerRecreateError>>>,
     consumer_sequence: u64,
     stream_sequence: u64,
 }
 
-impl<'a> futures::Stream for Ordered<'a> {
+impl futures::Stream for Ordered {
     type Item = Result<jetstream::Message, OrderedError>;
 
     fn poll_next(

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -471,7 +471,7 @@ impl IntoConsumerConfig for OrderedConfig {
 }
 
 impl Consumer<OrderedConfig> {
-    pub async fn messages<'a>(self) -> Result<Ordered<'a>, StreamError> {
+    pub async fn messages<'a>(self) -> Result<Ordered, StreamError> {
         let subscriber = self
             .context
             .client
@@ -540,11 +540,11 @@ impl Consumer<OrderedConfig> {
     }
 }
 
-pub struct Ordered<'a> {
+pub struct Ordered {
     context: Context,
     consumer: Consumer<OrderedConfig>,
     subscriber: Option<Subscriber>,
-    subscriber_future: Option<BoxFuture<'a, Result<Subscriber, ConsumerRecreateError>>>,
+    subscriber_future: Option<BoxFuture<'static, Result<Subscriber, ConsumerRecreateError>>>,
     stream_sequence: Arc<AtomicU64>,
     consumer_sequence: Arc<AtomicU64>,
     shutdown: tokio::sync::oneshot::Receiver<ConsumerRecreateError>,
@@ -552,14 +552,14 @@ pub struct Ordered<'a> {
     heartbeat_sleep: Option<Pin<Box<tokio::time::Sleep>>>,
 }
 
-impl<'a> Drop for Ordered<'a> {
+impl Drop for Ordered {
     fn drop(&mut self) {
         // Stop trying to recreate the consumer
         self.handle.abort()
     }
 }
 
-impl<'a> futures::Stream for Ordered<'a> {
+impl futures::Stream for Ordered {
     type Item = Result<Message, OrderedError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -1034,17 +1034,17 @@ struct StreamInfoPage {
     streams: Option<Vec<super::stream::Info>>,
 }
 
-type PageRequest<'a> = BoxFuture<'a, Result<StreamPage, RequestError>>;
+type PageRequest = BoxFuture<'static, Result<StreamPage, RequestError>>;
 
-pub struct StreamNames<'a> {
+pub struct StreamNames {
     context: Context,
     offset: usize,
-    page_request: Option<PageRequest<'a>>,
+    page_request: Option<PageRequest>,
     streams: Vec<String>,
     done: bool,
 }
 
-impl futures::Stream for StreamNames<'_> {
+impl futures::Stream for StreamNames {
     type Item = Result<String, StreamsError>;
 
     fn poll_next(
@@ -1105,20 +1105,20 @@ impl futures::Stream for StreamNames<'_> {
     }
 }
 
-type PageInfoRequest<'a> = BoxFuture<'a, Result<StreamInfoPage, RequestError>>;
+type PageInfoRequest = BoxFuture<'static, Result<StreamInfoPage, RequestError>>;
 
 pub type StreamsErrorKind = RequestErrorKind;
 pub type StreamsError = RequestError;
 
-pub struct Streams<'a> {
+pub struct Streams {
     context: Context,
     offset: usize,
-    page_request: Option<PageInfoRequest<'a>>,
+    page_request: Option<PageInfoRequest>,
     streams: Vec<super::stream::Info>,
     done: bool,
 }
 
-impl futures::Stream for Streams<'_> {
+impl futures::Stream for Streams {
     type Item = Result<super::stream::Info, StreamsError>;
 
     fn poll_next(

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -427,7 +427,7 @@ impl Store {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn watch<T: AsRef<str>>(&self, key: T) -> Result<Watch<'_>, WatchError> {
+    pub async fn watch<T: AsRef<str>>(&self, key: T) -> Result<Watch, WatchError> {
         self.watch_with_deliver_policy(key, DeliverPolicy::New)
             .await
     }
@@ -457,7 +457,7 @@ impl Store {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn watch_with_history<T: AsRef<str>>(&self, key: T) -> Result<Watch<'_>, WatchError> {
+    pub async fn watch_with_history<T: AsRef<str>>(&self, key: T) -> Result<Watch, WatchError> {
         self.watch_with_deliver_policy(key, DeliverPolicy::LastPerSubject)
             .await
     }
@@ -466,7 +466,7 @@ impl Store {
         &self,
         key: T,
         deliver_policy: DeliverPolicy,
-    ) -> Result<Watch<'_>, WatchError> {
+    ) -> Result<Watch, WatchError> {
         let subject = format!("{}{}", self.prefix.as_str(), key.as_ref());
 
         debug!("initial consumer creation");
@@ -527,7 +527,7 @@ impl Store {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn watch_all(&self) -> Result<Watch<'_>, WatchError> {
+    pub async fn watch_all(&self) -> Result<Watch, WatchError> {
         self.watch(ALL_KEYS).await
     }
 
@@ -750,7 +750,7 @@ impl Store {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn history<T: AsRef<str>>(&self, key: T) -> Result<History<'_>, HistoryError> {
+    pub async fn history<T: AsRef<str>>(&self, key: T) -> Result<History, HistoryError> {
         if !is_valid_key(key.as_ref()) {
             return Err(HistoryError::new(HistoryErrorKind::InvalidKey));
         }
@@ -851,13 +851,13 @@ impl Store {
 }
 
 /// A structure representing a watch on a key-value bucket, yielding values whenever there are changes.
-pub struct Watch<'a> {
-    subscription: super::consumer::push::Ordered<'a>,
+pub struct Watch {
+    subscription: super::consumer::push::Ordered,
     prefix: String,
     bucket: String,
 }
 
-impl<'a> futures::Stream for Watch<'a> {
+impl futures::Stream for Watch {
     type Item = Result<Entry, WatcherError>;
 
     fn poll_next(
@@ -905,14 +905,14 @@ impl<'a> futures::Stream for Watch<'a> {
 }
 
 /// A structure representing the history of a key-value bucket, yielding past values.
-pub struct History<'a> {
-    subscription: super::consumer::push::Ordered<'a>,
+pub struct History {
+    subscription: super::consumer::push::Ordered,
     done: bool,
     prefix: String,
     bucket: String,
 }
 
-impl<'a> futures::Stream for History<'a> {
+impl futures::Stream for History {
     type Item = Result<Entry, WatcherError>;
 
     fn poll_next(
@@ -965,11 +965,11 @@ impl<'a> futures::Stream for History<'a> {
     }
 }
 
-pub struct Keys<'a> {
-    inner: History<'a>,
+pub struct Keys {
+    inner: History,
 }
 
-impl<'a> futures::Stream for Keys<'a> {
+impl futures::Stream for Keys {
     type Item = Result<String, WatcherError>;
 
     fn poll_next(

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -1664,18 +1664,18 @@ struct ConsumerInfoPage {
 
 type ConsumerNamesErrorKind = StreamsErrorKind;
 type ConsumerNamesError = StreamsError;
-type PageRequest<'a> = BoxFuture<'a, Result<ConsumerPage, RequestError>>;
+type PageRequest = BoxFuture<'static, Result<ConsumerPage, RequestError>>;
 
-pub struct ConsumerNames<'a> {
+pub struct ConsumerNames {
     context: Context,
     stream: String,
     offset: usize,
-    page_request: Option<PageRequest<'a>>,
+    page_request: Option<PageRequest>,
     consumers: Vec<String>,
     done: bool,
 }
 
-impl futures::Stream for ConsumerNames<'_> {
+impl futures::Stream for ConsumerNames {
     type Item = Result<String, ConsumerNamesError>;
 
     fn poll_next(
@@ -1742,18 +1742,18 @@ impl futures::Stream for ConsumerNames<'_> {
 
 pub type ConsumersErrorKind = StreamsErrorKind;
 pub type ConsumersError = StreamsError;
-type PageInfoRequest<'a> = BoxFuture<'a, Result<ConsumerInfoPage, RequestError>>;
+type PageInfoRequest = BoxFuture<'static, Result<ConsumerInfoPage, RequestError>>;
 
-pub struct Consumers<'a> {
+pub struct Consumers {
     context: Context,
     stream: String,
     offset: usize,
-    page_request: Option<PageInfoRequest<'a>>,
+    page_request: Option<PageInfoRequest>,
     consumers: Vec<super::consumer::Info>,
     done: bool,
 }
 
-impl futures::Stream for Consumers<'_> {
+impl futures::Stream for Consumers {
     type Item = Result<super::consumer::Info, ConsumersError>;
 
     fn poll_next(


### PR DESCRIPTION
Based on #1166 

`ObjectStore::get` calls itself recursively, so the returned future needs to be boxed. However, this is an implementation detail, there's no reason to expose it in the public API. Instead, we can move the recursive call to a separate `get_impl` function that handles the boxing, and `get` can just be a standard async function.

This is a minor stylistic change, but if it's desired it makes sense to land it at the same time as #1166 since that is already a breaking change.