### PR TITLE
Fix `subscription_capacity` documenttion default value

### DIFF
--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -606,7 +606,7 @@ impl ConnectOptions {
 
     /// Sets the capacity for `Subscribers`. Exceeding it will trigger `slow consumer` error
     /// callback and drop messages.
-    /// Default is set to 1024 messages buffer.
+    /// Default is set to 65536 messages buffer.
     ///
     /// # Examples
     /// ```no_run


### PR DESCRIPTION
Documentation didn't match implementation, resolves https://github.com/nats-io/nats.rs/issues/1275