### PR TITLE
Add Client::rtt for async-nats

### DIFF
--- a/.config/nats.dic
+++ b/.config/nats.dic
@@ -207,3 +207,5 @@ LF
 nats
 WebSocket
 rng
+rtt
+RTT

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -799,6 +799,35 @@ impl Client {
         Ok(())
     }
 
+    /// Calculates the round trip time between this client and the server by sending a PING and
+    /// waiting for a PONG response.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), async_nats::Error> {
+    /// let client = async_nats::connect("demo.nats.io").await?;
+    /// let rtt = client.rtt().await?;
+    /// println!("server rtt: {:?}", rtt);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn rtt(&self) -> Result<std::time::Duration, RttError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let start = std::time::Instant::now();
+
+        self.sender
+            .send(Command::Rtt { sender: tx })
+            .await
+            .map_err(|e| RttError::with_source(RttErrorKind::SendError, e))?;
+
+        rx.await
+            .map_err(|e| RttError::with_source(RttErrorKind::RecvError, e))?;
+
+        Ok(start.elapsed())
+    }
+
     /// Drains all subscriptions, stops any new messages from being published, and flushes any remaining
     /// messages, then closes the connection. Once completed, any streams associated with the
     /// connection and its [Clients](crate::Client) will be closed, and further [crate::Client] commands will fail.
@@ -1234,6 +1263,25 @@ impl Display for FlushErrorKind {
 }
 
 pub type FlushError = Error<FlushErrorKind>;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum RttErrorKind {
+    /// Failed to send the RTT Command to the handler
+    SendError,
+    /// Failed to receive the rtt
+    RecvError,
+}
+
+impl Display for RttErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SendError => write!(f, "failed to send ping request"),
+            Self::RecvError => write!(f, "failed to get rtt"),
+        }
+    }
+}
+
+pub type RttError = Error<RttErrorKind>;
 
 /// Represents statistics for the instance of the client throughout its lifecycle.
 #[derive(Default, Debug)]

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -397,6 +397,9 @@ pub(crate) enum Command {
     Flush {
         observer: oneshot::Sender<()>,
     },
+    Rtt {
+        sender: oneshot::Sender<()>,
+    },
     Drain {
         sid: Option<u64>,
     },
@@ -455,7 +458,8 @@ pub(crate) struct ConnectionHandler {
     connector: Connector,
     subscriptions: HashMap<u64, Subscription>,
     multiplexer: Option<Multiplexer>,
-    pending_pings: usize,
+    pings_out: usize,
+    pong_waiters: VecDeque<Option<oneshot::Sender<()>>>,
     info_sender: tokio::sync::watch::Sender<ServerInfo>,
     ping_interval: Interval,
     should_reconnect: bool,
@@ -479,7 +483,8 @@ impl ConnectionHandler {
             connector,
             subscriptions: HashMap::new(),
             multiplexer: None,
-            pending_pings: 0,
+            pings_out: 0,
+            pong_waiters: VecDeque::new(),
             info_sender,
             ping_interval,
             should_reconnect: false,
@@ -507,11 +512,11 @@ impl ConnectionHandler {
 
             #[cold]
             fn ping(&mut self) -> Poll<ExitReason> {
-                self.handler.pending_pings += 1;
+                self.handler.pings_out += 1;
 
-                if self.handler.pending_pings > MAX_PENDING_PINGS {
+                if self.handler.pings_out > MAX_PENDING_PINGS {
                     debug!(
-                        pending_pings = self.handler.pending_pings,
+                        pings_out = self.handler.pings_out,
                         max_pings = MAX_PENDING_PINGS,
                         "disconnecting due to too many pending pings"
                     );
@@ -519,6 +524,7 @@ impl ConnectionHandler {
                     Poll::Ready(ExitReason::Disconnected(None))
                 } else {
                     self.handler.connection.enqueue_write_op(&ClientOp::Ping);
+                    self.handler.pong_waiters.push_back(None);
 
                     Poll::Pending
                 }
@@ -707,7 +713,10 @@ impl ConnectionHandler {
             }
             ServerOp::Pong => {
                 debug!("received PONG");
-                self.pending_pings = self.pending_pings.saturating_sub(1);
+                self.pings_out = 0;
+                if let Some(Some(sender)) = self.pong_waiters.pop_front() {
+                    let _ = sender.send(());
+                }
             }
             ServerOp::Error(error) => {
                 debug!("received ERROR: {:?}", error);
@@ -837,6 +846,10 @@ impl ConnectionHandler {
             Command::Flush { observer } => {
                 self.flush_observers.push(observer);
             }
+            Command::Rtt { sender } => {
+                self.connection.enqueue_write_op(&ClientOp::Ping);
+                self.pong_waiters.push_back(Some(sender));
+            }
             Command::Drain { sid } => {
                 let mut drain_sub = |sid: u64| {
                     self.drain_pings.push_back(sid);
@@ -857,6 +870,7 @@ impl ConnectionHandler {
                     }
                 }
                 self.connection.enqueue_write_op(&ClientOp::Ping);
+                self.pong_waiters.push_back(None);
             }
             Command::Subscribe {
                 sid,
@@ -973,7 +987,8 @@ impl ConnectionHandler {
     }
 
     async fn handle_disconnect(&mut self) -> Result<(), ConnectError> {
-        self.pending_pings = 0;
+        self.pings_out = 0;
+        self.pong_waiters.clear();
         self.connector.events_tx.try_send(Event::Disconnected).ok();
         self.connector.state_tx.send(State::Disconnected).ok();
 

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -1604,4 +1604,22 @@ mod client {
 
         handle.abort();
     }
+
+    #[tokio::test]
+    async fn rtt_concurrent() {
+        let server = nats_server::run_basic_server();
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+        let mut handles = Vec::new();
+
+        for _ in 0..5 {
+            let c = client.clone();
+            handles.push(tokio::spawn(async move { c.rtt().await.unwrap() }));
+        }
+        for handle in handles {
+            let duration = handle.await.unwrap();
+            println!("{:?}", duration);
+            assert!(duration > Duration::ZERO);
+            assert!(duration < Duration::from_secs(1));
+        }
+    }
 }


### PR DESCRIPTION
Implement Client::rtt() which measures the round trip time to the server by sending a PING and awaiting the corresponding PONG.

Closes #909

Implements Client::rtt() for async-nats. Each RTT request sends its own PING with a per-ping timestamp and oneshot sender stored in a VecDeque, replacing the previous usize pending_pings counter to correctly correlate PING/PONG pairs even with concurrent callers and interleaved keepalive pings.