### PR TITLE
Remove stale experimental flags mentions

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -68,7 +68,7 @@ aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets?/aws-l
 ring = ["dep:ring", "tokio-rustls/ring", "tokio-websockets?/ring"]
 fips = ["aws-lc-rs", "tokio-rustls/fips"]
 # All experimental features are part of this feature flag.
-experimental = ["service"]
+experimental = []
 # Features that require nats-server version 2.10 or higher.
 # It is enabled by default since official 2.10 nats-server release.
 "server_2_10" = []

--- a/nats/src/kv.rs
+++ b/nats/src/kv.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //! Support for Key Value Store.
-//! This feature is experimental and the API may change.
 
 use std::io;
 use std::time::Duration;

--- a/nats/src/object_store.rs
+++ b/nats/src/object_store.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //! Support for Object Store.
-//! This feature is experimental and the API may change.
 
 use crate::header::HeaderMap;
 use crate::jetstream::{


### PR DESCRIPTION
No features were experimental, but some mentiones were still there for old client or had stale additional feature flag.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>