### PR TITLE
nats: De/Ser using `sample_freq` instead of `sample_frequency`

### DIFF
--- a/nats/tests/jetstream.rs
+++ b/nats/tests/jetstream.rs
@@ -806,7 +806,7 @@ fn jetstream_consumer_configs_sample_frequency() {
     };
     let consumer = js.add_consumer("SampledStream", cconfig).unwrap();
 
-    assert_eq!(80, consumer.config.sample_frequency); 
+    assert_eq!(80, consumer.config.sample_frequency);
 }
 
 // Helper function to return server and client.

--- a/nats/tests/jetstream.rs
+++ b/nats/tests/jetstream.rs
@@ -783,6 +783,32 @@ fn jetstream_pull_subscribe_bad_stream() {
         .expect_err("expected not found stream for a given subject");
 }
 
+#[test]
+fn jetstream_consumer_configs_sample_frequency() {
+    let s = nats_server::run_server("tests/configs/jetstream.conf");
+    let nc = nats::Options::new()
+        .error_callback(|err| println!("error!: {err}"))
+        .connect(s.client_url())
+        .unwrap();
+    let js = nats::jetstream::new(nc);
+
+    let sconfig = StreamConfig {
+        name: "SampledStream".into(),
+        ..Default::default()
+    };
+    js.add_stream(sconfig).unwrap();
+
+    let cconfig = ConsumerConfig {
+        durable_name: Some("SampledConsumer".into()),
+        filter_subject: "SampledSubject".into(),
+        sample_frequency: 80,
+        ..Default::default()
+    };
+    let consumer = js.add_consumer("SampledStream", cconfig).unwrap();
+
+    assert_eq!(80, consumer.config.sample_frequency); 
+}
+
 // Helper function to return server and client.
 pub fn run_basic_jetstream() -> (nats_server::Server, Connection, JetStream) {
     let s = nats_server::run_server("tests/configs/jetstream.conf");


### PR DESCRIPTION
Addendum to #1300 for the `nats` module.

This PR instructs serde to rename `sample_frequency` into `sample_freq` during de/serialization.
It also introduces a module for converting the `u8` into a `String`.

Finally, this PR adds a test in `nats/tests/jetstream.rs` that can be executed via `cargo test -- jetstream_consumer_configs_sample_frequency`, which checks that the stored config of the consumer now contains the correctly set field.
Removing the `rename = sample_freq` directive from the `ConsumerConfig` type causes this test to fail, so all seems to be correct.