### PR TITLE
Fix error deserialization when err_code is absent

### DIFF
--- a/async-nats/src/jetstream/errors.rs
+++ b/async-nats/src/jetstream/errors.rs
@@ -15,7 +15,7 @@ use std::{error, fmt};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize, Default)]
 pub struct ErrorCode(pub u64);
 
 impl ErrorCode {
@@ -621,6 +621,7 @@ impl ErrorCode {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Error {
     code: usize,
+    #[serde(default)]
     err_code: ErrorCode,
     description: Option<String>,
 }


### PR DESCRIPTION
In rare cases nats-server returns JetStream error without err_code. This causes deserialization error that does not allow to peek into rest of given error information.

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>