### PR TITLE
Run bench on CI only for Core Nats

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run benchmarks
         env:
           RUST_LOG: trace
-        run: cargo bench
+        run: cargo bench nats
       - name: Archive benchmarks
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
After adding much more benchmarks, it seems that this is too much for Github Actions. Running only Core Nats benchmarks should be enough for tracking general client performance.


Signed-off-by: Tomasz Pietrek <tomasz@nats.io>