### PR TITLE
Adds messages counters stream config

### DIFF
--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -1300,6 +1300,15 @@ pub struct Config {
         rename = "allow_msg_schedules"
     )]
     pub allow_message_schedules: bool,
+
+    /// Enables counters for the stream
+    #[cfg(feature = "server_2_12")]
+    #[serde(
+        default,
+        skip_serializing_if = "is_default",
+        rename = "allow_msg_counter"
+    )]
+    pub allow_message_counter: bool,
 }
 
 impl From<&Config> for Config {


### PR DESCRIPTION
This commit adds just a switch to the stream config. Counter utility for the clients will come in Orbit.rs as an extension.

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>