### PR TITLE
Don't force flush if write buffer isn't empty

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -416,7 +416,6 @@ pub(crate) struct ConnectionHandler {
     pending_pings: usize,
     info_sender: tokio::sync::watch::Sender<ServerInfo>,
     ping_interval: Interval,
-    is_flushing: bool,
     should_reconnect: bool,
     flush_observers: Vec<oneshot::Sender<()>>,
 }
@@ -439,7 +438,6 @@ impl ConnectionHandler {
             pending_pings: 0,
             info_sender,
             ping_interval,
-            is_flushing: false,
             should_reconnect: false,
             flush_observers: Vec::new(),
         }
@@ -579,12 +577,13 @@ impl ConnectionHandler {
                     }
                 }
 
-                if self.handler.is_flushing || self.handler.connection.should_flush() {
+                if let (ShouldFlush::Yes, _) | (ShouldFlush::No, false) = (
+                    self.handler.connection.should_flush(),
+                    self.handler.flush_observers.is_empty(),
+                ) {
                     match self.handler.connection.poll_flush(cx) {
                         Poll::Pending => {}
                         Poll::Ready(Ok(())) => {
-                            self.handler.is_flushing = false;
-
                             for observer in self.handler.flush_observers.drain(..) {
                                 let _ = observer.send(());
                             }
@@ -754,7 +753,6 @@ impl ConnectionHandler {
                 }
             }
             Command::Flush { observer } => {
-                self.is_flushing = true;
                 self.flush_observers.push(observer);
             }
             Command::Subscribe {
@@ -1568,6 +1566,8 @@ macro_rules! from_with_timeout {
     };
 }
 pub(crate) use from_with_timeout;
+
+use crate::connection::ShouldFlush;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
It turns out `poll_write` could return `Poll::Pending` while `poll_flush` could flush successfully (`Poll::Ready`). This seems like a rare case, although possible in theory.  This fixes it by actually making it behave the way it was described in the original PR https://github.com/nats-io/nats.rs/pull/1060#issuecomment-1657242359