### PR TITLE
conf: added env for default max history defaulting to 1

### DIFF
--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -29,6 +29,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{self, json};
 use std::borrow::Borrow;
+use std::env;
 use std::fmt::Display;
 use std::future::IntoFuture;
 use std::pin::Pin;
@@ -734,7 +735,7 @@ impl Context {
             }
             config.history
         } else {
-            1
+            env::var("NATS_KV_DEFAULT_MAX_HISTORY").unwrap_or("1".to_string()).parse().map_err(|_| CreateKeyValueErrorKind::TooLongHistory)?
         };
 
         let num_replicas = if config.num_replicas == 0 {


### PR DESCRIPTION
The history count in case the argument is not explicitly passed was fixed to 1, added an env in case someone wants to confure globally