### PR TITLE
feat: implement `futures::Sink<PublishMessage>` on `async_nats::Client`

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -27,6 +27,7 @@ serde_repr = "0.1.16"
 tokio = { version = "1.36", features = ["macros", "rt", "fs", "net", "sync", "time", "io-util"] }
 url = { version = "2"}
 tokio-rustls = { version = "0.26", default-features = false }
+tokio-util = "0.7"
 rustls-pemfile = "2"
 nuid = "0.5"
 serde_nanos = "0.1.3"

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -96,6 +96,15 @@ impl Client {
         }
     }
 
+    /// Returns a [`mpsc::Sender`] of [`Command`], that can be used to
+    /// asynchronously drive the client.
+    /// This is low-level API mostly suitable for advanced use cases,
+    /// most applications should rely on higher-level functionality like
+    /// [`Self::publish`] or [`Self::subscribe`]
+    pub fn command_sender(&self) -> mpsc::Sender<Command> {
+        self.sender.clone()
+    }
+
     /// Returns last received info from the server.
     ///
     /// # Examples

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -229,7 +229,7 @@ impl Client {
             .send(Command::Publish(PublishMessage {
                 subject,
                 payload,
-                respond: None,
+                reply: None,
                 headers: None,
             }))
             .await?;
@@ -267,7 +267,7 @@ impl Client {
             .send(Command::Publish(PublishMessage {
                 subject,
                 payload,
-                respond: None,
+                reply: None,
                 headers: Some(headers),
             }))
             .await?;
@@ -303,7 +303,7 @@ impl Client {
             .send(Command::Publish(PublishMessage {
                 subject,
                 payload,
-                respond: Some(reply),
+                reply: Some(reply),
                 headers: None,
             }))
             .await?;
@@ -342,7 +342,7 @@ impl Client {
             .send(Command::Publish(PublishMessage {
                 subject,
                 payload,
-                respond: Some(reply),
+                reply: Some(reply),
                 headers: Some(headers),
             }))
             .await?;

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -342,8 +342,9 @@ pub(crate) enum ServerOp {
     },
 }
 
+/// `Command` represents all commands that a [`Client`] can handle
 #[derive(Debug)]
-pub(crate) enum Command {
+pub enum Command {
     Publish {
         subject: Subject,
         payload: Bytes,

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -344,7 +344,7 @@ pub(crate) enum ServerOp {
 
 /// `Command` represents all commands that a [`Client`] can handle
 #[derive(Debug)]
-pub enum Command {
+pub(crate) enum Command {
     Publish {
         subject: Subject,
         payload: Bytes,

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -342,15 +342,19 @@ pub(crate) enum ServerOp {
     },
 }
 
+/// `PublishMessage` represents a message being published
+#[derive(Debug)]
+pub struct PublishMessage {
+    pub subject: Subject,
+    pub payload: Bytes,
+    pub respond: Option<Subject>,
+    pub headers: Option<HeaderMap>,
+}
+
 /// `Command` represents all commands that a [`Client`] can handle
 #[derive(Debug)]
 pub(crate) enum Command {
-    Publish {
-        subject: Subject,
-        payload: Bytes,
-        respond: Option<Subject>,
-        headers: Option<HeaderMap>,
-    },
+    Publish(PublishMessage),
     Request {
         subject: Subject,
         payload: Bytes,
@@ -823,12 +827,12 @@ impl ConnectionHandler {
                 self.connection.enqueue_write_op(&pub_op);
             }
 
-            Command::Publish {
+            Command::Publish(PublishMessage {
                 subject,
                 payload,
                 respond,
                 headers,
-            } => {
+            }) => {
                 self.connection.enqueue_write_op(&ClientOp::Publish {
                     subject,
                     payload,

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -347,7 +347,7 @@ pub(crate) enum ServerOp {
 pub struct PublishMessage {
     pub subject: Subject,
     pub payload: Bytes,
-    pub respond: Option<Subject>,
+    pub reply: Option<Subject>,
     pub headers: Option<HeaderMap>,
 }
 
@@ -830,7 +830,7 @@ impl ConnectionHandler {
             Command::Publish(PublishMessage {
                 subject,
                 payload,
-                respond,
+                reply: respond,
                 headers,
             }) => {
                 self.connection.enqueue_write_op(&ClientOp::Publish {


### PR DESCRIPTION
closes #1266 

An example real-world use case for this looks like this following:
https://github.com/rvolosatovs/wrpc/blob/85b043b84bd70fa2994cde8ced129d05b6739284/crates/transport-nats-next/src/lib.rs#L351-L412

This in an `AsyncWrite` implementation, which chunks bytes according to NATS payload limits and correctly handles polling and async wake up (using the `Publisher` introduced in this PR)