### PR TITLE
Make `Subject::from_static` a const fn

### DIFF
--- a/async-nats/src/subject.rs
+++ b/async-nats/src/subject.rs
@@ -21,7 +21,7 @@ impl Subject {
     /// let subject = Subject::from_static("Static string");
     /// assert_eq!(subject.as_str(), "Static string");
     /// ```
-    pub fn from_static(input: &'static str) -> Self {
+    pub const fn from_static(input: &'static str) -> Self {
         Subject {
             bytes: Bytes::from_static(input.as_bytes()),
         }


### PR DESCRIPTION
The whole point of having a `from_static` function is to use it in a const context :wink: 