### PR TITLE
Delete old objects when calling `ObjectStore::put`

### DIFF
--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -288,12 +288,8 @@ impl ObjectStore {
     {
         let object_meta: ObjectMetadata = meta.into();
 
-        let encoded_object_name = encode_object_name(&object_meta.name);
-        if !is_valid_object_name(&encoded_object_name) {
-            return Err(PutError::new(PutErrorKind::InvalidName));
-        }
         // Fetch any existing object info, if there is any for later use.
-        let maybe_existing_object_info = match self.info(&encoded_object_name).await {
+        let maybe_existing_object_info = match self.info(&object_meta.name).await {
             Ok(object_info) => Some(object_info),
             Err(_) => None,
         };
@@ -343,7 +339,13 @@ impl ObjectStore {
                 })?;
         }
         let digest = sha256.finish();
+
+        let encoded_object_name = encode_object_name(&object_meta.name);
+        if !is_valid_object_name(&encoded_object_name) {
+            return Err(PutError::new(PutErrorKind::InvalidName));
+        }
         let subject = format!("$O.{}.M.{}", &self.name, &encoded_object_name);
+
         let object_info = ObjectInfo {
             name: object_meta.name,
             description: object_meta.description,


### PR DESCRIPTION
When an object already exists in the object store, `ObjectStore::put` is supposed to purge it. Currently, this does not happen because the object name is erroneously double-encoded.

To reproduce:

```rust
#[tokio::main]
async fn main() -> Result<(), async_nats::Error> {
    let client = async_nats::connect("localhost:4222").await?;
    let jetstream = async_nats::jetstream::new(client);
    let kv = jetstream
        .create_object_store(async_nats::jetstream::object_store::Config {
            bucket: "store".to_owned(),
            ..Default::default()
        })
        .await?;

    let mut file = tokio::fs::File::open("foo").await?;
    kv.put("file", &mut file).await?;

    let mut file = tokio::fs::File::open("bar").await?;
    kv.put("file", &mut file).await?;

    Ok(())
}
```

```bash
echo foo >foo
echo bar >bar
cargo run
nats stream view OBJ_store
``` 

Output:
```
[1] Subject: $O.store.C.pGkr4eEuZBEg3NrGeApigQ Received: 2025-01-27T20:43:37-03:00
foo

[3] Subject: $O.store.C.pGkr4eEuZBEg3NrGeApioo Received: 2025-01-27T20:43:37-03:00
bar

[4] Subject: $O.store.M.ZmlsZQ== Received: 2025-01-27T20:43:37-03:00

  Nats-Rollup: sub
{"name":"file","description":null,"metadata":{},"headers":null,"options":{"link":null,"max_chunk_size":131072},"bucket":"store","nuid":"pGkr4eEuZBEg3NrGeApioo","size":4,"chunks":1,"mtime":"2025-01-27T23:43:37.168071192Z","digest":"SHA-256=fYZelZskZpGMmGOvypQtD7idfJrAyZuvw3SVBN7ZdzA="}


20:43:39 Reached apparent end of data
```

After the changes introduced by this PR:
```
[3] Subject: $O.store.C.LrStiyrrO355ash9mfODWe Received: 2025-01-27T20:44:08-03:00
bar

[4] Subject: $O.store.M.ZmlsZQ== Received: 2025-01-27T20:44:08-03:00

  Nats-Rollup: sub
{"name":"file","description":null,"metadata":{},"headers":null,"options":{"link":null,"max_chunk_size":131072},"bucket":"store","nuid":"LrStiyrrO355ash9mfODWe","size":4,"chunks":1,"mtime":"2025-01-27T23:44:08.885415879Z","digest":"SHA-256=fYZelZskZpGMmGOvypQtD7idfJrAyZuvw3SVBN7ZdzA="}


20:44:12 Reached apparent end of data
```