### PR TITLE
Add port/path support for WebSockets

### DIFF
--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -386,8 +386,6 @@ impl Connector {
             }
             #[cfg(feature = "websockets")]
             "wss" => {
-                let domain = rustls_webpki::types::ServerName::try_from(server_addr.host())
-                    .map_err(|err| ConnectError::with_source(crate::ConnectErrorKind::Tls, err))?;
                 let tls_config =
                     Arc::new(tls::config_tls(&self.options).await.map_err(|err| {
                         ConnectError::with_source(crate::ConnectErrorKind::Tls, err)

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -371,7 +371,16 @@ impl Connector {
                 let ws = tokio::time::timeout(
                     self.options.connection_timeout,
                     tokio_websockets::client::Builder::new()
-                        .uri(format!("{}://{}", server_addr.scheme(), socket_addr).as_str())
+                        .uri(
+                            format!(
+                                "{}://{}:{}{}", 
+                                server_addr.scheme(), 
+                                server_addr.host(), 
+                                server_addr.port(), 
+                                server_addr.path()
+                            )
+                            .as_str(),
+                        )
                         .map_err(|err| {
                             ConnectError::with_source(crate::ConnectErrorKind::ServerParse, err)
                         })?
@@ -399,10 +408,11 @@ impl Connector {
                         .connector(&tokio_websockets::Connector::Rustls(tls_connector))
                         .uri(
                             format!(
-                                "{}://{}:{}",
+                                "{}://{}:{}{}",
                                 server_addr.scheme(),
                                 domain.to_str(),
-                                server_addr.port()
+                                server_addr.port(),
+                                server_addr.path()
                             )
                             .as_str(),
                         )

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -371,16 +371,7 @@ impl Connector {
                 let ws = tokio::time::timeout(
                     self.options.connection_timeout,
                     tokio_websockets::client::Builder::new()
-                        .uri(
-                            format!(
-                                "{}://{}:{}{}", 
-                                server_addr.scheme(), 
-                                server_addr.host(), 
-                                server_addr.port(), 
-                                server_addr.path()
-                            )
-                            .as_str(),
-                        )
+                        .uri(server_addr.as_url_str())
                         .map_err(|err| {
                             ConnectError::with_source(crate::ConnectErrorKind::ServerParse, err)
                         })?
@@ -406,16 +397,7 @@ impl Connector {
                     self.options.connection_timeout,
                     tokio_websockets::client::Builder::new()
                         .connector(&tokio_websockets::Connector::Rustls(tls_connector))
-                        .uri(
-                            format!(
-                                "{}://{}:{}{}",
-                                server_addr.scheme(),
-                                domain.to_str(),
-                                server_addr.port(),
-                                server_addr.path()
-                            )
-                            .as_str(),
-                        )
+                        .uri(server_addr.as_url_str())
                         .map_err(|err| {
                             ConnectError::with_source(crate::ConnectErrorKind::ServerParse, err)
                         })?

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1613,9 +1613,9 @@ impl ServerAddr {
         self.0.port_or_known_default().unwrap_or(4222)
     }
 
-    /// Returns the URL path.
-    pub fn path(&self) -> &str {
-        self.0.path()
+    /// Returns the URL string.
+    pub fn as_url_str(&self) -> &str {
+        self.0.as_str()
     }
 
     /// Returns the optional username in the url.

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1613,6 +1613,11 @@ impl ServerAddr {
         self.0.port_or_known_default().unwrap_or(4222)
     }
 
+    /// Returns the URL path.
+    pub fn path(&self) -> &str {
+        self.0.path()
+    }
+
     /// Returns the optional username in the url.
     pub fn username(&self) -> Option<&str> {
         let user = self.0.username();


### PR DESCRIPTION
Added port and path to the URI used to open the WebSocket (ws or wss), to support connections through a reverse proxy.

Solves issue #1425