### PR TITLE
Update tokio-websockets, reqwest and jsonschema to the latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,7 +261,7 @@ jobs:
 
       - name: Install msrv Rust on ubuntu-latest
         id:   install-rust
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.89.0
       - name: Cache the build artifacts
         uses: Swatinem/rust-cache@v2
         with:

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
 version = "0.49.0"
 edition = "2021"
-rust-version = "1.88.0"
+rust-version = "1.89.0"
 description = "A async Rust NATS client"
 license = "Apache-2.0"
 documentation = "https://docs.rs/async-nats"
@@ -41,7 +41,7 @@ ring = { version = "0.17", optional = true }
 rand = "0.10.1"
 rustls-webpki = { package = "rustls-webpki", default-features = false, version = "0.103.10" }
 portable-atomic = "1"
-tokio-websockets = { version = "0.10", default-features = false, features = ["client", "rand", "rustls-webpki-roots"], optional = true }
+tokio-websockets = { version = "0.13", default-features = false, features = ["client", "rand", "rustls-webpki-roots"], optional = true }
 pin-project = "1.0"
 
 [dev-dependencies]
@@ -53,8 +53,8 @@ tokio = { version = "1.25.0", features = ["rt-multi-thread"] }
 futures = { version = "0.3.28", default-features = false, features = ["std", "async-await"] }
 tracing-subscriber = "0.3"
 async-nats = {path = ".", features = ["service", "server_2_10"], default-features = false}
-reqwest = "0.11.18"
-jsonschema = "0.17.1"
+reqwest = { version = "0.13.3", features = ["json", "rustls-no-provider"], default-features = false }
+jsonschema = { version = "0.46.5", default-features = false }
 chrono = "0.4.44"
 
 # for -Z minimal-versions
@@ -69,7 +69,7 @@ object-store = ["jetstream", "crypto"]
 service = ["dep:time", "dep:serde_nanos"]
 crypto = []
 websockets = ["dep:tokio-websockets"]
-aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets?/aws-lc-rs", "rustls-webpki/aws-lc-rs"]
+aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets?/aws_lc_rs", "rustls-webpki/aws-lc-rs"]
 ring = ["dep:ring", "tokio-rustls/ring", "tokio-websockets?/ring"]
 fips = ["aws-lc-rs", "tokio-rustls/fips"]
 nkeys = ["dep:nkeys", "dep:base64"]

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -15,6 +15,7 @@ mod client {
     use async_nats::client::Request;
     use async_nats::connection::State;
     use async_nats::header::HeaderValue;
+    use async_nats::rustls;
     use async_nats::{
         ConnectErrorKind, ConnectOptions, Event, RequestErrorKind, ServerAddr, Subject,
     };
@@ -546,6 +547,7 @@ mod client {
 
     #[tokio::test]
     async fn connect_invalid_tls_over_ip() {
+        rustls::crypto::ring::default_provider().install_default().unwrap();
         let server = nats_server::run_basic_server();
         assert!(async_nats::ConnectOptions::new()
             .require_tls(true)

--- a/async-nats/tests/service_tests.rs
+++ b/async-nats/tests/service_tests.rs
@@ -16,7 +16,7 @@ mod service {
     use async_nats::client::PublishErrorKind;
     use async_nats::service::{self, Info, ServiceExt, Stats};
     use futures_util::StreamExt;
-    use jsonschema::JSONSchema;
+    use jsonschema::Validator as JSONSchema;
     use std::error::Error;
     use std::fmt::Display;
     use std::{collections::HashMap, str::from_utf8};
@@ -558,12 +558,10 @@ mod service {
                 .await
                 .unwrap();
 
-            match JSONSchema::compile(&schema).unwrap().validate(&data) {
+            match JSONSchema::new(&schema).unwrap().validate(&data) {
                 Ok(_) => (),
-                Err(mut errs) => {
-                    if let Some(err) = errs.next() {
-                        panic!("schema {endpoint} validation error: {err}")
-                    }
+                Err(err) => {
+                    panic!("schema {endpoint} validation error: {err}")
                 }
             };
         }

--- a/async-nats/tests/service_tests.rs
+++ b/async-nats/tests/service_tests.rs
@@ -15,6 +15,7 @@
 mod service {
     use async_nats::client::PublishErrorKind;
     use async_nats::service::{self, Info, ServiceExt, Stats};
+    use async_nats::rustls;
     use futures_util::StreamExt;
     use jsonschema::Validator as JSONSchema;
     use std::error::Error;
@@ -515,6 +516,8 @@ mod service {
 
     #[tokio::test]
     async fn schemas() {
+        rustls::crypto::ring::default_provider().install_default().unwrap();
+
         let server = nats_server::run_basic_server();
         let client = async_nats::connect(server.client_url()).await.unwrap();
 


### PR DESCRIPTION
Updated:
- tokio-websockets to 0.13.x
- reqwest to 0.13.x
- jsonschema to 0.46
