### PR TITLE
Add public constructor for Acker

### DIFF
--- a/async-nats/src/jetstream/message.rs
+++ b/async-nats/src/jetstream/message.rs
@@ -336,6 +336,10 @@ pub struct Acker {
 // The async-trait crate is not a solution here, as it would mean we're allocating at every ack.
 // Creating separate function to ack just to avoid one duplication is not worth it either.
 impl Acker {
+    /// Public constructor
+    pub fn new(context: Context, reply: Option<Subject>) -> Self {
+        Self {context, reply}
+    }
     /// Acknowledges a message delivery by sending `+ACK` to the server.
     ///
     /// If [AckPolicy][crate::jetstream::consumer::AckPolicy] is set to `All` or `Explicit`, messages has to be acked.

--- a/async-nats/src/jetstream/message.rs
+++ b/async-nats/src/jetstream/message.rs
@@ -336,7 +336,6 @@ pub struct Acker {
 // The async-trait crate is not a solution here, as it would mean we're allocating at every ack.
 // Creating separate function to ack just to avoid one duplication is not worth it either.
 impl Acker {
-    /// Public constructor
     pub fn new(context: Context, reply: Option<Subject>) -> Self {
         Self { context, reply }
     }

--- a/async-nats/src/jetstream/message.rs
+++ b/async-nats/src/jetstream/message.rs
@@ -338,7 +338,7 @@ pub struct Acker {
 impl Acker {
     /// Public constructor
     pub fn new(context: Context, reply: Option<Subject>) -> Self {
-        Self {context, reply}
+        Self { context, reply }
     }
     /// Acknowledges a message delivery by sending `+ACK` to the server.
     ///


### PR DESCRIPTION
In some cases manual Acker creation is preferable, than usage `.split` method. That's public fn constructor introduction.