### PR TITLE
Improve stream overlap error context

### DIFF
--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -634,7 +634,7 @@ impl Context {
         let response: Response<Info> = self.request(subject, &config).await?;
 
         match response {
-            Response::Err { error } => Err(error.into()),
+            Response::Err { error } => Err(create_stream_error_with_config(error, &config)),
             Response::Ok(info) => Ok(Stream {
                 context: self.clone(),
                 info,
@@ -2227,6 +2227,28 @@ impl Display for CreateStreamErrorKind {
 }
 
 pub type CreateStreamError = Error<CreateStreamErrorKind>;
+
+fn create_stream_error_with_config(
+    error: super::errors::Error,
+    config: &Config,
+) -> CreateStreamError {
+    match error.kind() {
+        ErrorCode::STREAM_SUBJECT_OVERLAP => {
+            let subjects = if config.subjects.is_empty() {
+                vec![config.name.clone()]
+            } else {
+                config.subjects.clone()
+            };
+            error
+                .with_description_prefix(format!(
+                    "failed to create stream '{}' with subjects {subjects:?}",
+                    config.name
+                ))
+                .into()
+        }
+        _ => error.into(),
+    }
+}
 
 impl From<super::errors::Error> for CreateStreamError {
     fn from(error: super::errors::Error) -> Self {

--- a/async-nats/src/jetstream/errors.rs
+++ b/async-nats/src/jetstream/errors.rs
@@ -709,6 +709,14 @@ impl Error {
     pub fn kind(&self) -> ErrorCode {
         self.err_code
     }
+
+    pub(crate) fn with_description_prefix(mut self, prefix: String) -> Self {
+        self.description = Some(match self.description {
+            Some(description) => format!("{prefix}: {description}"),
+            None => prefix,
+        });
+        self
+    }
 }
 
 impl fmt::Display for Error {

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -398,6 +398,48 @@ mod jetstream {
             .unwrap();
     }
 
+    #[tokio::test]
+    async fn create_stream_subject_overlap_error_includes_config() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+        let context = async_nats::jetstream::new(client);
+
+        context
+            .create_stream(stream::Config {
+                name: "orders".into(),
+                subjects: vec!["orders.*".into()],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let err = match context
+            .create_stream(stream::Config {
+                name: "shipments".into(),
+                subjects: vec!["orders.new".into()],
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(_) => panic!("expected overlapping stream subjects to fail"),
+            Err(err) => err,
+        };
+
+        let message = err.to_string();
+        assert!(
+            message.contains("shipments"),
+            "error did not include stream name: {message}"
+        );
+        assert!(
+            message.contains("orders.new"),
+            "error did not include stream subjects: {message}"
+        );
+        assert!(
+            message.contains("subjects overlap with an existing stream"),
+            "error did not include server response: {message}"
+        );
+    }
+
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn create_stream_with_replicas() {


### PR DESCRIPTION
## Summary
- include the attempted stream name and subjects when stream creation fails with `ErrorCode::STREAM_SUBJECT_OVERLAP`
- keep the original JetStream error as the source so the server status and error code still show up
- add a JetStream integration test for the displayed context

## Context
When NATS returns error 10065, `async-nats` currently surfaces the server message as `subjects overlap with an existing stream`, but it does not show which create call failed. This keeps the existing error path and prefixes the server description with the attempted stream config.

Closes #1498.

## Test Plan
Using Rust 1.89.0 with `nats-server` v2.14.2 on PATH:

- `cargo fmt --check`
- `cargo test -p async-nats --test jetstream_tests create_stream_subject_overlap_error_includes_config -- --nocapture`
- `cargo test -p async-nats --test jetstream_tests -- --nocapture`
- `cargo test -p async-nats --lib -- --nocapture`
- `cargo clippy -p async-nats --all-targets -- -D warnings`