### PR TITLE
Add chrono as alternative to time.

### DIFF
--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -32,6 +32,7 @@ rustls-pki-types = "1"
 nuid = { version = "0.5", optional = true }
 serde_nanos = { version = "0.1.3", optional = true }
 time = { version = "0.3.36", features = ["parsing", "formatting", "serde", "serde-well-known"], optional = true }
+chrono = { version = "0.4.38", features = ["serde"], optional = true }
 rustls-native-certs = "0.8"
 tracing = "0.1"
 thiserror = "2.0"
@@ -61,12 +62,14 @@ chrono = "0.4.44"
 num = "0.4.1"
 
 [features]
-default = ["server_2_10", "server_2_11", "server_2_12", "server_2_14", "service", "ring", "jetstream", "nkeys", "crypto", "object-store", "kv", "websockets", "nuid"]
+default = ["server_2_10", "server_2_11", "server_2_12", "server_2_14", "service", "ring", "jetstream", "nkeys", "crypto", "object-store", "kv", "websockets", "nuid", "time"]
 # Enables Service API for the client.
-jetstream = ["dep:time", "dep:serde_nanos", "dep:tryhard", "dep:base64"]
+jetstream = ["dep:serde_nanos", "dep:tryhard", "dep:base64"]
 kv = ["jetstream"]
 object-store = ["jetstream", "crypto"]
-service = ["dep:time", "dep:serde_nanos"]
+service = ["dep:serde_nanos"]
+time = ["dep:time"]
+chrono = ["dep:chrono"]
 crypto = []
 websockets = ["dep:tokio-websockets"]
 aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets?/aws-lc-rs", "rustls-webpki/aws-lc-rs"]

--- a/async-nats/src/datetime.rs
+++ b/async-nats/src/datetime.rs
@@ -1,0 +1,117 @@
+// Copyright 2020-2026
+// TODO
+
+#[cfg(all(
+    any(feature = "jetstream", feature = "service"),
+    not(feature = "time"),
+    not(feature = "chrono")
+))]
+compile_error!(
+    "Either 'time' or 'chrono' feature must be enabled when 'jetstream' or 'service' is active."
+);
+
+#[cfg(feature = "chrono")]
+pub type DateTime = chrono::DateTime<chrono::Utc>;
+
+#[cfg(all(feature = "time", not(feature = "chrono")))]
+pub type DateTime = time::OffsetDateTime;
+
+#[cfg(feature = "chrono")]
+pub fn parse_rfc3339(s: &str) -> Result<DateTime, crate::Error> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .map_err(|e| e.into())
+}
+
+#[cfg(all(feature = "time", not(feature = "chrono")))]
+pub fn parse_rfc3339(s: &str) -> Result<DateTime, crate::Error> {
+    time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+        .map_err(|e| e.into())
+}
+
+#[cfg(feature = "chrono")]
+pub fn from_nanos(nanos: i128) -> Result<DateTime, crate::Error> {
+    let nanos_i64: i64 = nanos.try_into().map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "nanoseconds value too large for chrono",
+        )
+    })?;
+    let secs = nanos_i64 / 1_000_000_000;
+    let nsecs = (nanos_i64 % 1_000_000_000) as u32;
+    chrono::DateTime::from_timestamp(secs, nsecs).ok_or_else(|| {
+        Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid timestamp",
+        )) as crate::Error
+    })
+}
+
+#[cfg(all(feature = "time", not(feature = "chrono")))]
+pub fn from_nanos(nanos: i128) -> Result<DateTime, crate::Error> {
+    time::OffsetDateTime::from_unix_timestamp_nanos(nanos).map_err(|e| e.into())
+}
+
+#[cfg(feature = "chrono")]
+pub fn now() -> DateTime {
+    chrono::Utc::now()
+}
+
+#[cfg(all(feature = "time", not(feature = "chrono")))]
+pub fn now() -> DateTime {
+    time::OffsetDateTime::now_utc()
+}
+
+#[cfg(feature = "chrono")]
+pub mod rfc3339 {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    pub fn serialize<S>(
+        dt: &chrono::DateTime<chrono::Utc>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Serialize::serialize(dt, serializer)
+    }
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<chrono::DateTime<chrono::Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer)
+    }
+
+    pub mod option {
+        use serde::{Deserialize, Deserializer, Serialize, Serializer};
+        pub fn serialize<S>(
+            dt: &Option<chrono::DateTime<chrono::Utc>>,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            Serialize::serialize(dt, serializer)
+        }
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<chrono::DateTime<chrono::Utc>>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            Deserialize::deserialize(deserializer)
+        }
+    }
+}
+
+#[cfg(all(feature = "time", not(feature = "chrono")))]
+pub use time::serde::rfc3339;
+
+#[cfg(feature = "chrono")]
+pub fn add_std_duration(dt: DateTime, duration: std::time::Duration) -> DateTime {
+    let chrono_duration = chrono::Duration::from_std(duration).unwrap();
+    dt + chrono_duration
+}
+
+#[cfg(all(feature = "time", not(feature = "chrono")))]
+pub fn add_std_duration(dt: DateTime, duration: std::time::Duration) -> DateTime {
+    let time_duration = time::Duration::try_from(duration).unwrap();
+    dt + time_duration
+}

--- a/async-nats/src/jetstream/consumer/mod.rs
+++ b/async-nats/src/jetstream/consumer/mod.rs
@@ -21,10 +21,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use time::serde::rfc3339;
-
-#[cfg(feature = "server_2_11")]
-use time::OffsetDateTime;
+use crate::datetime::{rfc3339, DateTime};
 
 use super::context::{ConsumerInfoError, RequestError};
 use super::response::Response;
@@ -225,7 +222,7 @@ pub struct Info {
     pub name: String,
     /// The time the consumer was created
     #[serde(with = "rfc3339")]
-    pub created: time::OffsetDateTime,
+    pub created: DateTime,
     /// The consumer's configuration
     pub config: Config,
     /// Statistics for delivered messages
@@ -272,7 +269,7 @@ pub struct SequenceInfo {
         with = "rfc3339::option",
         skip_serializing_if = "Option::is_none"
     )]
-    pub last_active: Option<time::OffsetDateTime>,
+    pub last_active: Option<DateTime>,
 }
 
 /// Configuration for consumers. From a high level, the
@@ -429,7 +426,7 @@ pub struct Config {
         with = "rfc3339::option",
         skip_serializing_if = "Option::is_none"
     )]
-    pub pause_until: Option<OffsetDateTime>,
+    pub pause_until: Option<DateTime>,
 }
 
 #[cfg(feature = "server_2_11")]
@@ -514,7 +511,7 @@ pub enum DeliverPolicy {
     #[serde(rename = "by_start_time")]
     ByStartTime {
         #[serde(rename = "opt_start_time", with = "rfc3339")]
-        start_time: time::OffsetDateTime,
+        start_time: DateTime,
     },
     /// `LastPerSubject` will start the consumer with the last message
     /// for all subjects received.

--- a/async-nats/src/jetstream/consumer/pull.rs
+++ b/async-nats/src/jetstream/consumer/pull.rs
@@ -18,7 +18,7 @@ use futures_util::{
 };
 
 #[cfg(feature = "server_2_11")]
-use time::{serde::rfc3339, OffsetDateTime};
+use crate::datetime::{rfc3339, DateTime};
 
 #[cfg(feature = "server_2_10")]
 use std::collections::HashMap;
@@ -2587,7 +2587,7 @@ pub struct Config {
         with = "rfc3339::option",
         skip_serializing_if = "Option::is_none"
     )]
-    pub pause_until: Option<OffsetDateTime>,
+    pub pause_until: Option<DateTime>,
 }
 
 impl IntoConsumerConfig for &Config {

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -40,7 +40,7 @@ use std::{
 };
 use std::{sync::atomic::Ordering, time::Duration};
 #[cfg(feature = "server_2_11")]
-use time::{serde::rfc3339, OffsetDateTime};
+use crate::datetime::{rfc3339, DateTime};
 use tracing::{debug, trace};
 
 const ORDERED_IDLE_HEARTBEAT: Duration = Duration::from_secs(5);
@@ -286,7 +286,7 @@ pub struct Config {
         with = "rfc3339::option",
         skip_serializing_if = "Option::is_none"
     )]
-    pub pause_until: Option<OffsetDateTime>,
+    pub pause_until: Option<DateTime>,
 }
 
 impl FromConsumer for Config {

--- a/async-nats/src/jetstream/kv/mod.rs
+++ b/async-nats/src/jetstream/kv/mod.rs
@@ -27,7 +27,7 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use regex::Regex;
 use std::sync::LazyLock;
-use time::OffsetDateTime;
+use crate::datetime::DateTime;
 use tracing::debug;
 
 use crate::error::Error;
@@ -1533,7 +1533,7 @@ pub struct Entry {
     /// Distance from the latest value.
     pub delta: u64,
     /// The time the data was put in the bucket.
-    pub created: OffsetDateTime,
+    pub created: DateTime,
     /// The kind of operation that caused this entry.
     pub operation: Operation,
     /// Set to true after all historical messages have been received, and

--- a/async-nats/src/jetstream/message.rs
+++ b/async-nats/src/jetstream/message.rs
@@ -22,8 +22,7 @@ use futures_util::future::TryFutureExt;
 use futures_util::StreamExt;
 use std::fmt::Display;
 use std::{mem, time::Duration};
-use time::format_description::well_known::Rfc3339;
-use time::OffsetDateTime;
+use crate::datetime::{self, DateTime};
 
 /// A message received directly from the stream, without leveraging a consumer.
 #[derive(Debug, Clone)]
@@ -32,7 +31,7 @@ pub struct StreamMessage {
     pub sequence: u64,
     pub headers: HeaderMap,
     pub payload: Bytes,
-    pub time: OffsetDateTime,
+    pub time: DateTime,
 }
 
 /// An outbound message to be published.
@@ -182,7 +181,7 @@ impl TryFrom<crate::Message> for StreamMessage {
                 StreamMessageError::with_source(StreamMessageErrorKind::MissingHeader, "timestamp")
             })
             .and_then(|time| {
-                OffsetDateTime::parse(time.as_str(), &Rfc3339).map_err(|err| {
+                datetime::parse_rfc3339(time.as_str()).map_err(|err| {
                     StreamMessageError::with_source(
                         StreamMessageErrorKind::ParseError,
                         format!("could not parse timestamp header: {err}"),
@@ -514,7 +513,7 @@ impl Message {
                 consumer_sequence: try_parse!(),
                 published: {
                     let nanos: i128 = try_parse!();
-                    OffsetDateTime::from_unix_timestamp_nanos(nanos)?
+                    datetime::from_nanos(nanos)?
                 },
                 pending: try_parse!(),
                 token: if n_tokens >= 9 {
@@ -536,7 +535,7 @@ impl Message {
                 consumer_sequence: try_parse!(),
                 published: {
                     let nanos: i128 = try_parse!();
-                    OffsetDateTime::from_unix_timestamp_nanos(nanos)?
+                    datetime::from_nanos(nanos)?
                 },
                 pending: try_parse!(),
                 token: None,
@@ -813,7 +812,7 @@ pub struct Info<'a> {
     /// the number of messages known by the server to be pending to this consumer
     pub pending: u64,
     /// the time that this message was received by the server from its publisher
-    pub published: time::OffsetDateTime,
+    pub published: DateTime,
     /// Optional token, present in servers post-ADR-15
     pub token: Option<&'a str>,
 }

--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -38,7 +38,7 @@ use super::stream::{self, ConsumerError, ConsumerErrorKind, PurgeError, PurgeErr
 use super::{consumer::push::Ordered, stream::StorageType};
 use crate::error::Error;
 use crate::header::NATS_ROLLUP;
-use time::{serde::rfc3339, OffsetDateTime};
+use crate::datetime::{self, rfc3339, DateTime};
 
 const DEFAULT_CHUNK_SIZE: usize = 128 * 1024;
 const ROLLUP_SUBJECT: &str = "sub";
@@ -360,7 +360,7 @@ impl ObjectStore {
             chunks: object_chunks,
             size: object_size,
             digest: Some(format!("SHA-256={}", URL_SAFE.encode(digest))),
-            modified: Some(OffsetDateTime::now_utc()),
+            modified: Some(datetime::now()),
             deleted: false,
             metadata: object_meta.metadata,
             headers: object_meta.headers,
@@ -723,7 +723,7 @@ impl ObjectStore {
             nuid: crate::id_generator::next(),
             size: 0,
             chunks: 0,
-            modified: Some(OffsetDateTime::now_utc()),
+            modified: Some(datetime::now()),
             digest: None,
             deleted: false,
             metadata: HashMap::default(),
@@ -788,7 +788,7 @@ impl ObjectStore {
             nuid: crate::id_generator::next(),
             size: 0,
             chunks: 0,
-            modified: Some(OffsetDateTime::now_utc()),
+            modified: Some(datetime::now()),
             digest: None,
             deleted: false,
             metadata: HashMap::default(),
@@ -1111,7 +1111,7 @@ pub struct ObjectInfo {
     /// Date and time the object was last modified.
     #[serde(default, with = "rfc3339::option")]
     #[serde(rename = "mtime")]
-    pub modified: Option<time::OffsetDateTime>,
+    pub modified: Option<DateTime>,
     /// Digest of the object stream.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub digest: Option<String>,

--- a/async-nats/src/jetstream/stream.rs
+++ b/async-nats/src/jetstream/stream.rs
@@ -33,7 +33,7 @@ use bytes::Bytes;
 use futures_util::{future::BoxFuture, FutureExt, TryFutureExt};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
-use time::{serde::rfc3339, OffsetDateTime};
+use crate::datetime::{rfc3339, DateTime};
 
 use super::{
     consumer::{self, Consumer, FromConsumer, IntoConsumerConfig},
@@ -989,7 +989,7 @@ impl<I> Stream<I> {
     pub async fn pause_consumer(
         &self,
         name: &str,
-        pause_until: OffsetDateTime,
+        pause_until: DateTime,
     ) -> Result<PauseResponse, ConsumerError> {
         self.request_pause_consumer(name, Some(pause_until)).await
     }
@@ -1023,7 +1023,7 @@ impl<I> Stream<I> {
     async fn request_pause_consumer(
         &self,
         name: &str,
-        pause_until: Option<OffsetDateTime>,
+        pause_until: Option<DateTime>,
     ) -> Result<PauseResponse, ConsumerError> {
         let subject = format!("CONSUMER.PAUSE.{}.{}", self.name, name);
         let payload = &PauseResumeConsumerRequest { pause_until };
@@ -1316,7 +1316,7 @@ pub struct Config {
         with = "rfc3339::option",
         skip_serializing_if = "Option::is_none"
     )]
-    pub pause_until: Option<OffsetDateTime>,
+    pub pause_until: Option<DateTime>,
 
     /// Allows setting a TTL for a message in the stream.
     #[cfg(feature = "server_2_11")]
@@ -1625,7 +1625,7 @@ pub struct Info {
     pub config: Config,
     /// The time that this stream was created.
     #[serde(with = "rfc3339")]
-    pub created: time::OffsetDateTime,
+    pub created: DateTime,
     /// Various metrics associated with this stream.
     pub state: State,
     /// Information about leader and replicas.
@@ -1657,7 +1657,7 @@ pub struct DeleteStatus {
 pub struct PauseResponse {
     pub paused: bool,
     #[serde(with = "rfc3339")]
-    pub pause_until: OffsetDateTime,
+    pub pause_until: DateTime,
     #[serde(default, with = "serde_nanos")]
     pub pause_remaining: Option<Duration>,
 }
@@ -1666,7 +1666,7 @@ pub struct PauseResponse {
 #[derive(Serialize, Debug)]
 struct PauseResumeConsumerRequest {
     #[serde(with = "rfc3339::option", skip_serializing_if = "Option::is_none")]
-    pause_until: Option<OffsetDateTime>,
+    pause_until: Option<DateTime>,
 }
 
 #[cfg(feature = "server_2_14")]
@@ -1703,13 +1703,13 @@ pub struct State {
     pub first_sequence: u64,
     /// The time associated with the oldest message still present in this stream
     #[serde(with = "rfc3339", rename = "first_ts")]
-    pub first_timestamp: time::OffsetDateTime,
+    pub first_timestamp: DateTime,
     /// The last sequence number assigned to a message in this stream
     #[serde(rename = "last_seq")]
     pub last_sequence: u64,
     /// The time that the last message was received by this stream
     #[serde(with = "rfc3339", rename = "last_ts")]
-    pub last_timestamp: time::OffsetDateTime,
+    pub last_timestamp: DateTime,
     /// The number of consumers configured to consume this stream
     pub consumer_count: usize,
     /// The number of subjects in the stream
@@ -1747,7 +1747,7 @@ pub struct RawMessage {
 
     /// The time the message was published.
     #[serde(rename = "time", with = "rfc3339")]
-    pub time: time::OffsetDateTime,
+    pub time: DateTime,
 }
 
 impl TryFrom<RawMessage> for StreamMessage {
@@ -1875,7 +1875,7 @@ pub struct ClusterInfo {
     pub leader: Option<String>,
     /// The time since this server has been the leader.
     #[serde(default, with = "rfc3339::option")]
-    pub leader_since: Option<OffsetDateTime>,
+    pub leader_since: Option<DateTime>,
     /// Indicates if this account is a system account.
     #[cfg(feature = "server_2_12")]
     #[serde(default)]
@@ -1979,7 +1979,7 @@ pub struct Source {
         with = "rfc3339::option"
     )]
     /// Optional source start time.
-    pub start_time: Option<OffsetDateTime>,
+    pub start_time: Option<DateTime>,
     /// Optional additional filter subject.
     #[serde(default, skip_serializing_if = "is_default")]
     pub filter_subject: Option<String>,

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -265,6 +265,9 @@ pub use options::{AuthError, ConnectOptions};
 #[cfg(feature = "crypto")]
 #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 mod crypto;
+#[cfg(any(feature = "time", feature = "chrono", feature = "jetstream", feature = "service"))]
+pub mod datetime;
+
 pub mod error;
 pub mod header;
 mod id_generator;

--- a/async-nats/src/service/mod.rs
+++ b/async-nats/src/service/mod.rs
@@ -30,8 +30,7 @@ use futures_util::{
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
-use time::serde::rfc3339;
-use time::OffsetDateTime;
+use crate::datetime::{self, rfc3339, DateTime};
 use tokio::{sync::broadcast::Sender, task::JoinHandle};
 use tracing::debug;
 
@@ -91,7 +90,7 @@ pub struct Stats {
     // Service version.
     pub version: String,
     #[serde(with = "rfc3339")]
-    pub started: OffsetDateTime,
+    pub started: DateTime,
     /// Statistics of all endpoints.
     pub endpoints: Vec<endpoint::Stats>,
 }
@@ -354,7 +353,7 @@ impl Service {
             .queue_group
             .unwrap_or(DEFAULT_QUEUE_GROUP.to_string());
         let id = crate::id_generator::next();
-        let started = OffsetDateTime::now_utc();
+        let started = datetime::now();
         let subjects = Arc::new(Mutex::new(Vec::new()));
         let info = Info {
             kind: "io.nats.micro.v1.info_response".to_string(),

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -37,6 +37,7 @@ mod jetstream {
 
     use super::*;
     use async_nats::connection::State;
+    use async_nats::datetime;
     use async_nats::header::{self, HeaderMap, NATS_MESSAGE_ID};
     #[cfg(feature = "server_2_11")]
     use async_nats::jetstream::consumer::pull::BatchConfig;
@@ -58,7 +59,7 @@ mod jetstream {
     use async_nats::jetstream::AckKind;
     use async_nats::{ConnectOptions, StatusCode};
     use futures_util::stream::{StreamExt, TryStreamExt};
-    use time::OffsetDateTime;
+    use async_nats::datetime::DateTime;
     use tracing::debug;
 
     #[tokio::test]
@@ -1036,7 +1037,7 @@ mod jetstream {
             .unwrap()
             .create_consumer(consumer::pull::Config {
                 deliver_policy: DeliverPolicy::ByStartTime {
-                    start_time: OffsetDateTime::now_utc(),
+                    start_time: datetime::now(),
                 },
                 ..Default::default()
             })
@@ -4219,7 +4220,6 @@ mod jetstream {
     #[cfg(feature = "server_2_11")]
     #[tokio::test]
     async fn pause_consumer() {
-        use time::Duration;
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = async_nats::ConnectOptions::new()
             .connect(server.client_url())
@@ -4249,7 +4249,7 @@ mod jetstream {
         stream
             .pause_consumer(
                 "name",
-                OffsetDateTime::now_utc().saturating_add(Duration::seconds_f32(10.0)),
+                datetime::add_std_duration(datetime::now(), Duration::from_secs(10)),
             )
             .await
             .unwrap();
@@ -4266,7 +4266,7 @@ mod jetstream {
             .create_consumer(consumer::pull::Config {
                 durable_name: Some("blame".to_string()),
                 pause_until: Some(
-                    OffsetDateTime::now_utc().saturating_add(Duration::seconds_f32(3.0)),
+                    datetime::add_std_duration(datetime::now(), Duration::from_secs(3)),
                 ),
                 ..Default::default()
             })


### PR DESCRIPTION
Both `time` and `chrono` are popular Rust crates providing datetime utilities. `async_nats` optionally depends on `time` for the "jetstream" feature.

This change adds `chrono` as another optional dependency, introduces the `datetime.rs` abstraction layer above `time` and `chrono`, allows the user to control which dependency to build `async_nats` with.