### PR TITLE
Fix serde Stream roundtrip

### DIFF
--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -2078,9 +2078,7 @@ mod tests {
 
         let roundtrip: Config = {
             let ser = serde_json::to_string(&config).unwrap();
-            let de = serde_json::from_str(&ser).unwrap();
-
-            de
+            serde_json::from_str(&ser).unwrap()
         };
         assert_eq!(config, roundtrip);
     }


### PR DESCRIPTION
If someone does a serde serialize/deserialize roundtrip with jetstream::stream::Stream, it will result in error, as then `ConsumerLimits` will be `null`.
This should not happen in real-world scenarios, as server does not send nulls for those values, however its good to protect against those scenarios in case Go/nats-server changes its behaviour as some point in time.

closes #1293 

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>