### PR TITLE
Handle no responders in Consumers and never giving up

### DIFF
--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -852,7 +852,7 @@ impl futures::Stream for Ordered {
                             sequence,
                         )
                     })
-                    .retries(5)
+                    .retries(u32::MAX)
                     .exponential_backoff(Duration::from_millis(500))
                     .await
                 }
@@ -954,7 +954,7 @@ impl Stream {
                                 }
                             debug!("detected !Connected -> Connected state change");
 
-                            match tryhard::retry_fn(|| consumer.fetch_info()).retries(5).exponential_backoff(Duration::from_millis(500)).await {
+                            match tryhard::retry_fn(|| consumer.fetch_info()).retries(u32::MAX).exponential_backoff(Duration::from_millis(500)).await {
                                 Ok(info) => {
                                     if info.num_waiting == 0 {
                                         pending_reset = true;
@@ -1055,6 +1055,7 @@ impl From<MessagesError> for OrderedError {
                 kind: OrderedErrorKind::Other,
                 source: err.source,
             },
+            MessagesErrorKind::NoResponders => OrderedError::new(OrderedErrorKind::NoResponders),
         }
     }
 }

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -2245,7 +2245,7 @@ mod jetstream {
             .unwrap();
         assert_eq!(
             messages.next().await.unwrap().unwrap_err().kind(),
-            async_nats::jetstream::consumer::pull::MessagesErrorKind::Other,
+            async_nats::jetstream::consumer::pull::MessagesErrorKind::NoResponders,
         );
         // But the consumer iterator should still be there.
         // We should get timeout again.


### PR DESCRIPTION
Consumers did have max amount of times they tried to recover before they give up.
This changes the approach to never give up.
It also addreses the chnage in the server, which now sends `no responders` if the resource (JS, consumer, stream) does not exist.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>