### PR TITLE
Preserve case of server error messages

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1294,7 +1294,8 @@ impl ServerError {
     fn new(error: String) -> ServerError {
         match error.to_lowercase().as_str() {
             "authorization violation" => ServerError::AuthorizationViolation,
-            other => ServerError::Other(other.to_string()),
+            // error messages can contain case-sensitive values which should be preserved
+            _ => ServerError::Other(error),
         }
     }
 }


### PR DESCRIPTION
Server errors can contain case-sensitive values like subject names which can cause confusion if not displayed in their original case.

This was motivated by this error: `nats: permissions violation for publish to "$js.api.stream.info.kv_test"`, which is misleading since the actual subject is `$JS.API.STREAM.INFO.KV_test`.
