### PR TITLE
fix(ServerAddr): align port() with `Url::port_or_known_default`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 Cargo.lock
 .helix
 .DS_Store
+
+# nixago: ignore-linked-files
+/treefmt.toml


### PR DESCRIPTION
as the parsing of the strings goes through Url the output behavior is incorrect when the implicit defaults of `Url` are ignored.

for example `wss://nats-server.com:443` would previously lead to the client trying to connect to port `4222`, because `Url::port` returns `None` for this case.