### PR TITLE
Add backpressure to publish

### DIFF
--- a/.config/nats.dic
+++ b/.config/nats.dic
@@ -176,6 +176,13 @@ PinnedClient
 PriorityGroups
 priority_policy
 TTL
+inflight
+runtime
+backpressure
+domain
+{domain}
+$JS
+ContextBuilder
 futures_util
 StreamMessage
 StreamValue

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.184", features = ["derive"] }
 serde_json = "1.0.104"
 serde_repr = "0.1.16"
 tokio = { version = "1.36", features = ["macros", "rt", "fs", "net", "sync", "time", "io-util"] }
-tokio-stream = "0.1"
+tokio-stream = "0.1.17"
 url = { version = "2"}
 tokio-rustls = { version = "0.26", default-features = false }
 tokio-util = "0.7"

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.184", features = ["derive"] }
 serde_json = "1.0.104"
 serde_repr = "0.1.16"
 tokio = { version = "1.36", features = ["macros", "rt", "fs", "net", "sync", "time", "io-util"] }
+tokio-stream = "0.1"
 url = { version = "2"}
 tokio-rustls = { version = "0.26", default-features = false }
 tokio-util = "0.7"

--- a/async-nats/benches/jetstream.rs
+++ b/async-nats/benches/jetstream.rs
@@ -111,9 +111,9 @@ pub fn jetstream_publish_async(c: &mut Criterion) {
             |b, _| {
                 let rt = tokio::runtime::Runtime::new().unwrap();
                 let context = rt.block_on(async {
-                    let context = async_nats::jetstream::new(
-                        async_nats::connect(server.client_url()).await.unwrap(),
-                    );
+                    let context = async_nats::jetstream::context::ContextBuilder::new()
+                        .backpressure_on_inflight(true)
+                        .build(async_nats::connect(server.client_url()).await.unwrap());
 
                     let stream = context
                         .create_stream(stream::Config {
@@ -152,9 +152,10 @@ pub fn jetstream_publish_async(c: &mut Criterion) {
             |b, _| {
                 let rt = tokio::runtime::Runtime::new().unwrap();
                 let context = rt.block_on(async {
-                    let context = async_nats::jetstream::new(
-                        async_nats::connect(server.client_url()).await.unwrap(),
-                    );
+                    let context = async_nats::jetstream::context::ContextBuilder::new()
+                        .backpressure_on_inflight(true)
+                        .max_ack_inflight(5000)
+                        .build(async_nats::connect(server.client_url()).await.unwrap());
 
                     let stream = context
                         .create_stream(stream::Config {

--- a/async-nats/benches/jetstream.rs
+++ b/async-nats/benches/jetstream.rs
@@ -49,7 +49,7 @@ pub fn jetstream_publish_sync(c: &mut Criterion) {
     }
     throughput_group.finish();
 
-    let mut messages_group = c.benchmark_group("jetstream sync publish messages amount");
+    let mut messages_group = c.benchmark_group("jetstream::sync_publish_messages_amount");
     messages_group.sample_size(10);
     messages_group.warm_up_time(std::time::Duration::from_secs(1));
 
@@ -97,7 +97,7 @@ pub fn jetstream_publish_sync(c: &mut Criterion) {
 pub fn jetstream_publish_async(c: &mut Criterion) {
     let messages_per_iter = 50_000;
     let server = nats_server::run_server("tests/configs/jetstream.conf");
-    let mut throughput_group = c.benchmark_group("jetstream async publish throughput");
+    let mut throughput_group = c.benchmark_group("jetstream::async_publish_throughput");
     throughput_group.sample_size(10);
     throughput_group.warm_up_time(std::time::Duration::from_secs(1));
 
@@ -185,6 +185,102 @@ pub fn jetstream_publish_async(c: &mut Criterion) {
     }
     messages_group.finish();
 }
+
+pub fn jetstream_publish_async_no_ack(c: &mut Criterion) {
+    let messages_per_iter = 50_000;
+    let server = nats_server::run_server("tests/configs/jetstream.conf");
+    let mut throughput_group = c.benchmark_group("jetstream::async_publish_no_ack_throughput");
+    throughput_group.sample_size(10);
+    throughput_group.warm_up_time(std::time::Duration::from_secs(1));
+
+    for &size in [32, 1024, 8192].iter() {
+        throughput_group.throughput(criterion::Throughput::Bytes(
+            size as u64 * messages_per_iter,
+        ));
+        throughput_group.bench_with_input(
+            criterion::BenchmarkId::from_parameter(size),
+            &size,
+            |b, _| {
+                let rt = tokio::runtime::Runtime::new().unwrap();
+                let context = rt.block_on(async {
+                    let context = async_nats::jetstream::context::ContextBuilder::new()
+                        .backpressure_on_inflight(true)
+                        .build(async_nats::connect(server.client_url()).await.unwrap());
+
+                    let stream = context
+                        .create_stream(stream::Config {
+                            name: "bench".to_owned(),
+                            subjects: vec!["bench".to_string()],
+                            ..Default::default()
+                        })
+                        .await
+                        .unwrap();
+                    stream.purge().await.unwrap();
+                    context
+                });
+
+                b.to_async(rt).iter_with_large_drop(move || {
+                    let nc = context.clone();
+                    async move {
+                        publish_async_batch_no_ack(
+                            nc,
+                            Bytes::from_static(&MSG[..size]),
+                            messages_per_iter,
+                        )
+                        .await
+                    }
+                });
+            },
+        );
+    }
+    throughput_group.finish();
+
+    let mut messages_group = c.benchmark_group("jetstream::async_publish_no_ack_messages_amount");
+
+    messages_group.sample_size(10);
+    messages_group.warm_up_time(std::time::Duration::from_secs(1));
+
+    for &size in [32, 1024, 8192].iter() {
+        messages_group.throughput(criterion::Throughput::Elements(messages_per_iter));
+        messages_group.bench_with_input(
+            criterion::BenchmarkId::from_parameter(size),
+            &size,
+            |b, _| {
+                let rt = tokio::runtime::Runtime::new().unwrap();
+                let context = rt.block_on(async {
+                    let context = async_nats::jetstream::context::ContextBuilder::new()
+                        .backpressure_on_inflight(true)
+                        .max_ack_inflight(5000)
+                        .build(async_nats::connect(server.client_url()).await.unwrap());
+
+                    let stream = context
+                        .create_stream(stream::Config {
+                            name: "bench".to_owned(),
+                            subjects: vec!["bench".to_string()],
+                            ..Default::default()
+                        })
+                        .await
+                        .unwrap();
+                    stream.purge().await.unwrap();
+                    context
+                });
+
+                b.to_async(rt).iter_with_large_drop(move || {
+                    let context = context.clone();
+                    async move {
+                        publish_async_batch_no_ack(
+                            context,
+                            Bytes::from_static(&MSG[..size]),
+                            messages_per_iter,
+                        )
+                        .await
+                    }
+                });
+            },
+        );
+    }
+    messages_group.finish();
+}
 async fn publish_sync_batch(context: async_nats::jetstream::Context, msg: Bytes, amount: u64) {
     for _i in 0..amount {
         context
@@ -196,6 +292,17 @@ async fn publish_sync_batch(context: async_nats::jetstream::Context, msg: Bytes,
     }
 }
 
+async fn publish_async_batch_no_ack(
+    context: async_nats::jetstream::Context,
+    msg: Bytes,
+    amount: u64,
+) {
+    // This acts as a semaphore that does not allow for more than 10 publish acks awaiting.
+    for _ in 0..amount {
+        context.publish("bench", msg.clone()).await.unwrap();
+    }
+    context.wait_for_acks().await;
+}
 async fn publish_async_batch(context: async_nats::jetstream::Context, msg: Bytes, amount: u64) {
     // This acts as a semaphore that does not allow for more than 10 publish acks awaiting.
     let (tx, mut rx) = tokio::sync::mpsc::channel(amount as usize);
@@ -213,4 +320,9 @@ async fn publish_async_batch(context: async_nats::jetstream::Context, msg: Bytes
     handle.await.unwrap();
 }
 
-criterion_group!(jetstream, jetstream_publish_sync, jetstream_publish_async);
+criterion_group!(
+    jetstream,
+    jetstream_publish_sync,
+    jetstream_publish_async,
+    jetstream_publish_async_no_ack
+);

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -69,12 +69,14 @@ fn spawn_acker(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let stream = ReceiverStream::new(rx);
-        let _ = stream.for_each_concurrent(None, |(subscription, permit)| async move {
-            tokio::time::timeout(Duration::from_secs(30), subscription)
-                .await
-                .ok();
-            drop(permit);
-        });
+        stream
+            .for_each_concurrent(None, |(subscription, permit)| async move {
+                tokio::time::timeout(Duration::from_secs(30), subscription)
+                    .await
+                    .ok();
+                drop(permit);
+            })
+            .await;
     })
 }
 

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -298,10 +298,16 @@ impl Context {
         ContextBuilder::default().build(client)
     }
 
+    /// Sets the timeout for all JetStream API requests.
     pub fn set_timeout(&mut self, timeout: Duration) {
         self.timeout = timeout
     }
 
+    /// Waits until all pending `acks` are received from the server.
+    /// Be aware that this is probably not the way you want to await `acks`,
+    /// as it will wait for every `ack` that is pending, including those that might
+    /// be published after you call this method.
+    /// Useful in testing, or maybe batching.
     pub async fn wait_for_acks(&self) {
         self.max_ack_semaphore
             .acquire_many(self.semaphore_capacity as u32)
@@ -309,12 +315,14 @@ impl Context {
             .ok();
     }
 
+    /// Create a new [Context] with given API prefix.
     pub(crate) fn with_prefix<T: ToString>(client: Client, prefix: T) -> Context {
         ContextBuilder::new()
             .api_prefix(prefix.to_string())
             .build(client)
     }
 
+    /// Create a new [Context] with given domain.
     pub(crate) fn with_domain<T: AsRef<str>>(client: Client, domain: T) -> Context {
         ContextBuilder::new().domain(domain.as_ref()).build(client)
     }

--- a/async-nats/src/jetstream/mod.rs
+++ b/async-nats/src/jetstream/mod.rs
@@ -136,7 +136,7 @@ pub mod publish;
 pub mod response;
 pub mod stream;
 
-pub use context::Context;
+pub use context::{Context, ContextBuilder};
 pub use errors::Error;
 pub use errors::ErrorCode;
 pub use message::{AckKind, Message};

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -4608,4 +4608,28 @@ mod jetstream {
             .await
             .unwrap();
     }
+
+    #[tokio::test]
+    async fn test_async_publish_max_ack_pending() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+
+        let jetstream = async_nats::jetstream::new(client);
+
+        jetstream
+            .create_stream(stream::Config {
+                name: "events".to_string(),
+                subjects: vec!["events".to_string()],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        for i in 0..100_000 {
+            jetstream
+                .publish("events", format!("{i}").into())
+                .await
+                .unwrap();
+        }
+    }
 }


### PR DESCRIPTION
# Overview
Clients that are missing backpressure for async publishing of JetStream messages can negatively impac the NATS servers and clusters.

Rust client separates publish with ack, as two separate futures, which is fine and very flexible, but does not enforce any backpressure, or enable easier handling of it. That is especially relevant for users dropping `PublishAckFuture` and ignoring the `Ack` entirely.

This PR addresses this in two ways:
1. Error on `Context::publish` if the threshold for in-flight acks is reached
2. Spin a task that awaits for acks for `PubAckFuture` that were dropped.

## Challenges
1. A new background task was needed. This should be fine, as it idles if user does not drop acks.
2. Increased memory footprint of `Context`.