### PR TITLE
Revert stopping watcher and set `seen_current` instead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Install msrv Rust on ubuntu-latest
         id:   install-rust
-        uses: dtolnay/rust-toolchain@1.79.0
+        uses: dtolnay/rust-toolchain@1.81.0
       - name: Cache the build artifacts
         uses: Swatinem/rust-cache@v2
         with:

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -77,7 +77,12 @@ impl From<crate::RequestError> for DirectGetError {
     fn from(err: crate::RequestError) -> Self {
         match err.kind() {
             crate::RequestErrorKind::TimedOut => DirectGetError::new(DirectGetErrorKind::TimedOut),
-            crate::RequestErrorKind::NoResponders => DirectGetError::new(DirectGetErrorKind::Other),
+            crate::RequestErrorKind::NoResponders => {
+                DirectGetError::new(DirectGetErrorKind::ErrorResponse(
+                    StatusCode::NO_RESPONDERS,
+                    "no responders".to_string(),
+                ))
+            }
             crate::RequestErrorKind::Other => {
                 DirectGetError::with_source(DirectGetErrorKind::Other, err)
             }

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -47,7 +47,7 @@ mod jetstream {
         DiscardPolicy, StorageType,
     };
     use async_nats::jetstream::AckKind;
-    use async_nats::ConnectOptions;
+    use async_nats::{ConnectOptions, StatusCode};
     use futures::stream::{StreamExt, TryStreamExt};
     use time::OffsetDateTime;
     use tracing::debug;
@@ -875,7 +875,10 @@ mod jetstream {
 
         assert_eq!(
             stream.direct_get(1).await.unwrap_err().kind(),
-            DirectGetErrorKind::TimedOut
+            DirectGetErrorKind::ErrorResponse(
+                StatusCode::NO_RESPONDERS,
+                "no responders".to_string()
+            )
         );
     }
 

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -2220,7 +2220,6 @@ mod jetstream {
             .unwrap();
 
         let stream = context.get_stream("events").await.unwrap();
-        println!("STREAM INFO: {:?}", stream.cached_info());
         stream
             .create_consumer(consumer::pull::Config {
                 durable_name: Some("pull".into()),
@@ -2229,7 +2228,6 @@ mod jetstream {
             .await
             .unwrap();
         let consumer: PullConsumer = stream.get_consumer("pull").await.unwrap();
-        println!("CONSUMER INFO: {:?}", consumer.cached_info());
 
         // Delete the consumer before starting fetching messages.
         let name = &consumer.cached_info().name;
@@ -2245,7 +2243,7 @@ mod jetstream {
             .unwrap();
         assert_eq!(
             messages.next().await.unwrap().unwrap_err().kind(),
-            async_nats::jetstream::consumer::pull::MessagesErrorKind::MissingHeartbeat,
+            async_nats::jetstream::consumer::pull::MessagesErrorKind::Other,
         );
         // But the consumer iterator should still be there.
         // We should get timeout again.

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -50,7 +50,7 @@ mod jetstream {
     use async_nats::{ConnectOptions, StatusCode};
     use futures::stream::{StreamExt, TryStreamExt};
     use time::OffsetDateTime;
-    use tracing::{debug, Level};
+    use tracing::debug;
 
     #[tokio::test]
     async fn query_account_requests() {
@@ -2197,10 +2197,6 @@ mod jetstream {
 
     #[tokio::test]
     async fn pull_consumer_stream_with_heartbeat() {
-        tracing_subscriber::fmt()
-            .with_max_level(Level::DEBUG)
-            .init();
-        use tracing::debug;
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = ConnectOptions::new()
             .event_callback(|err| async move { println!("error: {err:?}") })

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -50,7 +50,7 @@ mod jetstream {
     use async_nats::{ConnectOptions, StatusCode};
     use futures::stream::{StreamExt, TryStreamExt};
     use time::OffsetDateTime;
-    use tracing::debug;
+    use tracing::{debug, Level};
 
     #[tokio::test]
     async fn query_account_requests() {
@@ -2195,9 +2195,12 @@ mod jetstream {
         messages.next().await.unwrap().unwrap();
     }
 
-    #[cfg(feature = "slow_tests")]
+    // #[cfg(feature = "slow_tests")]
     #[tokio::test]
     async fn pull_consumer_stream_with_heartbeat() {
+        tracing_subscriber::fmt()
+            .with_max_level(Level::DEBUG)
+            .init();
         use tracing::debug;
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = ConnectOptions::new()

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -2220,6 +2220,7 @@ mod jetstream {
             .unwrap();
 
         let stream = context.get_stream("events").await.unwrap();
+        println!("STREAM INFO: {:?}", stream.cached_info());
         stream
             .create_consumer(consumer::pull::Config {
                 durable_name: Some("pull".into()),
@@ -2228,6 +2229,7 @@ mod jetstream {
             .await
             .unwrap();
         let consumer: PullConsumer = stream.get_consumer("pull").await.unwrap();
+        println!("CONSUMER INFO: {:?}", consumer.cached_info());
 
         // Delete the consumer before starting fetching messages.
         let name = &consumer.cached_info().name;


### PR DESCRIPTION
In PR #1321, we introduced a change that was stopping watcher if there were no keys when starting the watch.
This is undesired behaviour, as watcher should allow for endless watch, no matter if there are keys or not.
This PR sets `seen_current` bool instead.

fixes #1376 

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>