### PR TITLE
Fix race condition in nats-server wrapper utility for cluster creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,38 @@ jobs:
           cargo test --features slow_tests,websockets -- --nocapture
       # TLS and version-specific tests are now run in parallel in a separate job
 
+  nats_server_tests:
+    defaults:
+      run:
+        working-directory: ./nats-server
+    name: nats-server tests (ubuntu-latest / stable)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Generate go.sum
+        run: touch go.sum
+      - name: Set up Go
+        id: setup-go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.25'
+      - name: Install nats-server
+        run: go install github.com/nats-io/nats-server/v2@main
+      - name: Install stable Rust
+        id: install-rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache the build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ steps.install-rust.outputs.cachekey }}-${{ hashFiles('**/Cargo.toml') }}
+          cache-on-failure: true
+      - name: Run nats-server tests
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          cargo test --lib -- --test-threads=1 --nocapture
+
   tls_tests:
     defaults:
       run:

--- a/nats-server/src/lib.rs
+++ b/nats-server/src/lib.rs
@@ -194,7 +194,7 @@ pub fn run_cluster<'a, C: IntoConfig<'a>>(cfg: C) -> Cluster {
             new_port
         })
         .collect::<Vec<usize>>();
-    let cluster = [port + 1, port + 101, port + 201];
+    let cluster = [ports[0] + 1, ports[1] + 1, ports[2] + 1];
 
     let s1 = run_cluster_node_with_port(
         cfg.0[0],
@@ -220,6 +220,10 @@ pub fn run_cluster<'a, C: IntoConfig<'a>>(cfg: C) -> Cluster {
         "cluster".to_string(),
         cluster[2],
     );
+
+    // Give the cluster a moment to establish routing and elect a leader.
+    thread::sleep(Duration::from_millis(2000));
+
     Cluster {
         servers: vec![s1, s2, s3],
     }


### PR DESCRIPTION
The tests were not using proper ports in case of reassignment. This commit also makes sure that GitHub CI is running the test.

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>