### PR TITLE
Add source implementation for Error

### DIFF
--- a/async-nats/src/error.rs
+++ b/async-nats/src/error.rs
@@ -60,7 +60,16 @@ where
     }
 }
 
-impl<Kind> std::error::Error for Error<Kind> where Kind: Clone + Debug + Display + PartialEq {}
+impl<Kind> std::error::Error for Error<Kind>
+where
+    Kind: Clone + Debug + Display + PartialEq,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|boxed| boxed.as_ref() as &(dyn std::error::Error + 'static))
+    }
+}
 
 impl<Kind> From<Kind> for Error<Kind>
 where


### PR DESCRIPTION
A lot of errors do contain source, but the Error type did not actually implement the `source()` method and was always returning `None`, using the default implementation. Thanks @hseeberger and @thomastaylor312 for reporting this indirectly.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>