### PR TITLE
Change Auth struct signature field to `Vec<u8>`

### DIFF
--- a/async-nats/src/auth.rs
+++ b/async-nats/src/auth.rs
@@ -5,7 +5,7 @@ pub struct Auth {
     pub jwt: Option<String>,
     pub nkey: Option<String>,
     pub(crate) signature_callback: Option<CallbackArg1<String, Result<String, AuthError>>>,
-    pub signature: Option<String>,
+    pub signature: Option<Vec<u8>>,
     pub username: Option<String>,
     pub password: Option<String>,
     pub token: Option<String>,

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -897,7 +897,7 @@ mod client {
                 "eyJqdGkiOiJMN1dBT1hJU0tPSUZNM1QyNEhMQ09ENzJRT1czQkNVWEdETjRKVU1SSUtHTlQ3RzdZVFRRIiwiaWF0IjoxNjUxNzkwOTgyLCJpc3MiOiJBRFRRUzdaQ0ZWSk5XNTcyNkdPWVhXNVRTQ1pGTklRU0hLMlpHWVVCQ0Q1RDc3T1ROTE9PS1pPWiIsIm5hbWUiOiJUZXN0V" +
                 "XNlciIsInN1YiI6IlVBRkhHNkZVRDJVVTRTREZWQUZVTDVMREZPMlhNNFdZTTc2VU5YVFBKWUpLN0VFTVlSQkhUMlZFIiwibmF0cyI6eyJwdWIiOnt9LCJzdWIiOnt9LCJzdWJzIjotMSwiZGF0YSI6LTEsInBheWxvYWQiOi0xLCJ0eXBlIjoidXNlciIsInZlcnNpb24iOjJ9fQ." +
                 "bp2-Jsy33l4ayF7Ku1MNdJby4WiMKUrG-rSVYGBusAtV3xP4EdCa-zhSNUaBVIL3uYPPCQYCEoM1pCUdOnoJBg");
-            
+
             let key_pair = nkeys::KeyPair::from_seed("SUACH75SWCM5D2JMJM6EKLR2WDARVGZT4QC6LX3AGHSWOMVAKERABBBRWM").unwrap();
             let sign = key_pair.sign(&nonce).map_err(async_nats::AuthError::new)?;
             auth.signature = Some(sign);


### PR DESCRIPTION
The signature received from the nkeys::KeyPair sign function is a `Vec<u8>` and the contents cannot be stored in a String.
This commit changes the type of the signature field in the Auth struct from a `Option<String>` to a `Option<Vec<u8>>`.
This allows for JWTs to be used and signed with the nonce in the custom auth callback.