### PR TITLE
Add `double_ack_with` method to JetStream Messages

### DIFF
--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -2457,9 +2457,9 @@ mod jetstream {
             .unwrap();
         let mut consumer = stream.get_consumer("pull").await.unwrap();
 
-        for _ in 0..10 {
+        for i in 0..10 {
             context
-                .publish("events", "dat".into())
+                .publish("events", format!("dat-{i}").into())
                 .await
                 .unwrap()
                 .await
@@ -2523,10 +2523,11 @@ mod jetstream {
         if let Some(message) = iter.next().await {
             message
                 .unwrap()
-                .ack_with(async_nats::jetstream::AckKind::Nak(None))
+                .double_ack_with(async_nats::jetstream::AckKind::Nak(None))
                 .await
                 .unwrap();
         }
+
         client.flush().await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
This will allow consumers of the library to obtain exactly-once delivery semantics across a wider range of valid usecases that include NAKing entire ranges of Messages.