### PR TITLE
Allow setting size limit for object storage buckets

### DIFF
--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -1119,6 +1119,7 @@ impl Context {
                 description: config.description.clone(),
                 subjects: vec![chunk_subject, meta_subject],
                 max_age: config.max_age,
+                max_bytes: config.max_bytes,
                 storage: config.storage,
                 num_replicas: config.num_replicas,
                 discard: DiscardPolicy::New,

--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -72,6 +72,8 @@ pub struct Config {
     /// Maximum age of any value in the bucket, expressed in nanoseconds
     #[serde(default, with = "serde_nanos")]
     pub max_age: Duration,
+    /// How large the storage bucket may become in total bytes.
+    pub max_bytes: i64,
     /// The type of storage backend, `File` (default) and `Memory`
     pub storage: StorageType,
     /// How many replicas to keep for each value in a cluster, maximum 5.


### PR DESCRIPTION
In line with the Go client: https://github.com/nats-io/nats.go/blob/370bc4fc4cac2de8d5dbbddbb98739f9cb2d7f8b/object.go#L283