### PR TITLE
Fix minor cargo workspace warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,3 @@ members = [
   "nats-server"
 ]
 
-[profile.release]
-debug = true
-split-debuginfo = "unpacked"
-
-[profile.dev]
-panic = 'abort'
-split-debuginfo = "unpacked"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,17 @@
 [workspace]
 
+resolver = "2"
+
 members = [
   "nats",
   "async-nats",
   "nats-server"
 ]
+
+[profile.release]
+debug = true
+split-debuginfo = "unpacked"
+
+[profile.dev]
+panic = 'abort'
+split-debuginfo = "unpacked"

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -23,14 +23,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [badges]
 maintenance = { status = "actively-developed" }
 
-[profile.release]
-debug = true
-split-debuginfo = "unpacked"
-
-[profile.dev]
-panic = 'abort'
-split-debuginfo = "unpacked"
-
 [dependencies]
 base64 = "0.13.0"
 base64-url = "1.4.10"


### PR DESCRIPTION
cargo warned about

* profiles are ignored anywhere but in the top-level manifest
* the resolver was at version 1, while edition 2021 was implying
   resolver = "2"

After comments on this pr, the workspace profiles were removed entirely.