### PR TITLE
Add check for max payload size when publishing messages

### DIFF
--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -866,4 +866,21 @@ mod client {
             Event::ClientError(async_nats::ClientError::MaxReconnects)
         );
     }
+
+    #[tokio::test]
+    async fn publish_payload_size() {
+        let server = nats_server::run_server("tests/configs/max_payload.conf");
+
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+
+        // this exceeds the small payload limit in server config.
+        let payload = vec![0u8; 1024 * 1024];
+
+        client.publish("big", payload.into()).await.unwrap_err();
+        client.publish("small", "data".into()).await.unwrap();
+        client
+            .publish("just_ok", vec![0u8; 1024 * 128].into())
+            .await
+            .unwrap();
+    }
 }

--- a/async-nats/tests/configs/max_payload.conf
+++ b/async-nats/tests/configs/max_payload.conf
@@ -1,0 +1,1 @@
+max_payload = 128KB


### PR DESCRIPTION
This adds check if the messages Client is publishing to a server it is connected too does not exceed `max_payload`.

This unfortunately asks for changing the error from a simple struct that maps error from `mpsc` error to a new one.
Tests of how disruptive the error change is is under progress, hence the Draft.

We are using new `Atomic` instead of relying on the server info watcher for performance reasons.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>