### PR TITLE
Bump base64 to v0.22

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -33,7 +33,7 @@ time = { version = "0.3.24", features = ["parsing", "formatting", "serde", "serd
 rustls-native-certs = "0.7"
 tracing = "0.1"
 thiserror = "1.0"
-base64 = "0.21"
+base64 = "0.22"
 tryhard = "0.5"
 ring = "0.17"
 rand = "0.8"


### PR DESCRIPTION
`base64` is one of those dependencies that get used by everybody and ends up finding itself into projects in the form of multiple duplicate versions. Since you're about to make a release let's do our part in not having duplicate versions of it :smiley:.

Changelog: https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md#0220