### PR TITLE
Improve statistics

### DIFF
--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -335,6 +335,7 @@ impl Connector {
         let mut connection = Connection::new(
             Box::new(tcp_stream),
             self.options.read_buffer_capacity.into(),
+            self.connect_stats.clone(),
         );
 
         let tls_connection = |connection: Connection| async {
@@ -352,7 +353,11 @@ impl Connector {
                 .connect(domain.to_owned(), connection.stream)
                 .await?;
 
-            Ok::<Connection, ConnectError>(Connection::new(Box::new(tls_stream), 0))
+            Ok::<Connection, ConnectError>(Connection::new(
+                Box::new(tls_stream),
+                0,
+                self.connect_stats.clone(),
+            ))
         };
 
         // If `tls_first` was set, establish TLS connection before getting INFO.

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -674,10 +674,6 @@ impl ConnectionHandler {
                     .connect_stats
                     .in_messages
                     .add(1, Ordering::Relaxed);
-                self.connector
-                    .connect_stats
-                    .in_bytes
-                    .add(length as u64, Ordering::Relaxed);
 
                 if let Some(subscription) = self.subscriptions.get_mut(&sid) {
                     let message: Message = Message {
@@ -808,11 +804,6 @@ impl ConnectionHandler {
             } => {
                 let (prefix, token) = respond.rsplit_once('.').expect("malformed request subject");
 
-                let header_len = headers
-                    .as_ref()
-                    .map(|headers| headers.len())
-                    .unwrap_or_default();
-
                 let multiplexer = if let Some(multiplexer) = self.multiplexer.as_mut() {
                     multiplexer
                 } else {
@@ -840,10 +831,6 @@ impl ConnectionHandler {
 
                 let respond: Subject = format!("{}{}", multiplexer.prefix, token).into();
 
-                self.connector.connect_stats.out_bytes.add(
-                    (payload.len() + respond.len() + subject.len() + header_len) as u64,
-                    Ordering::Relaxed,
-                );
                 let pub_op = ClientOp::Publish {
                     subject,
                     payload,

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -959,8 +959,8 @@ mod client {
 
         assert_eq!(stats.in_messages.load(Ordering::Relaxed), 0);
         assert_eq!(stats.out_messages.load(Ordering::Relaxed), 0);
-        assert_eq!(stats.in_bytes.load(Ordering::Relaxed), 0);
-        assert_eq!(stats.out_bytes.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.in_bytes.load(Ordering::Relaxed), 370);
+        assert_eq!(stats.out_bytes.load(Ordering::Relaxed), 253);
         assert_eq!(stats.connects.load(Ordering::Relaxed), 1);
 
         let mut responder = client.subscribe("request").await.unwrap();
@@ -992,8 +992,8 @@ mod client {
 
         assert_eq!(stats.in_messages.load(Ordering::Relaxed), 4);
         assert_eq!(stats.out_messages.load(Ordering::Relaxed), 4);
-        assert_eq!(stats.in_bytes.load(Ordering::Relaxed), 139);
-        assert_eq!(stats.out_bytes.load(Ordering::Relaxed), 139);
+        assert_eq!(stats.in_bytes.load(Ordering::Relaxed), 928);
+        assert_eq!(stats.out_bytes.load(Ordering::Relaxed), 888);
         assert_eq!(stats.connects.load(Ordering::Relaxed), 2);
     }
 }

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -959,8 +959,8 @@ mod client {
 
         assert_eq!(stats.in_messages.load(Ordering::Relaxed), 0);
         assert_eq!(stats.out_messages.load(Ordering::Relaxed), 0);
-        assert_eq!(stats.in_bytes.load(Ordering::Relaxed), 370);
-        assert_eq!(stats.out_bytes.load(Ordering::Relaxed), 253);
+        assert!(stats.in_bytes.load(Ordering::Relaxed) != 0);
+        assert!(stats.out_bytes.load(Ordering::Relaxed) != 0);
         assert_eq!(stats.connects.load(Ordering::Relaxed), 1);
 
         let mut responder = client.subscribe("request").await.unwrap();
@@ -992,8 +992,8 @@ mod client {
 
         assert_eq!(stats.in_messages.load(Ordering::Relaxed), 4);
         assert_eq!(stats.out_messages.load(Ordering::Relaxed), 4);
-        assert_eq!(stats.in_bytes.load(Ordering::Relaxed), 928);
-        assert_eq!(stats.out_bytes.load(Ordering::Relaxed), 888);
+        assert!(stats.in_bytes.load(Ordering::Relaxed) != 0);
+        assert!(stats.out_bytes.load(Ordering::Relaxed) != 0);
         assert_eq!(stats.connects.load(Ordering::Relaxed), 2);
     }
 }


### PR DESCRIPTION
Client statistics should could all bytes that are coming in and out of the client, not just part of messages.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>