### PR TITLE
Add note about webpki-roots license

### DIFF
--- a/async-nats/dependencies.md
+++ b/async-nats/dependencies.md
@@ -29,6 +29,7 @@ This file lists the dependencies used in this repository.
 | tokio-rustls 0.24.1       | Apache-2.0 OR MIT        |
 | tracing 0.1.37            | MIT                      |
 | url 2.4.1                 | Apache-2.0 OR MIT        |
+| webpki-roots (optional)   | CDLA-Permissive-2.0      |
 
 ## Dev dependencies (tests, examples, benchmarks)
 

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,7 @@ allow = [
     "OpenSSL",
     "Unicode-DFS-2016",
     "Unicode-3.0",
+    "CDLA-Permissive-2.0"
 ]
 
 default = "deny"


### PR DESCRIPTION
As webpki-roots pulled in by `tokio-websockets` (our optional dependency) and it's certificate data is licensed under CDLA, it requires us to add an exception to the license check.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>