### PR TITLE
Update rustls-native-certs from 0.7 to 0.8

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -33,7 +33,7 @@ rustls-pki-types = "1"
 nuid = { version = "0.5", optional = true }
 serde_nanos = { version = "0.1.3", optional = true }
 time = { version = "0.3.36", features = ["parsing", "formatting", "serde", "serde-well-known"], optional = true }
-rustls-native-certs = "0.7"
+rustls-native-certs = "0.8"
 tracing = "0.1"
 thiserror = "1.0"
 base64 = { version = "0.22", optional = true }
@@ -103,4 +103,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 [package.metadata.cargo-hack]
 # Optimize feature powerset testing
 # See CARGO_HACK_STRATEGY.md for detailed explanation
-

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -886,7 +886,7 @@ impl ConnectOptions {
     /// # async fn main() -> Result<(), async_nats::Error> {
     /// let mut root_store = async_nats::rustls::RootCertStore::empty();
     ///
-    /// root_store.add_parsable_certificates(rustls_native_certs::load_native_certs()?);
+    /// root_store.add_parsable_certificates(rustls_native_certs::load_native_certs().certs);
     ///
     /// let tls_client = async_nats::rustls::ClientConfig::builder()
     ///     .with_root_certificates(root_store)


### PR DESCRIPTION
This fixes #1502 which is an advisory that has been open since December of last year.

There is a slight change in the way the single use of this dependency generates the result, no longer failing on the first error but collecting all successes and errors into a single return value. I've added code to separate all errors by a new line character but would be happy to change that to any other separator you'd prefer.