### PR TITLE
Update rustls-webpki to 0.103.10

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -39,7 +39,7 @@ base64 = { version = "0.22", optional = true }
 tryhard = { version = "0.5", optional = true }
 ring = { version = "0.17", optional = true }
 rand = "0.8"
-rustls-webpki = { package = "rustls-webpki", default-features = false, version = "0.102" }
+rustls-webpki = { package = "rustls-webpki", default-features = false, version = "0.103.10" }
 portable-atomic = "1"
 tokio-websockets = { version = "0.10", default-features = false, features = ["client", "rand", "rustls-webpki-roots"], optional = true }
 pin-project = "1.0"
@@ -68,7 +68,7 @@ object-store = ["jetstream", "crypto"]
 service = ["dep:time", "dep:serde_nanos"]
 crypto = []
 websockets = ["dep:tokio-websockets"]
-aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets?/aws-lc-rs", "rustls-webpki/aws_lc_rs"]
+aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets?/aws-lc-rs", "rustls-webpki/aws-lc-rs"]
 ring = ["dep:ring", "tokio-rustls/ring", "tokio-websockets?/ring"]
 fips = ["aws-lc-rs", "tokio-rustls/fips"]
 nkeys = ["dep:nkeys", "dep:base64"]

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -470,7 +470,7 @@ impl Connector {
             );
             let tls_connector = tokio_rustls::TlsConnector::from(tls_config);
 
-            let domain = rustls_webpki::types::ServerName::try_from(server_addr.host())
+            let domain = crate::rustls::pki_types::ServerName::try_from(server_addr.host())
                 .map_err(|err| ConnectError::with_source(crate::ConnectErrorKind::Tls, err))?;
 
             let tls_stream = tls_connector

--- a/async-nats/src/tls.rs
+++ b/async-nats/src/tls.rs
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 use crate::connector::ConnectorOptions;
+use crate::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use crate::tls;
 use rustls_pki_types::pem::PemObject;
-use rustls_webpki::types::{CertificateDer, PrivateKeyDer};
 use std::io::{self, BufReader, ErrorKind};
 use std::path::PathBuf;
 use tokio_rustls::rustls::{ClientConfig, RootCertStore};


### PR DESCRIPTION
Currently, cargo audit flags a vulnerability in rustls-webpki and suggests updating to version >=0.103.10.

Let's update to a version that doesn't trigger a flag. This requires a couple small changes to import resolution due to breaking changes in v0.103.0.

See https://rustsec.org/advisories/RUSTSEC-2026-0049 for more details on the vulnerability in question.

Fixes #1549.