### PR TITLE
Release async-nats/v0.43.1

### DIFF
--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -1,4 +1,16 @@
-# v0.43.0
+
+# v0.43.1
+
+## Overview
+
+A hotfix for bugs and regressions introduced with recent release.
+
+## Fixed
+* Fix direct get with nats-server 2.11 & improve testing against older servers by @Jarema in https://github.com/nats-io/nats.rs/pull/1458
+* Properly handle acker cleanup by @Jarema in https://github.com/nats-io/nats.rs/pull/1460
+
+
+**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.43.0...async-nats/v0.43.13.0
 
 ## Overview
 

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
-version = "0.43.0"
+version = "0.43.1"
 edition = "2021"
 rust = "1.79.0"
 description = "A async Rust NATS client"


### PR DESCRIPTION
## Overview

A hotfix for a regression that was introduced with direct get builder that affected also KV.

## Fixed
* Fix direct get with nats-server 2.11 & improve testing against older servers by @Jarema in https://github.com/nats-io/nats.rs/pull/1458
* Properly handle acker cleanup by @Jarema in https://github.com/nats-io/nats.rs/pull/1460


**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.43.0...async-nats/v0.43.1

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>