### PR TITLE
Add BSD-2-Clause to allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ allow = [
     "MIT",
     "Apache-2.0",
     "ISC",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "OpenSSL",
     "Unicode-DFS-2016",


### PR DESCRIPTION
As we allow BSD-3-Clause, there is no point in denying BSD-2-Clause in our dependencies, as it less restrictive.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>