### PR TITLE
feat(client): expose websocket headers via ConnectOptions

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -42,6 +42,7 @@ rand = "0.10.1"
 rustls-webpki = { package = "rustls-webpki", default-features = false, version = "0.103.10" }
 portable-atomic = "1"
 tokio-websockets = { version = "0.10", default-features = false, features = ["client", "rand", "rustls-webpki-roots"], optional = true }
+http = { version = "1", default-features = false, features = ["std"], optional = true }
 pin-project = "1.0"
 
 [dev-dependencies]
@@ -68,7 +69,7 @@ kv = ["jetstream"]
 object-store = ["jetstream", "crypto"]
 service = ["dep:time", "dep:serde_nanos"]
 crypto = []
-websockets = ["dep:tokio-websockets"]
+websockets = ["dep:tokio-websockets", "dep:http"]
 aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets?/aws-lc-rs", "rustls-webpki/aws-lc-rs"]
 ring = ["dep:ring", "tokio-rustls/ring", "tokio-websockets?/ring"]
 fips = ["aws-lc-rs", "tokio-rustls/fips"]

--- a/async-nats/src/connector.rs
+++ b/async-nats/src/connector.rs
@@ -154,6 +154,8 @@ pub(crate) struct ConnectorOptions {
     pub(crate) max_reconnects: Option<usize>,
     pub(crate) local_address: Option<SocketAddr>,
     pub(crate) reconnect_to_server_callback: Option<ReconnectToServerCallback>,
+    #[cfg(feature = "websockets")]
+    pub(crate) websocket_headers: http::HeaderMap,
 }
 
 /// Maintains a list of servers and establishes connections.
@@ -483,11 +485,15 @@ impl Connector {
         let mut connection = match server_addr.scheme() {
             #[cfg(feature = "websockets")]
             "ws" => {
-                let ws = tokio_websockets::client::Builder::new()
+                let mut ws_builder = tokio_websockets::client::Builder::new()
                     .uri(server_addr.as_url_str())
                     .map_err(|err| {
                         ConnectError::with_source(crate::ConnectErrorKind::ServerParse, err)
-                    })?
+                    })?;
+                for (name, value) in self.options.websocket_headers.iter() {
+                    ws_builder = ws_builder.add_header(name.clone(), value.clone());
+                }
+                let ws = ws_builder
                     .connect()
                     .await
                     .map_err(|err| ConnectError::with_source(crate::ConnectErrorKind::Io, err))?;
@@ -502,12 +508,20 @@ impl Connector {
                         ConnectError::with_source(crate::ConnectErrorKind::Tls, err)
                     })?);
                 let tls_connector = tokio_rustls::TlsConnector::from(tls_config);
-                let ws = tokio_websockets::client::Builder::new()
-                    .connector(&tokio_websockets::Connector::Rustls(tls_connector))
+                // tokio_websockets::client::Builder::connector takes
+                // `&Connector`, so bind the rustls wrapper to a local
+                // first to satisfy the borrow lifetime.
+                let ws_connector = tokio_websockets::Connector::Rustls(tls_connector);
+                let mut ws_builder = tokio_websockets::client::Builder::new()
+                    .connector(&ws_connector)
                     .uri(server_addr.as_url_str())
                     .map_err(|err| {
                         ConnectError::with_source(crate::ConnectErrorKind::ServerParse, err)
-                    })?
+                    })?;
+                for (name, value) in self.options.websocket_headers.iter() {
+                    ws_builder = ws_builder.add_header(name.clone(), value.clone());
+                }
+                let ws = ws_builder
                     .connect()
                     .await
                     .map_err(|err| ConnectError::with_source(crate::ConnectErrorKind::Io, err))?;

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1063,6 +1063,8 @@ pub async fn connect_with_options<A: ToServerAddrs>(
             max_reconnects: options.max_reconnects,
             local_address: options.local_address,
             reconnect_to_server_callback: options.reconnect_to_server_callback,
+            #[cfg(feature = "websockets")]
+            websocket_headers: options.websocket_headers,
         },
         events_tx,
         state_tx,

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -70,6 +70,13 @@ pub struct ConnectOptions {
     pub(crate) skip_subject_validation: bool,
     pub(crate) local_address: Option<SocketAddr>,
     pub(crate) reconnect_to_server_callback: Option<ReconnectToServerCallback>,
+    /// Optional HTTP headers to inject on the WebSocket upgrade
+    /// request — only honoured by the `ws://` / `wss://` connector
+    /// arms; ignored on `nats://` / `tls://` schemes (no HTTP
+    /// upgrade in that codepath). Default empty; set via
+    /// [`ConnectOptions::websocket_headers`].
+    #[cfg(feature = "websockets")]
+    pub(crate) websocket_headers: http::HeaderMap,
 }
 
 impl fmt::Debug for ConnectOptions {
@@ -126,6 +133,8 @@ impl Default for ConnectOptions {
             skip_subject_validation: false,
             local_address: None,
             reconnect_to_server_callback: None,
+            #[cfg(feature = "websockets")]
+            websocket_headers: http::HeaderMap::new(),
         }
     }
 }
@@ -1037,6 +1046,55 @@ impl ConnectOptions {
     /// ```
     pub fn local_address(mut self, address: SocketAddr) -> ConnectOptions {
         self.local_address = Some(address);
+        self
+    }
+
+    /// Set custom HTTP headers to inject on the WebSocket upgrade
+    /// request. Only honoured by the `ws://` / `wss://` connector
+    /// arms; ignored on `nats://` / `tls://` schemes (no HTTP
+    /// upgrade in that codepath).
+    ///
+    /// Use case: a reverse proxy in front of the NATS server (e.g.
+    /// nginx / Kong / Envoy) requires a `Cookie:` or `Authorization:`
+    /// header on the WS upgrade to validate the session before
+    /// proxying. Without a hook on the underlying
+    /// `tokio_websockets::client::Builder` there's no way to set
+    /// these.
+    ///
+    /// Each header in the supplied `HeaderMap` is forwarded via
+    /// `tokio_websockets::client::Builder::add_header` before the
+    /// upgrade request goes out. Protocol-required upgrade headers
+    /// (`Sec-WebSocket-Key`, `Upgrade`, `Connection`, `Host`,
+    /// `Sec-WebSocket-Version`) are owned by the WS client and
+    /// should not be passed here — `add_header` overwrites them
+    /// silently.
+    ///
+    /// Default is an empty `HeaderMap`; callers that don't touch
+    /// this method see identical behaviour to previous releases.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), async_nats::ConnectError> {
+    /// # #[cfg(feature = "websockets")] {
+    /// use http::{HeaderMap, HeaderName, HeaderValue};
+    ///
+    /// let mut headers = HeaderMap::new();
+    /// headers.insert(
+    ///     HeaderName::from_static("cookie"),
+    ///     HeaderValue::from_static("session=abc123"),
+    /// );
+    /// async_nats::ConnectOptions::new()
+    ///     .websocket_headers(headers)
+    ///     .connect("wss://gateway.example.com/nats")
+    ///     .await?;
+    /// # }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "websockets")]
+    pub fn websocket_headers(mut self, headers: http::HeaderMap) -> ConnectOptions {
+        self.websocket_headers = headers;
         self
     }
 }


### PR DESCRIPTION
## Summary

Add `ConnectOptions::websocket_headers(http::HeaderMap)` so callers can inject custom HTTP headers on the WebSocket upgrade request when connecting to NATS through a reverse proxy that requires session-side validation.

## Motivation

A deployment proxying the NATS WebSocket through a reverse proxy commonly wants to validate a session `Cookie:` (or `Authorization:`) header on the WS upgrade before proxying the connection through to NATS. Today `Connector` builds its `tokio_websockets::client::Builder` with no caller hook between `.uri()` and `.connect()`, so there is no way to thread an upgrade-time header through.

`tokio-websockets` itself already exposes `Builder::add_header(name, value)`. This change plumbs one new field through `ConnectOptions → ConnectorOptions → connector::try_connect` and calls `add_header` in a loop before `.connect()`.

## API

\`\`\`rust
impl ConnectOptions {
    #[cfg(feature = "websockets")]
    pub fn websocket_headers(mut self, headers: http::HeaderMap) -> ConnectOptions;
}
\`\`\`

Default is an empty `HeaderMap`. Callers that don't touch the new method see byte-for-byte identical behaviour to upstream.

## Withdrawn

Closing this PR — withdrawing the contribution at my team's request before formal review. Apologies for the noise.