### PR TITLE
fix(consumer): invalid rate limit json

### DIFF
--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -304,7 +304,7 @@ pub struct Config {
     #[serde(default)]
     pub replay_policy: ReplayPolicy,
     /// The rate of message delivery in bits per second
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(rename = "rate_limit_bps", default, skip_serializing_if = "is_default")]
     pub rate_limit: u64,
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -613,7 +613,7 @@ pub struct OrderedConfig {
     /// Whether messages are sent as quickly as possible or at the rate of receipt
     pub replay_policy: ReplayPolicy,
     /// The rate of message delivery in bits per second
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(rename = "rate_limit_bps", default, skip_serializing_if = "is_default")]
     pub rate_limit: u64,
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(
@@ -2524,7 +2524,7 @@ pub struct Config {
     /// Whether messages are sent as quickly as possible or at the rate of receipt
     pub replay_policy: ReplayPolicy,
     /// The rate of message delivery in bits per second
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(rename = "rate_limit_bps", default, skip_serializing_if = "is_default")]
     pub rate_limit: u64,
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -236,7 +236,7 @@ pub struct Config {
     /// Whether messages are sent as quickly as possible or at the rate of receipt
     pub replay_policy: ReplayPolicy,
     /// The rate of message delivery in bits per second
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(rename = "rate_limit_bps", default, skip_serializing_if = "is_default")]
     pub rate_limit: u64,
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(
@@ -404,7 +404,7 @@ pub struct OrderedConfig {
     /// Whether messages are sent as quickly as possible or at the rate of receipt
     pub replay_policy: ReplayPolicy,
     /// The rate of message delivery in bits per second
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(rename = "rate_limit_bps", default, skip_serializing_if = "is_default")]
     pub rate_limit: u64,
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(

--- a/nats/src/jetstream/types.rs
+++ b/nats/src/jetstream/types.rs
@@ -221,7 +221,7 @@ pub struct ConsumerConfig {
     /// Whether messages are sent as quickly as possible or at the rate of receipt
     pub replay_policy: ReplayPolicy,
     /// The rate of message delivery in bits per second
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(rename = "rate_limit_bps", default, skip_serializing_if = "is_default")]
     pub rate_limit: u64,
     /// What percentage of acknowledgments should be samples for observability, 0-100
     #[serde(


### PR DESCRIPTION
Per the go server implementation it seems that the appropriate field is `rate_limit_bps` and not `rate_limit`:

https://github.com/nats-io/nats-server/blob/c3e0b35d48e095940af9da7331365d273c973de7/server/consumer.go#L102

Rename all `rate_limit` consumer fields to `rate_limit_bps`.