### PR TITLE
Change port for some tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,6 @@ jobs:
         env:
           RUST_BACKTRACE: 1
         run: |
-          nats-server --jetstream --port=4222 &
           cargo test --features=${{ matrix.features }} --features slow_tests -- --nocapture
 
   check_format:

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -785,7 +785,7 @@ mod client {
     #[tokio::test]
     async fn retry_on_initial_connect() {
         let _client = ConnectOptions::new()
-            .connect("localhost:7777")
+            .connect("localhost:7779")
             .await
             .expect_err("should fail to connect");
         let client = ConnectOptions::new()
@@ -793,14 +793,14 @@ mod client {
                 println!("event: {ev}");
             })
             .retry_on_initial_connect()
-            .connect("localhost:7777")
+            .connect("localhost:7779")
             .await
             .unwrap();
 
         let mut sub = client.subscribe("DATA").await.unwrap();
         client.publish("DATA", "payload".into()).await.unwrap();
         tokio::time::sleep(Duration::from_secs(2)).await;
-        let _server = nats_server::run_server_with_port("", Some("7777"));
+        let _server = nats_server::run_server_with_port("", Some("7779"));
         sub.next().await.unwrap();
     }
 
@@ -922,7 +922,7 @@ mod client {
                     tx.send(event).unwrap();
                 }
             })
-            .connect("localhost:7777")
+            .connect("localhost:7778")
             .await
             .unwrap();
 


### PR DESCRIPTION
As port 7777 is used by some tools, like Prometheus, it is easy to get into conflict.
Additionally, Github Actions Windows machines seem to run something on that port.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>