### PR TITLE
Improve test reliability by publishing with awaiting ack

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1157,7 +1157,12 @@ mod jetstream {
             .unwrap();
 
         for _ in 0..20 {
-            context.publish("events", "data".into()).await.unwrap();
+            context
+                .publish("events", "data".into())
+                .await
+                .unwrap()
+                .await
+                .unwrap();
         }
 
         let consumer = stream


### PR DESCRIPTION
This test was failing at Github Actions Windows runner.

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>