### PR TITLE
Add getter for Client request timeout

### DIFF
--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -135,6 +135,21 @@ impl Client {
         }
     }
 
+    /// Returns the default timeout for requests set when creating the client.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), async_nats::Error> {
+    /// let client = async_nats::connect("demo.nats.io").await?;
+    /// println!("default request timeout: {:?}", client.timeout());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn timeout(&self) -> Option<Duration> {
+        self.request_timeout
+    }
+
     /// Returns last received info from the server.
     ///
     /// # Examples

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -996,4 +996,28 @@ mod client {
         assert!(stats.out_bytes.load(Ordering::Relaxed) != 0);
         assert_eq!(stats.connects.load(Ordering::Relaxed), 2);
     }
+
+    #[tokio::test]
+    async fn client_timeout() {
+        let server = nats_server::run_basic_server();
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+
+        assert_eq!(client.timeout(), Some(Duration::from_secs(10)));
+
+        let client = async_nats::ConnectOptions::new()
+            .request_timeout(Some(Duration::from_secs(30)))
+            .connect(server.client_url())
+            .await
+            .unwrap();
+
+        assert_eq!(client.timeout(), Some(Duration::from_secs(30)));
+
+        let client = async_nats::ConnectOptions::new()
+            .request_timeout(None)
+            .connect(server.client_url())
+            .await
+            .unwrap();
+
+        assert_eq!(client.timeout(), None);
+    }
 }


### PR DESCRIPTION
This is neccessary for ergonomic Orbit extensions to the `Client`.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>