### PR TITLE
async-nats: check push consumers in `sample_freq` de/serialisation test

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -2586,6 +2586,7 @@ mod jetstream {
             .await
             .unwrap();
 
+        // Pull Consumer
         {
             let consumer = stream
                 .create_consumer(consumer::pull::Config {
@@ -2602,10 +2603,12 @@ mod jetstream {
             assert_eq!(100, consumer.cached_info().config.sample_frequency);
         }
 
+        // Push Consumer
         {
             let consumer = stream
-                .create_consumer(consumer::pull::Config {
+                .create_consumer(consumer::push::Config {
                     name: Some("SampledPushConsumer".into()),
+                    deliver_subject: "DeliverSubject".into(),
                     description: Some(
                         "See below to check that Ack Sampling has been set to 100%!".to_string(),
                     ),


### PR DESCRIPTION
Followup from #1354 

Previously merged test accidentally tested pull consumer configs twice, neglecting to test push consumer configs as well.