### PR TITLE
Add revision to kv operations

### DIFF
--- a/async-nats/examples/kv.rs
+++ b/async-nats/examples/kv.rs
@@ -138,7 +138,7 @@ async fn main() -> Result<(), async_nats::Error> {
     // Unsurprisingly, we get the new updated value as a message.
     // Since it's KV interface, we should be able to delete a key as well.
     // Does this result in a new message?
-    kv.delete("sue.color").await?;
+    kv.delete("sue.color", None).await?;
     let message = messages.next().await.unwrap()?;
     let metadata = message.info()?;
     println!(

--- a/async-nats/examples/kv.rs
+++ b/async-nats/examples/kv.rs
@@ -138,7 +138,7 @@ async fn main() -> Result<(), async_nats::Error> {
     // Unsurprisingly, we get the new updated value as a message.
     // Since it's KV interface, we should be able to delete a key as well.
     // Does this result in a new message?
-    kv.delete("sue.color", None).await?;
+    kv.delete("sue.color").await?;
     let message = messages.next().await.unwrap()?;
     let metadata = message.info()?;
     println!(

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -648,7 +648,11 @@ impl Store {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn delete<T: AsRef<str>>(&self, key: T, revison: Option<u64>) -> Result<(), DeleteError> {
+    pub async fn delete<T: AsRef<str>>(
+        &self,
+        key: T,
+        revison: Option<u64>,
+    ) -> Result<(), DeleteError> {
         if !is_valid_key(key.as_ref()) {
             return Err(DeleteError::new(DeleteErrorKind::InvalidKey));
         }
@@ -707,7 +711,11 @@ impl Store {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn purge<T: AsRef<str>>(&self, key: T, revison: Option<u64>) -> Result<(), PurgeError> {
+    pub async fn purge<T: AsRef<str>>(
+        &self,
+        key: T,
+        revison: Option<u64>,
+    ) -> Result<(), PurgeError> {
         if !is_valid_key(key.as_ref()) {
             return Err(PurgeError::new(PurgeErrorKind::InvalidKey));
         }

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -742,7 +742,7 @@ impl Store {
         self.purge_expect_revision(key, None).await
     }
 
-    /// Purges all the revisions of a entry destructively if the resision matches, leaving behind a single
+    /// Purges all the revisions of a entry destructively if the revision matches, leaving behind a single
     /// purge entry in-place.
     ///
     /// # Examples

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -739,7 +739,7 @@ impl Store {
     /// # }
     /// ```
     pub async fn purge<T: AsRef<str>>(&self, key: T) -> Result<(), PurgeError> {
-        self.purge_expected_revision(key, None).await
+        self.purge_expect_revision(key, None).await
     }
 
     /// Purges all the revisions of a entry destructively if the resision matches, leaving behind a single
@@ -762,11 +762,11 @@ impl Store {
     ///     .await?;
     /// kv.put("key", "value".into()).await?;
     /// let revision = kv.put("key", "another".into()).await?;
-    /// kv.purge_expected_revision("key", Some(revision)).await?;
+    /// kv.purge_expect_revision("key", Some(revision)).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn purge_expected_revision<T: AsRef<str>>(
+    pub async fn purge_expect_revision<T: AsRef<str>>(
         &self,
         key: T,
         revison: Option<u64>,

--- a/async-nats/tests/kv_tests.rs
+++ b/async-nats/tests/kv_tests.rs
@@ -373,12 +373,12 @@ mod kv {
 
         let wrong_revision = 3;
         let failed = kv
-            .purge_expected_revision("dz", Some(wrong_revision))
+            .purge_expect_revision("dz", Some(wrong_revision))
             .await
             .is_err();
         assert!(failed);
 
-        kv.purge_expected_revision("dz", Some(revision))
+        kv.purge_expect_revision("dz", Some(revision))
             .await
             .unwrap();
         let history = kv.history("dz").await.unwrap().count().await;

--- a/async-nats/tests/kv_tests.rs
+++ b/async-nats/tests/kv_tests.rs
@@ -247,6 +247,50 @@ mod kv {
     }
 
     #[tokio::test]
+    async fn delete_revision() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = ConnectOptions::new()
+            .event_callback(|event| async move { println!("event: {event:?}") })
+            .connect(server.client_url())
+            .await
+            .unwrap();
+
+        let context = async_nats::jetstream::new(client);
+
+        let kv = context
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: "delete".into(),
+                description: "test_description".into(),
+                history: 10,
+                storage: StorageType::File,
+                num_replicas: 1,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let payload: Bytes = "data".into();
+        let revision = kv.put("key", payload.clone()).await.unwrap();
+        let value = kv.get("key").await.unwrap();
+        assert_eq!(from_utf8(&value.unwrap()).unwrap(), payload);
+
+        let wrong_revision = 3;
+        let failed = kv.delete("key", Some(wrong_revision)).await.is_err();
+        assert!(failed);
+
+        kv.delete("key", Some(revision)).await.unwrap();
+        let ss = kv.get("kv").await.unwrap();
+        assert!(ss.is_none());
+
+        let mut entries = kv.history("key").await.unwrap();
+
+        let first_op = entries.next().await;
+        assert_eq!(first_op.unwrap().unwrap().operation, Operation::Put);
+
+        let first_op = entries.next().await;
+        assert_eq!(first_op.unwrap().unwrap().operation, Operation::Delete);
+    }
+
+    #[tokio::test]
     async fn purge() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = ConnectOptions::new()
@@ -282,6 +326,51 @@ mod kv {
         let history = kv.history("dz").await.unwrap().count().await;
         assert_eq!(history, 6);
         kv.purge("dz", None).await.unwrap();
+        let history = kv.history("dz").await.unwrap().count().await;
+        assert_eq!(history, 1);
+    }
+
+    #[tokio::test]
+    async fn purge_revision() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = ConnectOptions::new()
+            .event_callback(|event| async move { println!("event: {event:?}") })
+            .connect(server.client_url())
+            .await
+            .unwrap();
+
+        let context = async_nats::jetstream::new(client);
+
+        let kv = context
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: "purge".into(),
+                description: "test_description".into(),
+                history: 10,
+                storage: StorageType::File,
+                num_replicas: 1,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        kv.put("dz", "0".into()).await.unwrap();
+        kv.put("dz", "1".into()).await.unwrap();
+        kv.put("dz", "2".into()).await.unwrap();
+        kv.put("dz", "3".into()).await.unwrap();
+        kv.put("dz", "4".into()).await.unwrap();
+        let revision = kv.put("dz", "5".into()).await.unwrap();
+
+        kv.put("baz", "0".into()).await.unwrap();
+        kv.put("baz", "1".into()).await.unwrap();
+        kv.put("baz", "2".into()).await.unwrap();
+
+        let history = kv.history("dz").await.unwrap().count().await;
+        assert_eq!(history, 6);
+
+        let wrong_revision = 3;
+        let failed = kv.purge("dz", Some(wrong_revision)).await.is_err();
+        assert!(failed);
+
+        kv.purge("dz", Some(revision)).await.unwrap();
         let history = kv.history("dz").await.unwrap().count().await;
         assert_eq!(history, 1);
     }

--- a/async-nats/tests/kv_tests.rs
+++ b/async-nats/tests/kv_tests.rs
@@ -212,7 +212,6 @@ mod kv {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = ConnectOptions::new()
             .event_callback(|event| async move { println!("event: {event:?}") })
-            // .connect(server.client_url())
             .connect(server.client_url())
             .await
             .unwrap();
@@ -234,7 +233,7 @@ mod kv {
         kv.put("key", payload.clone()).await.unwrap();
         let value = kv.get("key").await.unwrap();
         assert_eq!(from_utf8(&value.unwrap()).unwrap(), payload);
-        kv.delete("key").await.unwrap();
+        kv.delete("key", None).await.unwrap();
         let ss = kv.get("kv").await.unwrap();
         assert!(ss.is_none());
 
@@ -252,7 +251,6 @@ mod kv {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = ConnectOptions::new()
             .event_callback(|event| async move { println!("event: {event:?}") })
-            // .connect(server.client_url())
             .connect(server.client_url())
             .await
             .unwrap();
@@ -283,7 +281,7 @@ mod kv {
 
         let history = kv.history("dz").await.unwrap().count().await;
         assert_eq!(history, 6);
-        kv.purge("dz").await.unwrap();
+        kv.purge("dz", None).await.unwrap();
         let history = kv.history("dz").await.unwrap().count().await;
         assert_eq!(history, 1);
     }
@@ -614,7 +612,7 @@ mod kv {
         assert_eq!(vec!["bar", "foo"], keys);
 
         // Delete a key and make sure it doesn't show up in the keys list
-        kv.delete("bar").await.unwrap();
+        kv.delete("bar", None).await.unwrap();
         let keys = kv
             .keys()
             .await
@@ -628,7 +626,7 @@ mod kv {
         for i in 0..10 {
             kv.put("bar", i.to_string().into()).await.unwrap();
         }
-        kv.purge("foo").await.unwrap();
+        kv.purge("foo", None).await.unwrap();
         let keys = kv
             .keys()
             .await
@@ -758,7 +756,7 @@ mod kv {
         let name = test.get("name").await.unwrap();
         assert_eq!(from_utf8(&name.unwrap()).unwrap(), "ivan");
 
-        test.purge("name").await.unwrap();
+        test.purge("name", None).await.unwrap();
         let name = test.get("name").await.unwrap();
         assert!(name.is_none());
 


### PR DESCRIPTION
[Similar to the nats.net.v2 client](https://github.com/nats-io/nats.net.v2/blob/main/src/NATS.Client.KeyValueStore/NatsKVStore.cs#L131), an option to add the expected revision was added. A delete or purge will be rejected similar to the update function.

This is needed to make better use of the immediately consistent properties of the kv store.
This is a breaking change, as all references to current deletes or purges will have to be updated to include a None.