### PR TITLE
Deprecate old client

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,14 @@ stable, yet versioned <1.0.0, like `rustls`, which might introduce breaking chan
 
 Feature flags are Documented in `Cargo.toml` and can be viewed [here](https://docs.rs/crate/async-nats/latest/source/Cargo.toml.orig).
 
-### nats
+### nats (deprecated)
+
+> **Deprecated:** Use [`async-nats`](https://crates.io/crates/async-nats) instead.
+> This crate only receives critical security fixes.
 
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Crates.io](https://img.shields.io/crates/v/nats.svg)](https://crates.io/crates/nats)
 [![Documentation](https://docs.rs/nats/badge.svg)](https://docs.rs/nats/)
-[![Build Status](https://github.com/nats-io/nats.rs/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/nats-io/nats.rs/actions)
-
-Legacy *synchronous* client that supports:
-
-* Core NATS
-* JetStream API
-* JetStream Management API
-* Key Value Store
-* Object Store
-
-This client does not get updates, unless those are security fixes.
-Please use the new `async-nats` crate.
 
 ### Documentation
 

--- a/nats/CHANGELOG.md
+++ b/nats/CHANGELOG.md
@@ -1,3 +1,6 @@
+> **Note:** This crate is deprecated. Use [`async-nats`](https://crates.io/crates/async-nats)
+> instead. Only critical security fixes will be applied going forward.
+
 # 0.25.0
 
 ## Overview

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nats"
 version = "0.25.0"
-description = "A Rust NATS client"
+description = "A Rust NATS client (deprecated — use async-nats instead)"
 authors = ["Derek Collison <derek@nats.io>", "Tyler Neely <tyler@nats.io>", "Stjepan Glavina <stjepan@nats.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ features = ["unstable"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [badges]
-maintenance = { status = "actively-developed" }
+maintenance = { status = "deprecated" }
 
 [dependencies]
 base64 = "0.13.0"

--- a/nats/README.md
+++ b/nats/README.md
@@ -1,3 +1,14 @@
+# DEPRECATED
+
+> **This crate is deprecated.** Use [`async-nats`](https://crates.io/crates/async-nats) instead.
+>
+> This crate will only receive critical security fixes. No new features or bug fixes will be added.
+>
+> If you need to use the async client in a synchronous context, see the
+> [`async-nats` examples](https://github.com/nats-io/nats.rs/tree/main/async-nats/examples).
+
+---
+
 <p align="center">
   <img src="logo/logo.svg">
 </p>
@@ -10,16 +21,6 @@
 
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Crates.io](https://img.shields.io/crates/v/nats.svg)](https://crates.io/crates/nats)
-[![Documentation](https://docs.rs/nats/badge.svg)](https://docs.rs/nats/)
-[![Build Status](https://github.com/nats-io/nats.rs/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/nats-io/nats.rs/actions)
-
-## :warning: Legacy Notice
-
-This is the old legacy client. It will not get new features or updates beyond critical security fixes.
-
-Use [async nats](https://crates.io/crates/async-nats) instead.
-
-If you would like to use the async client in sync context, check the [async-nats examples](https://github.com/nats-io/nats.rs/tree/main/async-nats/examples).
 
 ## Motivation
 

--- a/nats/src/lib.rs
+++ b/nats/src/lib.rs
@@ -13,8 +13,18 @@
 
 //! A Rust client for the NATS.io ecosystem.
 //!
-//! <div class="warning"> This is the old legacy client. It will not get new features or updates beyond critical security fixes.
-//! Use <a href="https://crates.io/crates/async-nats">async-nats</a> instead. </div>
+//! # Deprecated
+//!
+//! <div class="warning">
+//! <strong>This crate is deprecated.</strong> Use
+//! <a href="https://crates.io/crates/async-nats">async-nats</a> instead.
+//!
+//! This crate will only receive critical security fixes. No new features or bug fixes will be
+//! added.
+//!
+//! If you need to use the async client in a synchronous context, see the
+//! <a href="https://github.com/nats-io/nats.rs/tree/main/async-nats/examples">async-nats examples</a>.
+//! </div>
 //!
 //! `git clone https://github.com/nats-io/nats.rs`
 //!
@@ -193,6 +203,7 @@
 // As this is a deprecated client, we don't want warnings from new lints to make CI red.
 #![allow(clippy::all)]
 #![allow(warnings)]
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 /// Async-enabled NATS client.
 pub mod asynk;
 
@@ -206,15 +217,19 @@ mod proto;
 mod secure_wipe;
 mod subscription;
 
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 /// Header constants and types.
 pub mod header;
 
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 /// `JetStream` stream management and consumers.
 pub mod jetstream;
 
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub mod kv;
 
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub mod object_store;
 
@@ -245,6 +260,7 @@ pub type ConnectionOptions = Options;
 #[deprecated(since = "0.17.0", note = "this has been moved to `header::HeaderMap`.")]
 pub type Headers = HeaderMap;
 
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 pub use header::HeaderMap;
 
 use std::{
@@ -256,10 +272,15 @@ use std::{
 use lazy_static::lazy_static;
 use regex::Regex;
 
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 pub use connector::{IntoServerList, ServerAddress};
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 pub use jetstream::JetStreamOptions;
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 pub use message::Message;
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 pub use options::Options;
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 pub use subscription::{Handler, Subscription};
 
 /// A re-export of the `rustls` crate used in this crate,
@@ -268,6 +289,7 @@ pub use subscription::{Handler, Subscription};
 pub use rustls;
 
 #[doc(hidden)]
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 pub use connect::ConnectInfo;
 
 use client::Client;
@@ -284,6 +306,7 @@ lazy_static! {
 
 /// Information sent by the server back to this client
 /// during initial connection, and possibly again later.
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 #[allow(unused)]
 #[derive(Debug, Default, Clone)]
 pub struct ServerInfo {
@@ -350,6 +373,7 @@ impl ServerInfo {
 }
 
 /// A NATS connection.
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 #[derive(Clone, Debug)]
 pub struct Connection(pub(crate) Arc<Inner>);
 
@@ -365,6 +389,10 @@ impl Drop for Inner {
 }
 
 /// Connect to one or more NATS servers at the given URLs.
+///
+/// # Deprecated
+///
+/// This crate is deprecated. Use [`async-nats`](https://crates.io/crates/async-nats) instead.
 ///
 /// The [`IntoServerList`] trait allows to pass URLs in various different formats. Furthermore, if
 /// you need more control of the connection's parameters use [`Options::connect()`].
@@ -412,6 +440,7 @@ impl Drop for Inner {
 ///     Ok(())
 /// }
 /// ```
+#[deprecated(since = "0.25.0", note = "use the async-nats crate instead")]
 pub fn connect<I: IntoServerList>(nats_urls: I) -> io::Result<Connection> {
     Options::new().connect(nats_urls)
 }


### PR DESCRIPTION
This PR clearly sets old client as deprecated.

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>