### PR TITLE
Add `try_server_info` and `max_payload` methods

### DIFF
--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -77,7 +77,7 @@ impl Display for PublishErrorKind {
 /// [crate::connect] and [crate::ConnectOptions::connect]
 #[derive(Clone, Debug)]
 pub struct Client {
-    info: tokio::sync::watch::Receiver<ServerInfo>,
+    info: tokio::sync::watch::Receiver<Option<ServerInfo>>,
     pub(crate) state: tokio::sync::watch::Receiver<State>,
     pub(crate) sender: mpsc::Sender<Command>,
     poll_sender: PollSender<Command>,
@@ -217,7 +217,7 @@ impl Sink<OutboundMessage> for Client {
 impl Client {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        info: tokio::sync::watch::Receiver<ServerInfo>,
+        info: tokio::sync::watch::Receiver<Option<ServerInfo>>,
         state: tokio::sync::watch::Receiver<State>,
         sender: mpsc::Sender<Command>,
         capacity: usize,
@@ -286,7 +286,32 @@ impl Client {
         self.request_timeout
     }
 
-    /// Returns last received info from the server.
+    /// Returns the last received info from the server if one has been observed.
+    ///
+    /// This is useful when [`ConnectOptions::retry_on_initial_connect`][crate::ConnectOptions::retry_on_initial_connect]
+    /// is enabled and the client is returned before the first server `INFO`
+    /// message arrives.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main () -> Result<(), async_nats::Error> {
+    /// let client = async_nats::ConnectOptions::new()
+    ///     .retry_on_initial_connect()
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// println!("info available: {}", client.try_server_info().is_some());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_server_info(&self) -> Option<ServerInfo> {
+        // We ignore notifying the watcher, as that requires mutable client reference.
+        self.info.borrow().clone()
+    }
+
+    /// Returns the latest server info, or the client's initial default values
+    /// until the first server `INFO` message arrives.
     ///
     /// # Examples
     ///
@@ -299,8 +324,7 @@ impl Client {
     /// # }
     /// ```
     pub fn server_info(&self) -> ServerInfo {
-        // We ignore notifying the watcher, as that requires mutable client reference.
-        self.info.borrow().to_owned()
+        self.try_server_info().unwrap_or_else(ServerInfo::initial)
     }
 
     /// Returns true if the server version is compatible with the version components.

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -77,7 +77,7 @@ impl Display for PublishErrorKind {
 /// [crate::connect] and [crate::ConnectOptions::connect]
 #[derive(Clone, Debug)]
 pub struct Client {
-    info: tokio::sync::watch::Receiver<ServerInfo>,
+    info: tokio::sync::watch::Receiver<Option<ServerInfo>>,
     pub(crate) state: tokio::sync::watch::Receiver<State>,
     pub(crate) sender: mpsc::Sender<Command>,
     poll_sender: PollSender<Command>,
@@ -217,7 +217,7 @@ impl Sink<OutboundMessage> for Client {
 impl Client {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        info: tokio::sync::watch::Receiver<ServerInfo>,
+        info: tokio::sync::watch::Receiver<Option<ServerInfo>>,
         state: tokio::sync::watch::Receiver<State>,
         sender: mpsc::Sender<Command>,
         capacity: usize,
@@ -286,6 +286,30 @@ impl Client {
         self.request_timeout
     }
 
+    /// Returns the last received info from the server if one has been observed.
+    ///
+    /// This is useful when [`ConnectOptions::retry_on_initial_connect`][crate::ConnectOptions::retry_on_initial_connect]
+    /// is enabled and the client is returned before the first server `INFO`
+    /// message arrives.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main () -> Result<(), async_nats::Error> {
+    /// let client = async_nats::ConnectOptions::new()
+    ///     .retry_on_initial_connect()
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// println!("info available: {}", client.try_server_info().is_some());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_server_info(&self) -> Option<ServerInfo> {
+        // We ignore notifying the watcher, as that requires mutable client reference.
+        self.info.borrow().clone()
+    }
+
     /// Returns last received info from the server.
     ///
     /// # Examples
@@ -299,8 +323,26 @@ impl Client {
     /// # }
     /// ```
     pub fn server_info(&self) -> ServerInfo {
-        // We ignore notifying the watcher, as that requires mutable client reference.
-        self.info.borrow().to_owned()
+        self.try_server_info().unwrap_or_default()
+    }
+
+    /// Returns the maximum payload size currently used by the client.
+    ///
+    /// Before the first server `INFO` message arrives, this returns the default
+    /// server payload limit used for client-side publish validation.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main () -> Result<(), async_nats::Error> {
+    /// let client = async_nats::connect("demo.nats.io").await?;
+    /// println!("max payload: {:?}", client.max_payload());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn max_payload(&self) -> usize {
+        self.max_payload.load(Ordering::Relaxed)
     }
 
     /// Returns true if the server version is compatible with the version components.

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -199,7 +199,7 @@ impl Connector {
             state_tx,
             max_payload,
             connect_stats,
-            last_info: ServerInfo::default(),
+            last_info: ServerInfo::initial(),
         })
     }
 

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -234,6 +234,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const LANG: &str = "rust";
 const MAX_PENDING_PINGS: usize = 2;
 const MULTIPLEXER_SID: u64 = 0;
+pub(crate) const DEFAULT_SERVER_MAX_PAYLOAD: usize = 1024 * 1024;
 
 /// A re-export of the `rustls` crate used in this crate,
 /// for use in cases where manual client configurations
@@ -456,7 +457,7 @@ pub(crate) struct ConnectionHandler {
     subscriptions: HashMap<u64, Subscription>,
     multiplexer: Option<Multiplexer>,
     pending_pings: usize,
-    info_sender: tokio::sync::watch::Sender<ServerInfo>,
+    info_sender: tokio::sync::watch::Sender<Option<ServerInfo>>,
     ping_interval: Interval,
     should_reconnect: bool,
     flush_observers: Vec<oneshot::Sender<()>>,
@@ -468,7 +469,7 @@ impl ConnectionHandler {
     pub(crate) fn new(
         connection: Connection,
         connector: Connector,
-        info_sender: tokio::sync::watch::Sender<ServerInfo>,
+        info_sender: tokio::sync::watch::Sender<Option<ServerInfo>>,
         ping_period: Duration,
     ) -> ConnectionHandler {
         let mut ping_interval = interval(ping_period);
@@ -983,7 +984,7 @@ impl ConnectionHandler {
     async fn handle_reconnect(&mut self) -> Result<(), ConnectError> {
         let (info, connection) = self.connector.connect().await?;
         self.connection = connection;
-        let _ = self.info_sender.send(info);
+        let _ = self.info_sender.send(Some(info));
 
         self.subscriptions
             .retain(|_, subscription| !subscription.sender.is_closed());
@@ -1031,7 +1032,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
     let (events_tx, mut events_rx) = mpsc::channel(128);
     let (state_tx, state_rx) = tokio::sync::watch::channel(State::Pending);
     // We're setting it to the default server payload size.
-    let max_payload = Arc::new(AtomicUsize::new(1024 * 1024));
+    let max_payload = Arc::new(AtomicUsize::new(DEFAULT_SERVER_MAX_PAYLOAD));
     let statistics = Arc::new(Statistics::default());
 
     let mut connector = Connector::new(
@@ -1063,13 +1064,13 @@ pub async fn connect_with_options<A: ToServerAddrs>(
     )
     .map_err(|err| ConnectError::with_source(ConnectErrorKind::ServerParse, err))?;
 
-    let mut info: ServerInfo = Default::default();
+    let mut info = None;
     let mut connection = None;
     if !options.retry_on_initial_connect {
         debug!("retry on initial connect failure is disabled");
         let (info_ok, connection_ok) = connector.try_connect().await?;
         connection = Some(connection_ok);
-        info = info_ok;
+        info = Some(info_ok);
     }
 
     let (info_sender, info_watcher) = tokio::sync::watch::channel(info.clone());
@@ -1105,7 +1106,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
                     return;
                 }
             };
-            info_sender.send(info).ok();
+            info_sender.send(Some(info)).ok();
             connection = Some(connection_ok);
         }
         let connection = connection.unwrap();

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -345,6 +345,17 @@ pub struct ServerInfo {
     pub jetstream: bool,
 }
 
+pub(crate) const DEFAULT_SERVER_MAX_PAYLOAD: usize = 1024 * 1024;
+
+impl ServerInfo {
+    pub(crate) fn initial() -> Self {
+        Self {
+            max_payload: DEFAULT_SERVER_MAX_PAYLOAD,
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ServerOp {
     Ok,
@@ -456,7 +467,7 @@ pub(crate) struct ConnectionHandler {
     subscriptions: HashMap<u64, Subscription>,
     multiplexer: Option<Multiplexer>,
     pending_pings: usize,
-    info_sender: tokio::sync::watch::Sender<ServerInfo>,
+    info_sender: tokio::sync::watch::Sender<Option<ServerInfo>>,
     ping_interval: Interval,
     should_reconnect: bool,
     flush_observers: Vec<oneshot::Sender<()>>,
@@ -468,7 +479,7 @@ impl ConnectionHandler {
     pub(crate) fn new(
         connection: Connection,
         connector: Connector,
-        info_sender: tokio::sync::watch::Sender<ServerInfo>,
+        info_sender: tokio::sync::watch::Sender<Option<ServerInfo>>,
         ping_period: Duration,
     ) -> ConnectionHandler {
         let mut ping_interval = interval(ping_period);
@@ -983,7 +994,7 @@ impl ConnectionHandler {
     async fn handle_reconnect(&mut self) -> Result<(), ConnectError> {
         let (info, connection) = self.connector.connect().await?;
         self.connection = connection;
-        let _ = self.info_sender.send(info);
+        let _ = self.info_sender.send(Some(info));
 
         self.subscriptions
             .retain(|_, subscription| !subscription.sender.is_closed());
@@ -1031,7 +1042,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
     let (events_tx, mut events_rx) = mpsc::channel(128);
     let (state_tx, state_rx) = tokio::sync::watch::channel(State::Pending);
     // We're setting it to the default server payload size.
-    let max_payload = Arc::new(AtomicUsize::new(1024 * 1024));
+    let max_payload = Arc::new(AtomicUsize::new(DEFAULT_SERVER_MAX_PAYLOAD));
     let statistics = Arc::new(Statistics::default());
 
     let mut connector = Connector::new(
@@ -1063,13 +1074,13 @@ pub async fn connect_with_options<A: ToServerAddrs>(
     )
     .map_err(|err| ConnectError::with_source(ConnectErrorKind::ServerParse, err))?;
 
-    let mut info: ServerInfo = Default::default();
+    let mut info = None;
     let mut connection = None;
     if !options.retry_on_initial_connect {
         debug!("retry on initial connect failure is disabled");
         let (info_ok, connection_ok) = connector.try_connect().await?;
         connection = Some(connection_ok);
-        info = info_ok;
+        info = Some(info_ok);
     }
 
     let (info_sender, info_watcher) = tokio::sync::watch::channel(info.clone());
@@ -1105,7 +1116,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
                     return;
                 }
             };
-            info_sender.send(info).ok();
+            info_sender.send(Some(info)).ok();
             connection = Some(connection_ok);
         }
         let connection = connection.unwrap();

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -798,11 +798,27 @@ mod client {
             .await
             .unwrap();
 
+        assert!(
+            client.try_server_info().is_none(),
+            "server info should not be available before the first INFO frame"
+        );
+        assert_eq!(
+            client.server_info().max_payload,
+            1024 * 1024,
+            "compatibility fallback should match the default server payload limit"
+        );
+
         let mut sub = client.subscribe("DATA").await.unwrap();
         client.publish("DATA", "payload".into()).await.unwrap();
         tokio::time::sleep(Duration::from_secs(2)).await;
         let _server = nats_server::run_server_with_port("", Some("7779"));
         sub.next().await.unwrap();
+
+        let info = client
+            .try_server_info()
+            .expect("server info should be available after connecting");
+        assert_eq!(info.port, 7779);
+        assert_eq!(client.server_info(), info);
     }
 
     #[tokio::test]

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -798,11 +798,32 @@ mod client {
             .await
             .unwrap();
 
+        assert!(
+            client.try_server_info().is_none(),
+            "server info should not be available before the first INFO frame"
+        );
+        assert_eq!(
+            client.server_info(),
+            async_nats::ServerInfo::default(),
+            "server_info should preserve the original fallback state"
+        );
+        assert_eq!(
+            client.max_payload(),
+            1024 * 1024,
+            "current max payload should use the default server payload limit"
+        );
+
         let mut sub = client.subscribe("DATA").await.unwrap();
         client.publish("DATA", "payload".into()).await.unwrap();
         tokio::time::sleep(Duration::from_secs(2)).await;
         let _server = nats_server::run_server_with_port("", Some("7779"));
         sub.next().await.unwrap();
+
+        let info = client
+            .try_server_info()
+            .expect("server info should be available after connecting");
+        assert_eq!(info.port, 7779);
+        assert_eq!(client.server_info(), info);
     }
 
     #[tokio::test]
@@ -944,6 +965,8 @@ mod client {
         let server = nats_server::run_server("tests/configs/max_payload.conf");
 
         let client = async_nats::connect(server.client_url()).await.unwrap();
+
+        assert_eq!(client.max_payload(), 1024 * 128);
 
         // this exceeds the small payload limit in server config.
         let payload = vec![0u8; 1024 * 1024];


### PR DESCRIPTION
- retry_on_initial_connect can expose placeholder ServerInfo values before the first INFO frame arrives, which makes downstream clients treat max_payload as zero.
- callers need a way to distinguish between real server metadata and the pre-connect placeholder state without forcing a breaking API change.
- aligning the compatibility fallback with the existing 1 MiB internal default removes the current footgun while preserving existing callers.