### PR TITLE
Release v0.35.1

### DIFF
--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.35.1
+## Overview
+
+This release fixes broken docs build caused by `fips`, which cannot be built in restricted docs.rs environment.
+
+## What's Changed
+* Fix docs.rs build by @Jarema in https://github.com/nats-io/nats.rs/pull/1259
+* Preserve case of server error messages by @oscarwcl in https://github.com/nats-io/nats.rs/pull/1258
+
+
+**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.35.0...async-nats/v0.35.1
+
 # 0.35.0
 
 ## Overview

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
-version = "0.35.0"
+version = "0.35.1"
 edition = "2021"
 rust = "1.67.0"
 description = "A async Rust NATS client"


### PR DESCRIPTION
# 0.35.1
## Overview

This release fixes broken docs build caused by `fips`, which cannot be built in restricted docs.rs environment.

## What's Changed
* Fix docs.rs build by @Jarema in https://github.com/nats-io/nats.rs/pull/1259
* Preserve case of server error messages by @oscarwcl in https://github.com/nats-io/nats.rs/pull/1258


**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.35.0...async-nats/v0.35.1

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>