### PR TITLE
Add get stream no io

### DIFF
--- a/.config/nats.dic
+++ b/.config/nats.dic
@@ -155,3 +155,4 @@ create_consumer_strict
 create_consumer_strict_on_stream
 leafnodes
 get_stream
+get_stream_no_info

--- a/.config/nats.dic
+++ b/.config/nats.dic
@@ -154,3 +154,4 @@ update_consumer_on_stream
 create_consumer_strict
 create_consumer_strict_on_stream
 leafnodes
+get_stream


### PR DESCRIPTION
This methods allows for getting the handler for `Stream` without calling
the server info API.
It can be useful when user wants to perform single operation on many
streams.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>