### PR TITLE
Add local_address option to bind client to a specific local IP

### DIFF
--- a/async-nats/examples/local_address.rs
+++ b/async-nats/examples/local_address.rs
@@ -1,0 +1,55 @@
+// Copyright 2020-2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Demonstrates connecting to a NATS server while binding the client socket
+/// to a specific local address. This is useful on machines with multiple
+/// network interfaces when you need to control which one is used, or when
+/// you need to bind to a specific local port.
+///
+/// Usage:
+///   cargo run --example local_address -- <local_addr> [nats_url]
+///
+/// Examples:
+///   cargo run --example local_address -- 127.0.0.1:0
+///   cargo run --example local_address -- 127.0.0.1:9898 nats://localhost:4222
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), async_nats::Error> {
+    let local_addr: std::net::SocketAddr = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:0".to_string())
+        .parse()
+        .expect("invalid socket address, expected format: IP:PORT (e.g. 127.0.0.1:0)");
+
+    let nats_url = env::args()
+        .nth(2)
+        .unwrap_or_else(|| "nats://localhost:4222".to_string());
+
+    println!("Connecting to {nats_url} using local address {local_addr}");
+
+    let client = async_nats::ConnectOptions::new()
+        .local_address(local_addr)
+        .connect(&nats_url)
+        .await?;
+
+    // Publish a test message to verify the connection works.
+    client
+        .publish("local_address.test", "Hello from bound address!".into())
+        .await?;
+    client.flush().await?;
+
+    println!("Published a message successfully from {local_addr}");
+
+    Ok(())
+}

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -48,7 +48,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::net::TcpStream;
+use tokio::net::{TcpSocket, TcpStream};
 use tokio::time::sleep;
 use tokio_rustls::rustls;
 
@@ -69,6 +69,7 @@ pub(crate) struct ConnectorOptions {
     pub(crate) reconnect_delay_callback: Box<dyn Fn(usize) -> Duration + Send + Sync + 'static>,
     pub(crate) auth_callback: Option<CallbackArg1<Vec<u8>, Result<Auth, AuthError>>>,
     pub(crate) max_reconnects: Option<usize>,
+    pub(crate) local_address: Option<SocketAddr>,
 }
 
 /// Maintains a list of servers and establishes connections.
@@ -427,12 +428,29 @@ impl Connector {
                 Connection::new(Box::new(con), 0, self.connect_stats.clone())
             }
             _ => {
-                let tcp_stream = tokio::time::timeout(
-                    self.options.connection_timeout,
-                    TcpStream::connect(socket_addr),
-                )
-                .await
-                .map_err(|_| ConnectError::new(crate::ConnectErrorKind::TimedOut))??;
+                let tcp_stream = if let Some(local_addr) = self.options.local_address {
+                    let socket = if local_addr.is_ipv4() {
+                        TcpSocket::new_v4()?
+                    } else {
+                        TcpSocket::new_v6()?
+                    };
+                    socket.bind(local_addr).map_err(|err| {
+                        ConnectError::with_source(crate::ConnectErrorKind::Io, err)
+                    })?;
+                    tokio::time::timeout(
+                        self.options.connection_timeout,
+                        socket.connect(*socket_addr),
+                    )
+                    .await
+                    .map_err(|_| ConnectError::new(crate::ConnectErrorKind::TimedOut))??
+                } else {
+                    tokio::time::timeout(
+                        self.options.connection_timeout,
+                        TcpStream::connect(socket_addr),
+                    )
+                    .await
+                    .map_err(|_| ConnectError::new(crate::ConnectErrorKind::TimedOut))??
+                };
                 tcp_stream.set_nodelay(true)?;
 
                 Connection::new(

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1035,6 +1035,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
             reconnect_delay_callback: options.reconnect_delay_callback,
             auth_callback: options.auth_callback,
             max_reconnects: options.max_reconnects,
+            local_address: options.local_address,
         },
         events_tx,
         state_tx,

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -20,6 +20,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::engine::Engine;
 use futures_util::Future;
 use std::fmt::Formatter;
+use std::net::SocketAddr;
 use std::{fmt, path::PathBuf, pin::Pin, time::Duration};
 #[cfg(feature = "nkeys")]
 use std::{path::Path, sync::Arc};
@@ -64,6 +65,7 @@ pub struct ConnectOptions {
     pub(crate) read_buffer_capacity: u16,
     pub(crate) reconnect_delay_callback: Box<dyn Fn(usize) -> Duration + Send + Sync + 'static>,
     pub(crate) auth_callback: Option<CallbackArg1<Vec<u8>, Result<Auth, AuthError>>>,
+    pub(crate) local_address: Option<SocketAddr>,
 }
 
 impl fmt::Debug for ConnectOptions {
@@ -116,6 +118,7 @@ impl Default for ConnectOptions {
             }),
             auth: Default::default(),
             auth_callback: None,
+            local_address: None,
         }
     }
 }
@@ -922,6 +925,38 @@ impl ConnectOptions {
     /// ```
     pub fn read_buffer_capacity(mut self, size: u16) -> ConnectOptions {
         self.read_buffer_capacity = size;
+        self
+    }
+
+    /// Sets the local socket address that the client will bind to when connecting
+    /// to the server. This is useful when the client machine has multiple
+    /// network interfaces and you want to control which one is used, or when
+    /// you need to bind to a specific local port.
+    ///
+    /// Use port `0` to let the operating system assign an ephemeral port.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), async_nats::ConnectError> {
+    /// // Bind to a specific IP with an OS-assigned port
+    /// let addr: std::net::SocketAddr = "192.168.1.10:0".parse().unwrap();
+    /// async_nats::ConnectOptions::new()
+    ///     .local_address(addr)
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    ///
+    /// // Bind to a specific IP and port
+    /// let addr: std::net::SocketAddr = "192.168.1.10:9898".parse().unwrap();
+    /// async_nats::ConnectOptions::new()
+    ///     .local_address(addr)
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn local_address(mut self, address: SocketAddr) -> ConnectOptions {
+        self.local_address = Some(address);
         self
     }
 }

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -1206,4 +1206,37 @@ mod client {
             elapsed
         );
     }
+
+    #[tokio::test]
+    async fn local_address() {
+        let server = nats_server::run_basic_server();
+
+        let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let client = ConnectOptions::new()
+            .local_address(addr)
+            .connect(server.client_url())
+            .await
+            .unwrap();
+
+        client.publish("test", "data".into()).await.unwrap();
+        client.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_address_with_port() {
+        let server = nats_server::run_basic_server();
+
+        let addr: std::net::SocketAddr = "127.0.0.1:19898".parse().unwrap();
+        let client = ConnectOptions::new()
+            .local_address(addr)
+            .connect(server.client_url())
+            .await
+            .unwrap();
+
+        client.publish("test", "data".into()).await.unwrap();
+        client.flush().await.unwrap();
+
+        // Connection succeeded, meaning the bind to port 19898 worked.
+        // If the port was already in use or bind failed, connect would have errored.
+    }
 }


### PR DESCRIPTION
Adds ConnectOptions::local_address() to allow specifying the local IP address the client binds to when connecting to the NATS server. This is useful when the client machine has multiple network interfaces and you need to control which one is used for outgoing connections.

The implementation uses tokio::net::TcpSocket to create the socket, optionally bind it to the configured local address (with port 0 for OS-assigned ephemeral port), and then connect to the server.