### PR TITLE
Document feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Supports:
 The API is stable, however it remains on 0.x.x versioning, as async ecosystem is still introducing a lot of ergonomic improvements. Some of our dependencies are also considered
 stable, yet versioned <1.0.0, like `rustls`, which might introduce breaking changes that can affect our users in some way.
 
+#### Feature flags
+
+Feature flags are Documented in `Cargo.toml` and can be viewed [here](https://docs.rs/crate/async-nats/latest/source/Cargo.toml.orig).
+
 ### nats
 
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -57,10 +57,18 @@ num = "0.4.1"
 
 [features]
 default = ["server_2_10"]
+# Enables Service API for the client.
 service = []
+# All experimental features are part of this feature flag.
 experimental = ["service"]
+# Features that require nats-server version 2.10 or higher.
+# It is enabled by default since official 2.10 nats-server release.
 "server_2_10" = []
+# Used for enabling/disabling tests that by design take a lot of time to  complete.
+# Those tests are usually used for time-sensitive checks, like consumer heartbeats, longer timeouts, etc.
 slow_tests = []
+# Used for tests that ensure compatibility across client libraries in APIs that are abstraction
+# layer build on top of NATS server features (Service API, KV, Object Store etc.)
 compatibility_tests = []
 
 


### PR DESCRIPTION
Addresses #1243 

As there is no good way in Rust to document feature flags beyond listing them, adding comments to `Cargo.toml` seems to be the best answer.

The link in the Readme directs to the `Cargo.toml` from latest release, which should avoid docs drift.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>