### PR TITLE
Do asynchronous DNS lookups in `ServerAddr::socket_addrs`

### DIFF
--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -152,6 +152,7 @@ impl Connector {
 
             let socket_addrs = server_addr
                 .socket_addrs()
+                .await
                 .map_err(|err| ConnectError::with_source(crate::ConnectErrorKind::Dns, err))?;
             for socket_addr in socket_addrs {
                 match self

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -202,7 +202,7 @@ use std::fmt::Display;
 use std::future::Future;
 use std::iter;
 use std::mem;
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use std::option;
 use std::pin::Pin;
 use std::slice;
@@ -1427,8 +1427,8 @@ impl ServerAddr {
     }
 
     /// Return the sockets from resolving the server address.
-    pub fn socket_addrs(&self) -> io::Result<impl Iterator<Item = SocketAddr>> {
-        (self.host(), self.port()).to_socket_addrs()
+    pub async fn socket_addrs(&self) -> io::Result<impl Iterator<Item = SocketAddr> + '_> {
+        tokio::net::lookup_host((self.host(), self.port())).await
     }
 }
 


### PR DESCRIPTION
Turns out `ServerAddr::socket_addrs` was blocking the tokio runtime because it used the std blocking implementation for doing DNS lookups. This switches to the `tokio` implementation, which internally does a `spawn_blocking` of the std call.