### PR TITLE
async-nats: Support `sample_freq` values containing a %

### DIFF
--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -448,7 +448,9 @@ pub(crate) mod sample_freq_deser {
             (Some(number), None) => T::from_str(number).map_err(serde::de::Error::custom),
             // A percentage sign occurred right at the end
             (Some(number), Some("")) => T::from_str(number).map_err(serde::de::Error::custom),
-            _ => Err(serde::de::Error::custom(format!("Malformed sample frequency: {s}")))
+            _ => Err(serde::de::Error::custom(format!(
+                "Malformed sample frequency: {s}"
+            ))),
         }
     }
 

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -605,7 +605,7 @@ pub struct OrderedConfig {
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(
         rename = "sample_freq",
-        with = "super::from_str",
+        with = "super::sample_freq_deser",
         default,
         skip_serializing_if = "is_default"
     )]
@@ -2051,7 +2051,7 @@ pub struct Config {
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(
         rename = "sample_freq",
-        with = "super::from_str",
+        with = "super::sample_freq_deser",
         default,
         skip_serializing_if = "is_default"
     )]

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -236,7 +236,7 @@ pub struct Config {
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(
         rename = "sample_freq",
-        with = "super::from_str",
+        with = "super::sample_freq_deser",
         default,
         skip_serializing_if = "is_default"
     )]
@@ -389,7 +389,7 @@ pub struct OrderedConfig {
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(
         rename = "sample_freq",
-        with = "super::from_str",
+        with = "super::sample_freq_deser",
         default,
         skip_serializing_if = "is_default"
     )]

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -2586,6 +2586,7 @@ mod jetstream {
             .await
             .unwrap();
 
+        // Pull Consumer
         {
             let consumer = stream
                 .create_consumer(consumer::pull::Config {
@@ -2602,10 +2603,12 @@ mod jetstream {
             assert_eq!(100, consumer.cached_info().config.sample_frequency);
         }
 
+        // Push Consumer
         {
             let consumer = stream
-                .create_consumer(consumer::pull::Config {
+                .create_consumer(consumer::push::Config {
                     name: Some("SampledPushConsumer".into()),
+                    deliver_subject: "DeliverSubject".into(),
                     description: Some(
                         "See below to check that Ack Sampling has been set to 100%!".to_string(),
                     ),

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -2586,7 +2586,6 @@ mod jetstream {
             .await
             .unwrap();
 
-        // Pull Consumer
         {
             let consumer = stream
                 .create_consumer(consumer::pull::Config {
@@ -2603,12 +2602,10 @@ mod jetstream {
             assert_eq!(100, consumer.cached_info().config.sample_frequency);
         }
 
-        // Push Consumer
         {
             let consumer = stream
-                .create_consumer(consumer::push::Config {
+                .create_consumer(consumer::pull::Config {
                     name: Some("SampledPushConsumer".into()),
-                    deliver_subject: "DeliverSubject".into(),
                     description: Some(
                         "See below to check that Ack Sampling has been set to 100%!".to_string(),
                     ),


### PR DESCRIPTION
Closes #1353.

This PR updates `async-nats`'s deserialization routine for `sample_freq` in consumers to account for a terminating '%', which is seen in the wild when managing NATS resources using Terraform / OpenTofu. 

The changed code is partially tested by the same test added in #1300, but currently does not contain a test for the new case.
I instead tested it against the setup outlined in #1353.
I'd like to add such a case, but I'm not sure how to do so, as Rust's type system forbids me from creating a consumer with `sample_freq` set to something ending in %.