### PR TITLE
Release v0.49.0

### DIFF
--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v0.49.0
+## Overview
+
+This is a small release adding missing client-side max-payload validations for some methods.
+It is a minor release as it adds new error kind variants for relevant calls.
+
+## What's Changed
+* Add TryFrom impls for HeaderName by @yordis in https://github.com/nats-io/nats.rs/pull/1587
+* Add max payload validation where it was missing by @Jarema in https://github.com/nats-io/nats.rs/pull/1590
+
+## New Contributors
+* @scottf made their first contribution in https://github.com/nats-io/nats.rs/pull/1579
+
+**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.48.0...async-nats/v0.49.0
+
 # v0.48.0
 ## Added
 * Add recent jetstream error codes by @Jarema in https://github.com/nats-io/nats.rs/pull/1564

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 rust-version = "1.88.0"
 description = "A async Rust NATS client"


### PR DESCRIPTION
# v0.49.0
## Overview

This is a small release adding missing client-side max-payload validations for some methods.
It is a minor release as it adds new error kind variants for relevant calls.

## What's Changed
* Add TryFrom impls for HeaderName by @yordis in https://github.com/nats-io/nats.rs/pull/1587
* Add max payload validation where it was missing by @Jarema in https://github.com/nats-io/nats.rs/pull/1590

## New Contributors
* @scottf made their first contribution in https://github.com/nats-io/nats.rs/pull/1579

**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.48.0...async-nats/v0.48.1


Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>