### PR TITLE
use proper doc comments

### DIFF
--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -637,16 +637,16 @@ pub struct OrderedConfig {
     #[serde(default, skip_serializing_if = "is_default")]
     pub metadata: HashMap<String, String>,
     /// Maximum number of messages that can be requested in single Pull Request.
-    /// This is used explicitly by [batch] and [fetch], but also, under the hood, by [messages] and
-    /// [stream]
+    /// This is used explicitly by [Consumer::batch] and [Consumer::fetch], but also, under the hood, by [Consumer::messages] and
+    /// [Consumer::stream]
     pub max_batch: i64,
     /// Maximum number of bytes that can be requested in single Pull Request.
-    /// This is used explicitly by [batch] and [fetch], but also, under the hood, by [messages] and
-    /// [stream]
+    /// This is used explicitly by [Consumer::batch] and [Consumer::fetch], but also, under the hood, by [Consumer::messages] and
+    /// [Consumer::stream]
     pub max_bytes: i64,
     /// Maximum expiry that can be set for a single Pull Request.
-    /// This is used explicitly by [batch] and [fetch], but also, under the hood, by [messages] and
-    /// [stream]
+    /// This is used explicitly by [Consumer::batch] and [Consumer::fetch], but also, under the hood, by [Consumer::messages] and
+    /// [Consumer::stream]
     pub max_expires: Duration,
 }
 

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -270,7 +270,7 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "is_default")]
     pub memory_storage: bool,
     #[cfg(feature = "server_2_10")]
-    // Additional consumer metadata.
+    /// Additional consumer metadata.
     #[serde(default, skip_serializing_if = "is_default")]
     pub metadata: HashMap<String, String>,
     /// Custom backoff for missed acknowledgments.
@@ -424,7 +424,7 @@ pub struct OrderedConfig {
     #[serde(default, skip_serializing_if = "is_default")]
     pub max_waiting: i64,
     #[cfg(feature = "server_2_10")]
-    // Additional consumer metadata.
+    /// Additional consumer metadata.
     #[serde(default, skip_serializing_if = "is_default")]
     pub metadata: HashMap<String, String>,
 }


### PR DESCRIPTION
Some fields were documented using standard comments. This is almost certainly not intended.