### PR TITLE
Remove needless async for service functions that don't require it

### DIFF
--- a/async-nats/src/service/mod.rs
+++ b/async-nats/src/service/mod.rs
@@ -453,14 +453,14 @@ impl Service {
     /// If there are more instances of [Services][Service] with the same name, the [Service] will
     /// be scaled down by one instance. If it was the only running instance, it will effectively
     /// remove the service entirely.
-    pub async fn stop(self) -> Result<(), Error> {
+    pub fn stop(self) -> Result<(), Error> {
         self.shutdown_tx.send(())?;
         self.handle.abort();
         Ok(())
     }
 
     /// Resets [Stats] of the [Service] instance.
-    pub async fn reset(&mut self) {
+    pub fn reset(&mut self) {
         for value in self.endpoints_state.lock().unwrap().endpoints.values_mut() {
             value.errors = 0;
             value.processing_time = Duration::default();
@@ -470,7 +470,7 @@ impl Service {
     }
 
     /// Returns [Stats] for this service instance.
-    pub async fn stats(&self) -> HashMap<String, endpoint::Stats> {
+    pub fn stats(&self) -> HashMap<String, endpoint::Stats> {
         self.endpoints_state
             .lock()
             .unwrap()
@@ -481,7 +481,7 @@ impl Service {
     }
 
     /// Returns [Info] for this service instance.
-    pub async fn info(&self) -> Info {
+    pub fn info(&self) -> Info {
         self.info.clone()
     }
 

--- a/async-nats/tests/compatibility.rs
+++ b/async-nats/tests/compatibility.rs
@@ -539,7 +539,7 @@ mod compatibility {
             .unwrap();
 
         let cleanup = tests.next().await.expect("failed to get cleanup");
-        service.stop().await.expect("failed to stop service");
+        service.stop().expect("failed to stop service");
         client
             .publish(cleanup.reply.unwrap(), "".into())
             .await

--- a/async-nats/tests/service_tests.rs
+++ b/async-nats/tests/service_tests.rs
@@ -283,13 +283,12 @@ mod service {
 
         assert!(service
             .stats()
-            .await
             .get("products")
             .unwrap()
             .last_error
             .is_some());
 
-        service.stop().await.unwrap();
+        service.stop().unwrap();
 
         assert!(response.next().await.is_some());
         assert!(response.next().await.is_some());
@@ -392,7 +391,7 @@ mod service {
             }
         });
         // Check the stats.
-        let standard_service_stats = standard_service.stats().await;
+        let standard_service_stats = standard_service.stats();
         assert_eq!(
             standard_service_stats
                 .get("group.grouped")
@@ -400,7 +399,7 @@ mod service {
                 .queue_group,
             "group_custom"
         );
-        let custom_service_stats = service_with_custom_queue.stats().await;
+        let custom_service_stats = service_with_custom_queue.stats();
         assert_eq!(
             custom_service_stats
                 .get("group.grouped")
@@ -586,7 +585,7 @@ mod service {
 
         let mut endpoint = service.endpoint("products").await.unwrap();
 
-        service.stop().await.unwrap();
+        service.stop().unwrap();
         client.publish("products", "data".into()).await.unwrap();
         assert!(endpoint.next().await.is_none());
     }


### PR DESCRIPTION
These functions are actually fine as blocking.