### PR TITLE
Release v0.44.0

### DIFF
--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.44.0
+## Overview
+A release that focuses on reorganization of types and improvement of extension traits for [orbit](https://github.com/synadia-io/orbit.rs)
+
+## What's Changed
+* Enable service API by default by @Jarema in https://github.com/nats-io/nats.rs/pull/1461
+* Extend client traits by @Jarema in https://github.com/nats-io/nats.rs/pull/1456
+* Reorganize `message` types by @Jarema in https://github.com/nats-io/nats.rs/pull/1462
+
+
+**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.43.1...async-nats/v0.44.0
 
 # v0.43.1
 

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
-version = "0.43.1"
+version = "0.44.0"
 edition = "2021"
 rust = "1.79.0"
 description = "A async Rust NATS client"


### PR DESCRIPTION
## Overview
A release that focuses on reorganization of types and improvement of extension traits for [orbit](https://github.com/synadia-io/orbit.rs)

## What's Changed
* Enable service API by default by @Jarema in https://github.com/nats-io/nats.rs/pull/1461
* Extend client traits by @Jarema in https://github.com/nats-io/nats.rs/pull/1456
* Reorganize `message` types by @Jarema in https://github.com/nats-io/nats.rs/pull/1462


**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.43.1...async-nats/v0.44.0

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>