### PR TITLE
fix #1180: Add missing docs for ConnectOptions

### DIFF
--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -819,11 +819,19 @@ impl ConnectOptions {
         self
     }
 
+    /// By default, [`ConnectOptions::connect`] will return an error if
+    /// the connection to the server cannot be established.
+    ///
+    /// Setting `retry_on_initial_connect` makes the client
+    /// establish the connection in the background.
     pub fn retry_on_initial_connect(mut self) -> ConnectOptions {
         self.retry_on_initial_connect = true;
         self
     }
 
+    /// By default, a server may advertise other servers in the cluster known to it.
+    /// By setting this option, the client will ignore the advertised servers.
+    /// This may be useful if the client may not be able to reach them.
     pub fn ignore_discovered_servers(mut self) -> ConnectOptions {
         self.ignore_discovered_servers = true;
         self


### PR DESCRIPTION
Docs for `ConnectOptions::retry_on_initial_connect` and `ConnectOptions::ignore_discovered_servers`.