### PR TITLE
Revert endless retry on consumer info

### DIFF
--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -954,7 +954,7 @@ impl Stream {
                                 }
                             debug!("detected !Connected -> Connected state change");
 
-                            match tryhard::retry_fn(|| consumer.fetch_info()).retries(u32::MAX).custom_backoff(backoff).await {
+                            match tryhard::retry_fn(|| consumer.fetch_info()).retries(5).custom_backoff(backoff).await {
                                 Ok(info) => {
                                     if info.num_waiting == 0 {
                                         pending_reset = true;


### PR DESCRIPTION
Actually, info should fail after few tried, giving user feedback.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>