### PR TITLE
Allow conversion from &str in ToSubject.

### DIFF
--- a/async-nats/src/subject.rs
+++ b/async-nats/src/subject.rs
@@ -152,6 +152,12 @@ impl ToSubject for String {
     }
 }
 
+impl ToSubject for &str {
+    fn to_subject(&self) -> Subject {
+        Subject::from(self.as_str())
+    }
+}
+
 impl Serialize for Subject {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
I haven't discovered why can't we pass a borrowed str and it make api a bit more versatile.