### PR TITLE
Improve kv::Watcher without messages

### DIFF
--- a/async-nats/tests/kv_tests.rs
+++ b/async-nats/tests/kv_tests.rs
@@ -532,6 +532,29 @@ mod kv {
             }
         }
     }
+
+    #[tokio::test]
+    async fn watch_no_messages() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+
+        let context = async_nats::jetstream::new(client);
+        let kv = context
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: "history".to_string(),
+                description: "test_description".to_string(),
+                history: 15,
+                storage: StorageType::File,
+                num_replicas: 1,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let mut watcher = kv.watch_with_history("foo").await.unwrap();
+        assert!(watcher.next().await.is_none());
+    }
+
     #[tokio::test]
     async fn watch() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");


### PR DESCRIPTION
Until now, if underlying watcher for given consumer did not have any pending messages, it would indefinitely wait for the first one. This commit improves it by checking message pending count on initial consumer info, and returning `None` if there are no messages.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>