### PR TITLE
Add `client.flush()` calls to example code in docs

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -54,6 +54,9 @@
 //!         client.publish("messages", "data".into()).await?;
 //!     }
 //!
+//!     // Flush internal buffer to make sure messages are sent
+//!     client.flush().await?;
+//!
 //!     // Receive and process messages
 //!     while let Some(message) = subscriber.next().await {
 //!         println!("Received message {:?}", message);
@@ -84,6 +87,10 @@
 //! for _ in 0..10 {
 //!     client.publish(subject, data.clone()).await?;
 //! }
+//! 
+//! // Flush internal buffer to make sure messages are sent
+//! client.flush().await?;
+//! 
 //! #    Ok(())
 //! # }
 //! ```

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -54,9 +54,6 @@
 //!         client.publish("messages", "data".into()).await?;
 //!     }
 //!
-//!     // Flush internal buffer to make sure messages are sent
-//!     client.flush().await?;
-//!
 //!     // Receive and process messages
 //!     while let Some(message) = subscriber.next().await {
 //!         println!("Received message {:?}", message);
@@ -88,7 +85,7 @@
 //!     client.publish(subject, data.clone()).await?;
 //! }
 //!
-//! // Flush internal buffer to make sure messages are sent
+//! // Flush internal buffer before exiting to make sure all messages are sent
 //! client.flush().await?;
 //!
 //! #    Ok(())

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -87,10 +87,10 @@
 //! for _ in 0..10 {
 //!     client.publish(subject, data.clone()).await?;
 //! }
-//! 
+//!
 //! // Flush internal buffer to make sure messages are sent
 //! client.flush().await?;
-//! 
+//!
 //! #    Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
This PR adds `client.flush()` calls to publish examples in the documentation to help avoid potential confusion when messages aren't immediately published due to buffering (in fact, on my short-lived CLI app they weren't being sent at all). See https://github.com/nats-io/nats.rs/issues/773#issuecomment-2119116600.

@Jarema I actually have a few questions in regards to this:
1. is `flush()` supposed to be called on a regular basis if not publishing too frequently?
2. do you mind briefly explaining to me how the buffering works in this case? is it only count-based or time-based too?
3. how could I tweak it so that it flushes more frequently by itself?