### PR TITLE
Bump nkeys to 0.4

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["network-programming", "api-bindings"]
 memchr = "2.4"
 bytes = { version = "1.4.0", features = ["serde"] }
 futures = { version = "0.3.28", default-features = false, features = ["std"] }
-nkeys = "0.3.1"
+nkeys = "0.4"
 once_cell = "1.18.0"
 regex = "1.9.1"
 serde = { version = "1.0.184", features = ["derive"] }


### PR DESCRIPTION
Changes: https://github.com/wasmCloud/nkeys/compare/v0.3.2...v0.4.0