### PR TITLE
Add consumer action

### DIFF
--- a/.config/nats.dic
+++ b/.config/nats.dic
@@ -149,3 +149,7 @@ max_ack_pending
 footgun
 KV
 rebalance
+update_consumer
+update_consumer_on_stream
+create_consumer_strict
+create_consumer_strict_on_stream

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -41,12 +41,12 @@ use super::errors::ErrorCode;
 use super::is_valid_name;
 use super::kv::{Store, MAX_HISTORY};
 use super::object_store::{is_valid_bucket_name, ObjectStore};
-#[cfg(feature = "server_2_10")]
-use super::stream::Compression;
 use super::stream::{
-    self, Config, ConsumerCreateStrictError, ConsumerError, ConsumerErrorKind, ConsumerUpdateError,
-    DeleteStatus, DiscardPolicy, External, Info, Stream,
+    self, Config, ConsumerError, ConsumerErrorKind, DeleteStatus, DiscardPolicy, External, Info,
+    Stream,
 };
+#[cfg(feature = "server_2_10")]
+use super::stream::{Compression, ConsumerCreateStrictError, ConsumerUpdateError};
 
 /// A context which can perform jetstream scoped requests.
 #[derive(Debug, Clone)]
@@ -1735,7 +1735,9 @@ enum ConsumerAction {
     #[serde(rename = "")]
     CreateOrUpdate,
     #[serde(rename = "create")]
+    #[cfg(feature = "server_2_10")]
     Create,
     #[serde(rename = "update")]
+    #[cfg(feature = "server_2_10")]
     Update,
 }

--- a/async-nats/src/jetstream/errors.rs
+++ b/async-nats/src/jetstream/errors.rs
@@ -97,7 +97,7 @@ impl ErrorCode {
     /// General RAFT error
     pub const RAFT_GENERAL: ErrorCode = ErrorCode(10041);
 
-    /// Jetstream unable to subscribe to restore snapshot     
+    /// Jetstream unable to subscribe to restore snapshot
     pub const RESTORE_SUBSCRIBE_FAILED: ErrorCode = ErrorCode(10042);
 
     /// Stream deletion failed
@@ -435,6 +435,42 @@ impl ErrorCode {
 
     /// Duplicate source configuration detected
     pub const SOURCE_DUPLICATE_DETECTED: ErrorCode = ErrorCode(10140);
+
+    /// Sourced stream name is invalid
+    pub const SOURCE_INVALID_STREAM_NAME: ErrorCode = ErrorCode(10141);
+
+    /// Mirrored stream name is invalid
+    pub const MIRROR_INVALID_STREAM_NAME: ErrorCode = ErrorCode(10142);
+
+    /// Source with multiple subject transforms cannot also have a single subject filter
+    pub const SOURCE_MULTIPLE_FILTERS_NOT_ALLOWED: ErrorCode = ErrorCode(10144);
+
+    /// Source subject filter is invalid
+    pub const SOURCE_INVALID_SUBJECT_FILTER: ErrorCode = ErrorCode(10145);
+
+    /// Source transform destination is invalid
+    pub const SOURCE_INVALID_TRANSFORM_DESTINATION: ErrorCode = ErrorCode(10146);
+
+    /// Source filters cannot overlap
+    pub const SOURCE_OVERLAPPING_SUBJECT_FILTERS: ErrorCode = ErrorCode(10147);
+
+    /// Consumer already exists
+    pub const CONSUMER_ALREADY_EXISTS: ErrorCode = ErrorCode(10148);
+
+    /// Consumer does not exist
+    pub const CONSUMER_DOES_NOT_EXIST: ErrorCode = ErrorCode(10149);
+
+    /// Mirror with multiple subject transforms cannot also have a single subject filter
+    pub const MIRROR_MULTIPLE_FILTERS_NOT_ALLOWED: ErrorCode = ErrorCode(10150);
+
+    /// Mirror subject filter is invalid
+    pub const MIRROR_INVALID_SUBJECT_FILTER: ErrorCode = ErrorCode(10151);
+
+    /// Mirror subject filters cannot overlap
+    pub const MIRROR_OVERLAPPING_SUBJECT_FILTERS: ErrorCode = ErrorCode(10152);
+
+    /// Consumer inactive threshold exceeds system limit
+    pub const CONSUMER_INACTIVE_THRESHOLD_EXCESS: ErrorCode = ErrorCode(10153);
 }
 
 /// `Error` type returned from an API response when an error occurs.


### PR DESCRIPTION
We decided to not change behavior of `create_consumer`, as this would be a breaking change that does not show up during compile time.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>