### PR TITLE
fix: ensure the ping interval waker is registered

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -487,7 +487,10 @@ impl ConnectionHandler {
             ///   [`Self::receiver`] was closed, so there's nothing
             ///   more for us to do than to exit the client.
             fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-                if self.handler.ping_interval.poll_tick(cx).is_ready() {
+                // We need to be sure the waker is registered, therefore we need to poll until we
+                // get a `Poll::Pending`. With a sane interval delay, this means that the loop
+                // breaks at the second iteration.
+                while self.handler.ping_interval.poll_tick(cx).is_ready() {
                     if let Poll::Ready(exit) = self.ping() {
                         return Poll::Ready(exit);
                     }


### PR DESCRIPTION
When an interval is ready, it does not need to register its internal waker, leading to the future not being polled anymore if the connection received no data.

The fix is pretty simple, and it should never cause any problems unless the interval duration is very close to zero, which will probably cause strange issues anyway.