### PR TITLE
Optimize consumer recreate

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1131,6 +1131,35 @@ mod jetstream {
     }
 
     #[tokio::test]
+    async fn delete_consumer_from_stream() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+        let context = async_nats::jetstream::new(client);
+
+        let stream = context.get_or_create_stream("stream").await.unwrap();
+        stream
+            .create_consumer(consumer::pull::Config {
+                durable_name: Some("pull".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        stream
+            .create_consumer(consumer::push::Config {
+                durable_name: Some("push".into()),
+                deliver_subject: "subject".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let _consumer = context
+            .delete_consumer_from_stream("pull", "stream")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn get_or_create_consumer() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = async_nats::connect(server.client_url()).await.unwrap();

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1160,6 +1160,33 @@ mod jetstream {
     }
 
     #[tokio::test]
+    async fn create_consumer_on_stream() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+        let context = async_nats::jetstream::new(client);
+
+        let stream = context.get_or_create_stream("stream").await.unwrap();
+        stream
+            .create_consumer(consumer::pull::Config {
+                durable_name: Some("pull".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        context
+            .create_consumer_on_stream(
+                consumer::push::Config {
+                    durable_name: Some("push".into()),
+                    deliver_subject: "subject".into(),
+                    ..Default::default()
+                },
+                "stream",
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn get_or_create_consumer() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = async_nats::connect(server.client_url()).await.unwrap();

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1157,6 +1157,10 @@ mod jetstream {
             .delete_consumer_from_stream("pull", "stream")
             .await
             .unwrap();
+        assert!(stream
+            .get_consumer::<consumer::Config>("pull")
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -1173,7 +1177,7 @@ mod jetstream {
             })
             .await
             .unwrap();
-        context
+        let consumer = context
             .create_consumer_on_stream(
                 consumer::push::Config {
                     durable_name: Some("push".into()),
@@ -1184,6 +1188,7 @@ mod jetstream {
             )
             .await
             .unwrap();
+        assert_eq!(consumer.cached_info().name, "push");
     }
 
     #[tokio::test]


### PR DESCRIPTION
This Pull requests optimizes how we handle recreating Ordered Consumers by not calling Stream Info, as we don't need it.
It also adds ability to delete and create a consumer directly on the `Context`.


Signed-off-by: Tomasz Pietrek <tomasz@nats.io>