### PR TITLE
fix bug: adding back prefix in service group creation

### DIFF
--- a/async-nats/src/service/mod.rs
+++ b/async-nats/src/service/mod.rs
@@ -903,7 +903,9 @@ mod tests {
 
         let group = Group {
             prefix: "test".to_string(),
-            stats: Arc::new(Mutex::new(Endpoints { endpoints: HashMap::new() })),
+            stats: Arc::new(Mutex::new(Endpoints {
+                endpoints: HashMap::new(),
+            })),
             client,
             shutdown_tx: tokio::sync::broadcast::channel(1).0,
             subjects: Arc::new(Mutex::new(vec![])),
@@ -916,4 +918,3 @@ mod tests {
         assert_eq!(new_group.queue_group, "custom_queue");
     }
 }
-

--- a/async-nats/src/service/mod.rs
+++ b/async-nats/src/service/mod.rs
@@ -639,7 +639,7 @@ impl Group {
         queue_group: Z,
     ) -> Group {
         Group {
-            prefix: prefix.to_string(),
+            prefix: format!("{}.{}", self.prefix.to_string(), prefix.to_string()),
             stats: self.stats.clone(),
             client: self.client.clone(),
             shutdown_tx: self.shutdown_tx.clone(),

--- a/async-nats/src/service/mod.rs
+++ b/async-nats/src/service/mod.rs
@@ -639,7 +639,7 @@ impl Group {
         queue_group: Z,
     ) -> Group {
         Group {
-            prefix: format!("{}.{}", self.prefix.to_string(), prefix.to_string()),
+            prefix: format!("{}.{}", self.prefix, prefix.to_string()),
             stats: self.stats.clone(),
             client: self.client.clone(),
             shutdown_tx: self.shutdown_tx.clone(),
@@ -891,3 +891,29 @@ impl std::fmt::Debug for StatsHandler {
         write!(f, "Stats handler")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_group_with_queue_group() {
+        let server = nats_server::run_basic_server();
+        let client = crate::connect(server.client_url()).await.unwrap();
+
+        let group = Group {
+            prefix: "test".to_string(),
+            stats: Arc::new(Mutex::new(Endpoints { endpoints: HashMap::new() })),
+            client,
+            shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            subjects: Arc::new(Mutex::new(vec![])),
+            queue_group: "default".to_string(),
+        };
+
+        let new_group = group.group_with_queue_group("v1", "custom_queue");
+
+        assert_eq!(new_group.prefix, "test.v1");
+        assert_eq!(new_group.queue_group, "custom_queue");
+    }
+}
+


### PR DESCRIPTION
fix bug: adding back prefix in service group creation

Currently, the prefix will be missing if we are creating group from group.
e.g.
```
let sg = service.group("level1");
sg.endpoint("endpoint1") ==> we can expect to see "level1.endpoint1"

let g2 = sg.group("level2:);
g2.endpoint("endpoint2") ==> now we will see "level2.endpoint2"
```
this patch is to fix and apply the prefix for the g2 endpoint such that the topic will become
`level1.level2.endpoint2`

