### PR TITLE
Add stream name check to all stream management methods

### DIFF
--- a/async-nats/src/jetstream/mod.rs
+++ b/async-nats/src/jetstream/mod.rs
@@ -198,3 +198,27 @@ pub fn with_domain<T: AsRef<str>>(client: Client, domain: T) -> Context {
 pub fn with_prefix(client: Client, prefix: &str) -> Context {
     context::Context::with_prefix(client, prefix)
 }
+
+/// Checks if a name passed in JS API is valid one.
+/// The restrictions are there because some fields in the JetStream configs are passed as part of the subject to apply permissions.
+/// Examples are stream names, consumer names, etc.
+pub(crate) fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains(|c| char::is_ascii_whitespace(&c) || c == '.')
+        && name != ">"
+        && name != "*"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_name() {
+        assert!(is_valid_name("stream"));
+        assert!(!is_valid_name("name.name"));
+        assert!(!is_valid_name("name name"));
+        assert!(!is_valid_name(">"));
+        assert!(!is_valid_name(""));
+    }
+}

--- a/async-nats/src/jetstream/mod.rs
+++ b/async-nats/src/jetstream/mod.rs
@@ -199,14 +199,14 @@ pub fn with_prefix(client: Client, prefix: &str) -> Context {
     context::Context::with_prefix(client, prefix)
 }
 
-/// Checks if a name passed in JS API is valid one.
+/// Checks if a name passed in JetStream API is valid one.
 /// The restrictions are there because some fields in the JetStream configs are passed as part of the subject to apply permissions.
 /// Examples are stream names, consumer names, etc.
 pub(crate) fn is_valid_name(name: &str) -> bool {
     !name.is_empty()
-        && !name.contains(|c| char::is_ascii_whitespace(&c) || c == '.')
-        && name != ">"
-        && name != "*"
+        && name
+            .bytes()
+            .all(|c| !c.is_ascii_whitespace() && c != b'.' && c != b'*' && c != b'>')
 }
 
 #[cfg(test)]
@@ -216,6 +216,8 @@ mod tests {
     #[test]
     fn test_is_valid_name() {
         assert!(is_valid_name("stream"));
+        assert!(!is_valid_name("str>eam"));
+        assert!(!is_valid_name("str*eam"));
         assert!(!is_valid_name("name.name"));
         assert!(!is_valid_name("name name"));
         assert!(!is_valid_name(">"));

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -1794,6 +1794,7 @@ pub enum ConsumerErrorKind {
     TimedOut,
     Request,
     InvalidConsumerType,
+    InvalidName,
     JetStream(super::errors::Error),
     Other,
 }
@@ -1806,6 +1807,7 @@ impl Display for ConsumerErrorKind {
             Self::JetStream(err) => write!(f, "JetStream error: {}", err),
             Self::Other => write!(f, "consumer error"),
             Self::InvalidConsumerType => write!(f, "invalid consumer type"),
+            Self::InvalidName => write!(f, "invalid consumer name"),
         }
     }
 }


### PR DESCRIPTION
fixes #1213 

The new validation function does also check for empty name, but we keep separate check for Stream methods for consistency across Stream API.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>