### PR TITLE
Recreate ordered pull on heartbeats

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -34,7 +34,7 @@ rustls-native-certs = "0.7"
 tracing = "0.1"
 thiserror = "1.0"
 base64 = "0.21"
-tokio-retry = "0.3"
+tryhard = "0.5"
 ring = "0.17"
 rand = "0.8"
 webpki = { package = "rustls-webpki", version = "0.102" }

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -125,6 +125,7 @@ impl Connector {
     }
 
     pub(crate) async fn try_connect(&mut self) -> Result<(ServerInfo, Connection), ConnectError> {
+        tracing::debug!("connecting");
         let mut error = None;
 
         let mut servers = self.servers.clone();
@@ -277,6 +278,7 @@ impl Connector {
                                 }
                             },
                             Some(_) => {
+                                tracing::debug!("connected to {}", server_info.port);
                                 self.attempts = 0;
                                 self.events_tx.send(Event::Connected).await.ok();
                                 self.state_tx.send(State::Connected).ok();

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -2267,7 +2267,6 @@ async fn recreate_consumer_stream(
         stream.delete_consumer(consumer_name),
     )
     .await
-    .map_err(|err| ConsumerRecreateError::with_source(ConsumerRecreateErrorKind::TimedOut, err))
     .ok();
 
     let deliver_policy = {


### PR DESCRIPTION
This PR adds few improvements to ordered consumers:

- It will recreate ordered pull consumers if `heartbeats` are missed twice
- It will retry all push and pull ordered consumer recreation API calls to have chance of success in case  of network/consensus instasbilities
- Add more tracing

Above provide smoother experience for working with ordered consumers in unstable network/consensus/extreme load conditions.

This PR also replaces `tokio_retry` with (tryhard)[https://github.com/EmbarkStudios/tryhard], ask I found bug in how `tokio_retry` counts backoffs. Also `tryhard` is actively maintained by a well know entity.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>

