### PR TITLE
Add ability to fetch stream subjects

### DIFF
--- a/.config/nats.dic
+++ b/.config/nats.dic
@@ -158,3 +158,5 @@ get_stream
 get_stream_no_info
 lifecycle
 AtomicU64
+with_deleted
+StreamInfoBuilder

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -172,10 +172,11 @@ impl Stream<Info> {
     ///
     /// let mut stream = jetstream.get_stream("events").await?;
     ///
-    /// let info = stream.info_with_subjects().await?;
+    /// let mut info = stream.info_with_subjects("events.>").await?;
     ///
     /// while let Some(subject) = info.next().await {
-    ///    println!("Subject: {}", subject.unwrap());
+    ///    let (subject, count) = subject?;
+    ///    println!("Subject: {} count: {}", subject, count);
     /// }
     /// # Ok(())
     /// # }

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -210,7 +210,7 @@ impl<I> Stream<I> {
     /// let mut info = stream.info_with_subjects("events.>").await?;
     ///
     /// while let Some((subject, count)) = info.try_next().await? {
-    ///    println!("Subject: {} count: {}", subject, count);
+    ///     println!("Subject: {} count: {}", subject, count);
     /// }
     /// # Ok(())
     /// # }
@@ -249,12 +249,15 @@ impl<I> Stream<I> {
     ///
     /// let mut stream = jetstream.get_stream("events").await?;
     ///
-    /// let mut info = stream.info_builder()
+    /// let mut info = stream
+    ///     .info_builder()
     ///     .with_deleted()
-    ///     .subjects("events.>").try_next().await?;
+    ///     .subjects("events.>")
+    ///     .try_next()
+    ///     .await?;
     ///
     /// while let Some((subject, count)) = info.try_next().await? {
-    ///    println!("Subject: {} count: {}", subject, count);
+    ///     println!("Subject: {} count: {}", subject, count);
     /// }
     /// # Ok(())
     /// # }

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -13,10 +13,8 @@
 //
 //! Manage operations on a [Stream], create/delete/update [Consumer].
 
-#[cfg(feature = "server_2_10")]
-use std::collections::HashMap;
 use std::{
-    collections,
+    collections::{self, HashMap},
     fmt::{self, Debug, Display},
     future::IntoFuture,
     io::{self, ErrorKind},

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -193,7 +193,7 @@ impl<I> Stream<I> {
         }
     }
 
-    /// Retrieves [[stream::Info]] from the server and returns a [[futures::Stream]] that allows
+    /// Retrieves [[Info]] from the server and returns a [[futures::Stream]] that allows
     /// iterating over all subjects in the stream fetched via paged API.
     ///
     /// # Examples

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -166,7 +166,7 @@ impl Stream<Info> {
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::Error> {
-    /// use futures::StreamExt;
+    /// use futures::TryStreamExt;
     /// let client = async_nats::connect("localhost:4222").await?;
     /// let jetstream = async_nats::jetstream::new(client);
     ///
@@ -174,8 +174,7 @@ impl Stream<Info> {
     ///
     /// let mut info = stream.info_with_subjects("events.>").await?;
     ///
-    /// while let Some(subject) = info.next().await {
-    ///    let (subject, count) = subject?;
+    /// while let Some((subject, count)) = info.try_next().await? {
     ///    println!("Subject: {} count: {}", subject, count);
     /// }
     /// # Ok(())

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -251,9 +251,9 @@ impl<I> Stream<I> {
     ///
     /// let mut info = stream
     ///     .info_builder()
-    ///     .with_deleted()
+    ///     .with_deleted(true)
     ///     .subjects("events.>")
-    ///     .try_next()
+    ///     .fetch()
     ///     .await?;
     ///
     /// while let Some((subject, count)) = info.try_next().await? {

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -36,7 +36,9 @@ mod jetstream {
         self, push, AckPolicy, DeliverPolicy, Info, OrderedPullConsumer, OrderedPushConsumer,
         PullConsumer, PushConsumer, ReplayPolicy,
     };
-    use async_nats::jetstream::context::{GetStreamByNameErrorKind, Publish, PublishErrorKind};
+    use async_nats::jetstream::context::{
+        GetStreamByNameErrorKind, Publish, PublishAckFuture, PublishErrorKind,
+    };
     use async_nats::jetstream::response::Response;
     #[cfg(feature = "server_2_10")]
     use async_nats::jetstream::stream::ConsumerLimits;
@@ -3701,5 +3703,51 @@ mod jetstream {
 
         let err = jetstream.stream_by_subject("foo").await.unwrap_err();
         assert_eq!(err.kind(), GetStreamByNameErrorKind::NotFound);
+    }
+
+    #[tokio::test]
+    async fn stream_subjects() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+
+        let jetstream = async_nats::jetstream::new(client);
+
+        let stream = jetstream
+            .create_stream(stream::Config {
+                name: "events".to_string(),
+                subjects: vec!["events.>".to_string()],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<PublishAckFuture>(1000);
+
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        tokio::task::spawn(async move {
+            while let Some(ack) = rx.recv().await {
+                ack.await.unwrap();
+            }
+            done_tx.send(()).unwrap();
+        });
+
+        for i in 0..220_000 {
+            let ack = jetstream
+                .publish(format!("events.{i}"), "data".into())
+                .await
+                .unwrap();
+            tx.send(ack).await.unwrap();
+        }
+        drop(tx);
+        done_rx.await.unwrap();
+
+        let info = stream.info_with_subjects("events.>").await.unwrap();
+
+        let i = info.info.clone();
+        let count = info.count().await;
+        println!("messages: {:?}", i.state.messages);
+        // println!("info: {:?}", i);
+        println!("count: {count}");
+        assert!(count.eq(&220_000));
     }
 }

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -938,6 +938,14 @@ mod jetstream {
                 .stream_sequence,
             3
         );
+
+        let info = stream
+            .info_builder()
+            .with_deleted(true)
+            .fetch()
+            .await
+            .unwrap();
+        assert_eq!(info.info.state.deleted_count, Some(1));
     }
 
     #[tokio::test]
@@ -3746,7 +3754,20 @@ mod jetstream {
         let i = info.info.clone();
         let count = info.count().await;
         println!("messages: {:?}", i.state.messages);
-        // println!("info: {:?}", i);
+        println!("count: {count}");
+        assert!(count.eq(&220_000));
+
+        let info = stream
+            .info_builder()
+            .subjects("events.>")
+            .with_deleted(true)
+            .fetch()
+            .await
+            .unwrap();
+
+        let i = info.info.clone();
+        let count = info.count().await;
+        println!("messages: {:?}", i.state.messages);
         println!("count: {count}");
         assert!(count.eq(&220_000));
     }


### PR DESCRIPTION
This is a draft solution that tries to find a sensible way to fetch subjects for from `stream info`, which returns subjects with pagination nested under info.state.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>