### PR TITLE
Fix docs.rs build

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -83,5 +83,6 @@ harness = false
 lto = true
 
 [package.metadata.docs.rs]
-all-features = true
+# We can't use `all-features` because the `fips` doesn't compile in restricted docs.rs environment.
+features = ["server_2_10",  "service", "experimental", "ring", "aws-lc-rs"]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
The docs.rs build is failing because of the fact, that the `fips` dependency while compiling, tries to write some files, which is not allowed in read-only docs.rs environment.