### PR TITLE
Fix typo in documentation of stream.rs

### DIFF
--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -603,7 +603,7 @@ impl<I> Stream<I> {
         .await
     }
 
-    /// Get a fist message from the stream for a given subject starting from provided sequence.
+    /// Get a first message from the stream for a given subject starting from provided sequence.
     /// This low-level API always reaches stream leader.
     /// This should be discouraged in favor of using [Stream::direct_get_first_for_subject].
     ///


### PR DESCRIPTION
Just corrects fist -> first.