### PR TITLE
Release v0.44.2

### DIFF
--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.44.2
+## Overview
+This PR adds a new method to Context traits and fixes the docs build
+
+## What's Changed
+* Add send_request method to JetStream Context by @Jarema in https://github.com/nats-io/nats.rs/pull/1466
+* Fix docs by @Jarema in https://github.com/nats-io/nats.rs/pull/1468
+
+**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.44.1...async-nats/v0.44.2
+
 # v0.44.1
 ## What's Changed
 * Add missing errors types by @Jarema in https://github.com/nats-io/nats.rs/pull/1464

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
-version = "0.44.1"
+version = "0.44.2"
 edition = "2021"
 rust = "1.79.0"
 description = "A async Rust NATS client"


### PR DESCRIPTION
# v0.44.2
## Overview
This PR adds a new method to Context traits and fixes the docs build

## What's Changed
* Add send_request method to JetStream Context by @Jarema in https://github.com/nats-io/nats.rs/pull/1466
* Fix docs by @Jarema in https://github.com/nats-io/nats.rs/pull/1468

**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.44.1...async-nats/v0.44.2


Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>