### PR TITLE
Add client traits

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -253,7 +253,7 @@ mod options;
 
 pub use auth::Auth;
 pub use client::{
-    Client, PublishError, RequestError, RequestErrorKind, Requester, Statistics, SubscribeError,
+    Client, PublishError, Request, RequestError, RequestErrorKind, Statistics, SubscribeError,
 };
 pub use options::{AuthError, ConnectOptions};
 

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -253,7 +253,7 @@ mod options;
 
 pub use auth::Auth;
 pub use client::{
-    Client, PublishError, Request, RequestError, RequestErrorKind, Statistics, SubscribeError,
+    Client, PublishError, RequestError, RequestErrorKind, Requester, Statistics, SubscribeError,
 };
 pub use options::{AuthError, ConnectOptions};
 

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -12,10 +12,11 @@
 // limitations under the License.
 
 mod client {
+    use async_nats::client::Request;
     use async_nats::connection::State;
     use async_nats::header::HeaderValue;
     use async_nats::{
-        ConnectErrorKind, ConnectOptions, Event, Request, RequestErrorKind, ServerAddr, Subject,
+        ConnectErrorKind, ConnectOptions, Event, RequestErrorKind, ServerAddr, Subject,
     };
     use bytes::Bytes;
     use futures::future::join_all;


### PR DESCRIPTION
This allows others to extend the client.
It introduces first set of traits.


It introduces new `traits` module to avoid name conflicts.