### PR TITLE
Use last header value for JetStream messages

### DIFF
--- a/async-nats/src/header.rs
+++ b/async-nats/src/header.rs
@@ -169,6 +169,23 @@ impl HeaderMap {
             .and_then(|x| x.first())
     }
 
+    /// Gets a last value for a given key. If key is not found, [Option::None] is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use async_nats::HeaderMap;
+    ///
+    /// let mut headers = HeaderMap::new();
+    /// headers.append("Key", "Value");
+    /// let values = headers.get_last("Key").unwrap();
+    /// ```
+    pub fn get_last<K: IntoHeaderName>(&self, key: K) -> Option<&HeaderValue> {
+        self.inner
+            .get(&key.into_header_name())
+            .and_then(|x| x.last())
+    }
+
     /// Gets an iterator to the values for a given key.
     ///
     /// # Examples
@@ -679,6 +696,9 @@ mod tests {
         assert_eq!(key, "value".to_string());
 
         assert_eq!(headers.get("Key").unwrap().as_str(), "value");
+
+        let key: String = headers.get_last("Key").unwrap().as_str().into();
+        assert_eq!(key, "other".to_string());
     }
 
     #[test]

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -650,7 +650,7 @@ impl futures::Stream for Ordered {
                                     debug!("received idle heartbeats");
                                     if let Some(headers) = message.headers.as_ref() {
                                         if let Some(sequence) =
-                                            headers.get(crate::header::NATS_LAST_CONSUMER)
+                                            headers.get_last(crate::header::NATS_LAST_CONSUMER)
                                         {
                                             let sequence: u64 =
                                                 sequence.as_str().parse().map_err(|err| {

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -357,7 +357,7 @@ impl Store {
                             kv_operation_from_message(&message).unwrap_or(Operation::Put);
 
                         let sequence = headers
-                            .get(header::NATS_SEQUENCE)
+                            .get_last(header::NATS_SEQUENCE)
                             .ok_or_else(|| {
                                 EntryError::with_source(
                                     EntryErrorKind::Other,
@@ -374,7 +374,7 @@ impl Store {
                             })?;
 
                         let created = headers
-                            .get(header::NATS_TIME_STAMP)
+                            .get_last(header::NATS_TIME_STAMP)
                             .ok_or_else(|| {
                                 EntryError::with_source(
                                     EntryErrorKind::Other,


### PR DESCRIPTION
As republish will append new headers, using first value could lead to misleading data when a message is republish from one stream to another.

This commit fixes it by always picking the last header value.

reference ADR issue: https://github.com/nats-io/nats-architecture-and-design/issues/250

Signed-off-by: Tomasz Pietrek <tomasz@nats.io