### PR TITLE
Bump to thiserror v2

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -34,7 +34,7 @@ serde_nanos = { version = "0.1.3", optional = true }
 time = { version = "0.3.36", features = ["parsing", "formatting", "serde", "serde-well-known"], optional = true }
 rustls-native-certs = "0.8"
 tracing = "0.1"
-thiserror = "1.0"
+thiserror = "2.0"
 base64 = { version = "0.22", optional = true }
 tryhard = { version = "0.5", optional = true }
 ring = { version = "0.17", optional = true }


### PR DESCRIPTION
Straightforward dependency upgrade. Eliminates the duplicate dependency in downstream projects.