### PR TITLE
Improve transient dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,15 @@ jobs:
         env:
           RUST_BACKTRACE: 1
         run: |
-          cargo test --features=${{ matrix.features }} --features slow_tests -- --nocapture
+          cargo test --features slow_tests,websockets -- --nocapture
+      - name: TLS tests (ring, aws-lc-rs, fips)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          # we do not want to create more matrices just for tls test.
+          # It's easier to test it manually here.
+          cargo test tls --features=ring --no-default-features -- --nocapture
+          cargo test tls --features=aws-lc-rs --no-default-features -- --nocapture
+          cargo test tls --features=fips --no-default-features -- --nocapture
 
   check_format:
     name: check format (ubuntu-latest / nightly)

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -39,9 +39,9 @@ base64 = "0.22"
 tryhard = "0.5"
 ring = { version = "0.17", optional = true }
 rand = "0.8"
-webpki = { package = "rustls-webpki", version = "0.102" }
+rustls-webpki = { package = "rustls-webpki", default-features = false, version = "0.102" }
 portable-atomic = "1"
-tokio-websockets = { version = "0.10", features = ["client", "rand", "rustls-native-roots"], optional = true }
+tokio-websockets = { version = "0.10", default-features = false, features = ["client", "rand", "rustls-webpki-roots"], optional = true }
 pin-project = "1.0"
 
 [dev-dependencies]
@@ -52,7 +52,7 @@ rand = "0.8"
 tokio = { version = "1.25.0", features = ["rt-multi-thread"] }
 futures = { version = "0.3.28", default-features = false, features = ["std", "async-await"] }
 tracing-subscriber = "0.3"
-async-nats = {path = ".", features = ["experimental"]}
+async-nats = {path = ".", features = ["service", "server_2_10"], default-features = false}
 reqwest = "0.11.18"
 jsonschema = "0.17.1"
 
@@ -64,8 +64,8 @@ default = ["server_2_10", "ring"]
 # Enables Service API for the client.
 service = []
 websockets = ["dep:tokio-websockets"]
-aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets/aws-lc-rs"]
-ring = ["dep:ring", "tokio-rustls/ring", "tokio-websockets/ring"]
+aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets?/aws-lc-rs", "rustls-webpki/aws_lc_rs"]
+ring = ["dep:ring", "tokio-rustls/ring", "tokio-websockets?/ring"]
 fips = ["aws-lc-rs", "tokio-rustls/fips"]
 # All experimental features are part of this feature flag.
 experimental = ["service"]

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -350,7 +350,7 @@ impl Connector {
             }
             #[cfg(feature = "websockets")]
             "wss" => {
-                let domain = webpki::types::ServerName::try_from(server_addr.host())
+                let domain = rustls_webpki::types::ServerName::try_from(server_addr.host())
                     .map_err(|err| ConnectError::with_source(crate::ConnectErrorKind::Tls, err))?;
                 let tls_config =
                     Arc::new(tls::config_tls(&self.options).await.map_err(|err| {
@@ -406,7 +406,7 @@ impl Connector {
             );
             let tls_connector = tokio_rustls::TlsConnector::from(tls_config);
 
-            let domain = webpki::types::ServerName::try_from(server_addr.host())
+            let domain = rustls_webpki::types::ServerName::try_from(server_addr.host())
                 .map_err(|err| ConnectError::with_source(crate::ConnectErrorKind::Tls, err))?;
 
             let tls_stream = tls_connector

--- a/async-nats/src/tls.rs
+++ b/async-nats/src/tls.rs
@@ -13,10 +13,10 @@
 
 use crate::connector::ConnectorOptions;
 use crate::tls;
+use rustls_webpki::types::{CertificateDer, PrivateKeyDer};
 use std::io::{self, BufReader, ErrorKind};
 use std::path::PathBuf;
 use tokio_rustls::rustls::{ClientConfig, RootCertStore};
-use webpki::types::{CertificateDer, PrivateKeyDer};
 
 /// Loads client certificates from a `.pem` file.
 /// If the pem file is found, but does not contain any certificates, it will return
@@ -67,8 +67,10 @@ pub(crate) async fn config_tls(options: &ConnectorOptions) -> io::Result<ClientC
                 let trust_anchors = load_certs(cafile.to_owned())
                     .await?
                     .into_iter()
-                    .map(|cert| webpki::anchor_from_trusted_cert(&cert).map(|ta| ta.to_owned()))
-                    .collect::<Result<Vec<_>, webpki::Error>>()
+                    .map(|cert| {
+                        rustls_webpki::anchor_from_trusted_cert(&cert).map(|ta| ta.to_owned())
+                    })
+                    .collect::<Result<Vec<_>, rustls_webpki::Error>>()
                     .map_err(|err| {
                         io::Error::new(
                             ErrorKind::InvalidInput,

--- a/async-nats/tests/kv_tests.rs
+++ b/async-nats/tests/kv_tests.rs
@@ -1041,7 +1041,7 @@ mod kv {
             }
         })
         .retries(5)
-        .exponential_backoff(Duration::from_millis(500))
+        .exponential_backoff(Duration::from_millis(2000))
         .await
         .unwrap();
 


### PR DESCRIPTION
This reduces the dependencies footprint in scenarios when `websockets` and `aws-lc-rs` are not used.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>