### PR TITLE
Abort acker only when last context instance is dropped

### DIFF
--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use std::task::Poll;
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, TryAcquireError};
 use tokio::time::Duration;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::debug;
 
 use super::consumer::{self, Consumer, FromConsumer, IntoConsumerConfig};
@@ -60,15 +60,14 @@ pub struct Context {
     pub(crate) prefix: String,
     pub(crate) timeout: Duration,
     pub(crate) max_ack_semaphore: Arc<tokio::sync::Semaphore>,
-    pub(crate) acker_task: Arc<tokio::task::JoinHandle<()>>,
     pub(crate) ack_sender:
-        tokio::sync::mpsc::UnboundedSender<(oneshot::Receiver<Message>, OwnedSemaphorePermit)>,
+        tokio::sync::mpsc::Sender<(oneshot::Receiver<Message>, OwnedSemaphorePermit)>,
     pub(crate) backpressure_on_inflight: bool,
     pub(crate) semaphore_capacity: usize,
 }
 
 fn spawn_acker(
-    rx: UnboundedReceiverStream<(oneshot::Receiver<Message>, OwnedSemaphorePermit)>,
+    rx: ReceiverStream<(oneshot::Receiver<Message>, OwnedSemaphorePermit)>,
     ack_timeout: Duration,
     concurrency: Option<usize>,
 ) -> tokio::task::JoinHandle<()> {
@@ -78,13 +77,8 @@ fn spawn_acker(
             drop(permit);
         })
         .await;
+        debug!("Acker task exited");
     })
-}
-
-impl Drop for Context {
-    fn drop(&mut self) {
-        self.acker_task.abort();
-    }
 }
 
 use std::marker::PhantomData;
@@ -269,22 +263,17 @@ where
 
     /// Build the [Context] with the given settings.
     pub fn build(self, client: Client) -> Context {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<(
+        let (tx, rx) = tokio::sync::mpsc::channel::<(
             oneshot::Receiver<Message>,
             OwnedSemaphorePermit,
-        )>();
-        let stream = UnboundedReceiverStream::new(rx);
-        let acker_task = Arc::new(spawn_acker(
-            stream,
-            self.ack_timeout,
-            self.concurrency_limit,
-        ));
+        )>(self.semaphore_capacity);
+        let stream = ReceiverStream::new(rx);
+        spawn_acker(stream, self.ack_timeout, self.concurrency_limit);
         Context {
             client,
             prefix: self.prefix,
             timeout: self.timeout,
             max_ack_semaphore: Arc::new(tokio::sync::Semaphore::new(self.semaphore_capacity)),
-            acker_task,
             ack_sender: tx,
             backpressure_on_inflight: self.backpressure_on_inflight,
             semaphore_capacity: self.semaphore_capacity,
@@ -1656,15 +1645,14 @@ pub struct PublishAckFuture {
     timeout: Duration,
     subscription: Option<oneshot::Receiver<Message>>,
     permit: Option<OwnedSemaphorePermit>,
-    tx: mpsc::UnboundedSender<(oneshot::Receiver<Message>, OwnedSemaphorePermit)>,
+    tx: mpsc::Sender<(oneshot::Receiver<Message>, OwnedSemaphorePermit)>,
 }
 
 impl Drop for PublishAckFuture {
     fn drop(&mut self) {
         if let (Some(sub), Some(permit)) = (self.subscription.take(), self.permit.take()) {
-            // Unbounded send should never fail unless receiver is dropped (Context dropped)
-            if self.tx.send((sub, permit)).is_err() {
-                // Context was dropped, permit will be released when it goes out of scope
+            if let Err(err) = self.tx.try_send((sub, permit)) {
+                tracing::warn!("failed to pass future permit to the acker: {}", err);
             }
         }
     }


### PR DESCRIPTION
fixes #1455 

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>