### PR TITLE
Change `jetstream::Error`'s `Display` message

### DIFF
--- a/async-nats/src/jetstream/errors.rs
+++ b/async-nats/src/jetstream/errors.rs
@@ -502,8 +502,8 @@ impl fmt::Display for Error {
         write!(
             fmt,
             "{} (code {}, error code {})",
-            self.code,
             self.description.as_ref().unwrap_or(&"unknown".to_string()),
+            self.code,
             self.err_code.0,
         )
     }


### PR DESCRIPTION
The current `Display` message for `jetstream::Error` is a little confusing. For example, this piece of code:

```rust
#[tokio::main]
async fn main() -> Result<(), async_nats::Error> {
    let client = async_nats::connect("localhost:4222").await?;
    let jetstream = async_nats::jetstream::new(client);
    if let Err(err) = jetstream.get_object_store("nonexistent").await {
        eprintln!("{}", err);
    }
    Ok(())
}
```
prints
```
failed to get Object Store: jetstream error: 404 (code stream not found, error code 10059)
```

After this change, the message is:
```
failed to get Object Store: jetstream error: stream not found (code 404, error code 10059)
```