### PR TITLE
Remove unwrap from consumer

### DIFF
--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -961,7 +961,7 @@ impl Stream {
                                 .into()
                         }))
                         .await
-                        .unwrap();
+                        .ok();
                     trace!("result send over tx");
                 }
             }
@@ -1092,7 +1092,7 @@ impl futures::Stream for Stream {
                 && !self.pending_request
             {
                 debug!("pending messages reached threshold to send new fetch request");
-                self.request_tx.send(()).unwrap();
+                self.request_tx.send(()).ok();
                 self.pending_request = true;
             }
 


### PR DESCRIPTION
Although those unwraps seem safe, it's still better not not have app panicking at all.
Even in case of those somehow failing, client will recover by itself on next iteration of the timer.
If Stream is dropped, we also shutdown the task, so dropped sender/receiver should not matter.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>