### PR TITLE
Serialize/Deserialize Subject and HeaderName as strings

### DIFF
--- a/async-nats/src/subject.rs
+++ b/async-nats/src/subject.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 use std::str::{from_utf8, Utf8Error};
 
 /// A `Subject` is an immutable string type that guarantees valid UTF-8 contents.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Subject {
     bytes: Bytes,
 }
@@ -149,5 +149,23 @@ impl ToSubject for &'static str {
 impl ToSubject for String {
     fn to_subject(&self) -> Subject {
         Subject::from(self.as_str())
+    }
+}
+
+impl Serialize for Subject {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Subject {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(String::deserialize(deserializer)?.into())
     }
 }


### PR DESCRIPTION
The default derives produce a very ugly serialization format for these wrappers. Since they are guaranteed to be strings it makes sense to serialize/deserialize them directly as strings.

This also makes it possible to implement Object Store object headers, since they need to deserialize a HeaderMap from JSON. 