### PR TITLE
Switch to rustls-pki-types

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -29,7 +29,7 @@ tokio-stream = "0.1.17"
 url = { version = "2"}
 tokio-rustls = { version = "0.26", default-features = false }
 tokio-util = "0.7"
-rustls-pemfile = "2"
+rustls-pki-types ="1"
 nuid = "0.5"
 serde_nanos = "0.1.3"
 time = { version = "0.3.36", features = ["parsing", "formatting", "serde", "serde-well-known"] }


### PR DESCRIPTION
As rustls-pemfile has been deprecated,
we're moving the suggested alternative.

closes #1490 

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>