### PR TITLE
Fix recreating ordered consumer on server restart

### DIFF
--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -549,25 +549,6 @@ impl futures_util::Stream for Ordered {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
-            // Check heartbeat timer, but only if we have an active subscriber
-            // Don't check during recreation
-            if self.subscriber.is_some()
-                && self.subscriber_future.is_none()
-                && self
-                    .heartbeat_sleep
-                    .get_or_insert_with(|| {
-                        Box::pin(tokio::time::sleep(ORDERED_IDLE_HEARTBEAT.saturating_mul(2)))
-                    })
-                    .poll_unpin(cx)
-                    .is_ready()
-            {
-                self.heartbeat_sleep = None;
-                self.subscriber = None;
-                self.consumer_sequence.store(0, Ordering::Relaxed);
-                return Poll::Ready(Some(Err(OrderedError::new(
-                    OrderedErrorKind::MissingHeartbeat,
-                ))));
-            }
             // Poll for connection state changes
             match &mut self.state_change_future {
                 None => {
@@ -743,7 +724,39 @@ impl futures_util::Stream for Ordered {
                             }
                         }
                     }
-                    Poll::Pending => return Poll::Pending,
+                    Poll::Pending => {
+                        // The channel is drained. Only now consult the idle-heartbeat timer: a
+                        // live consumer keeps sending heartbeats well within the timeout, so an
+                        // empty channel past the deadline means the consumer is gone (e.g. the
+                        // server was restarted, or the consumer was deleted, while this stream
+                        // was idle). Recreate from the last delivered sequence instead of
+                        // erroring terminally and then hanging forever (#1596).
+                        //
+                        // Draining before this check is what makes it safe: if the application
+                        // merely paused while messages were still buffered, those are delivered
+                        // first (each resetting the timer), so a false timeout never discards
+                        // buffered messages. That matters because recreation resumes from the
+                        // last *delivered* sequence (AckPolicy::None), and on capped/discarding
+                        // streams the dropped messages might no longer be replayable.
+                        if self
+                            .heartbeat_sleep
+                            .get_or_insert_with(|| {
+                                Box::pin(tokio::time::sleep(
+                                    ORDERED_IDLE_HEARTBEAT.saturating_mul(2),
+                                ))
+                            })
+                            .poll_unpin(cx)
+                            .is_ready()
+                        {
+                            self.heartbeat_sleep = None;
+                            self.subscriber = None;
+                            self.consumer_sequence.store(0, Ordering::Relaxed);
+                            return Poll::Ready(Some(Err(OrderedError::new(
+                                OrderedErrorKind::MissingHeartbeat,
+                            ))));
+                        }
+                        return Poll::Pending;
+                    }
                 }
             }
         }

--- a/async-nats/src/jetstream/consumer/push.rs
+++ b/async-nats/src/jetstream/consumer/push.rs
@@ -562,6 +562,8 @@ impl futures_util::Stream for Ordered {
                     .is_ready()
             {
                 self.heartbeat_sleep = None;
+                self.subscriber = None;
+                self.consumer_sequence.store(0, Ordering::Relaxed);
                 return Poll::Ready(Some(Err(OrderedError::new(
                     OrderedErrorKind::MissingHeartbeat,
                 ))));

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1583,6 +1583,84 @@ mod jetstream {
         }
     }
 
+    // Regression test for #1596: an ordered push consumer that is *not* being polled across a
+    // server restart must still recreate its consumer and resume delivery once polling resumes,
+    // instead of surfacing "missed idle heartbeat" and then hanging forever. The actively-polled
+    // path recovers via connection-state transitions (see `push_ordered_recreate`); the idle path
+    // can only recover via the idle-heartbeat monitor, which must trigger recreation.
+    #[tokio::test]
+    async fn push_ordered_recreate_after_idle_restart() {
+        let mut server =
+            nats_server::run_server_with_port("tests/configs/jetstream.conf", Some("5657"));
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+        let context = async_nats::jetstream::new(client.clone());
+
+        context
+            .create_stream(stream::Config {
+                name: "events".into(),
+                subjects: vec!["events.>".into()],
+                storage: StorageType::File,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let stream = context.get_stream("events").await.unwrap();
+        let consumer: OrderedPushConsumer = stream
+            .create_consumer(consumer::push::OrderedConfig {
+                deliver_subject: "push".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let mut messages = consumer.messages().await.unwrap();
+
+        // Warm the consumer with one live delivery so it has a known last sequence to resume from.
+        context.publish("events.1", "1".into()).await.unwrap();
+        let message = tokio::time::timeout(Duration::from_secs(5), messages.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(message.info().unwrap().stream_sequence, 1);
+
+        // Restart the server while the consumer stream is idle (no `next()` in flight).
+        server.restart();
+        loop {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            if client.connection_state() == State::Connected {
+                break;
+            }
+        }
+
+        // Publish after the restart, then resume polling. Before the fix the first poll yields
+        // Err(MissingHeartbeat) and every subsequent poll hangs; the post-restart message is lost.
+        context.publish("events.2", "2".into()).await.unwrap();
+
+        // The missed-heartbeat error may surface once, but it must trigger consumer recreation
+        // rather than a terminal hang, so the post-restart message is eventually delivered.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "ordered consumer never recovered after an idle server restart"
+            );
+            match tokio::time::timeout(remaining, messages.next()).await {
+                Ok(Some(Ok(message))) => {
+                    if message.info().unwrap().stream_sequence == 2 {
+                        assert_eq!(message.payload.as_ref(), b"2");
+                        break;
+                    }
+                }
+                Ok(Some(Err(_))) => continue,
+                Ok(None) => panic!("ordered consumer stream ended unexpectedly"),
+                Err(_) => panic!("ordered consumer hung; never recovered after an idle restart"),
+            }
+        }
+    }
+
     // test added just to be sure, that if messages have arrived to the stream already, we won't
     // miss them in AckPolicy::None setup.
     #[tokio::test]

--- a/async-nats/tests/jetstream_tests.rs
+++ b/async-nats/tests/jetstream_tests.rs
@@ -1661,6 +1661,76 @@ mod jetstream {
         }
     }
 
+    // Companion to #1596: the idle-heartbeat recreation must not discard messages that are
+    // already buffered in the subscription. If the application simply pauses for longer than the
+    // heartbeat window while the consumer is alive and has queued messages, resuming must deliver
+    // all of them in order without surfacing a (false) "missed idle heartbeat" — otherwise, with
+    // AckPolicy::None, those buffered messages can be lost on capped/discarding streams.
+    #[tokio::test]
+    async fn push_ordered_buffered_messages_survive_idle() {
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+        let context = async_nats::jetstream::new(client.clone());
+
+        context
+            .create_stream(stream::Config {
+                name: "bursts".into(),
+                subjects: vec!["bursts.>".into()],
+                storage: StorageType::File,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let stream = context.get_stream("bursts").await.unwrap();
+        let consumer: OrderedPushConsumer = stream
+            .create_consumer(consumer::push::OrderedConfig {
+                deliver_subject: "push".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let mut messages = consumer.messages().await.unwrap();
+
+        // Establish the consumer with one live delivery, then leave the heartbeat timer armed by
+        // forcing a poll that finds the channel empty (the timeout drives one `Pending` poll).
+        context.publish("bursts.1", "1".into()).await.unwrap();
+        let first = tokio::time::timeout(Duration::from_secs(5), messages.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.payload.as_ref(), b"1");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), messages.next())
+                .await
+                .is_err(),
+            "expected no further messages yet"
+        );
+
+        // Publish a burst, then pause longer than ORDERED_IDLE_HEARTBEAT * 2 (10s) without polling.
+        // The burst buffers in the subscription while the heartbeat deadline elapses.
+        for i in 2..=6 {
+            context
+                .publish(format!("bursts.{i}"), i.to_string().into())
+                .await
+                .unwrap();
+        }
+        tokio::time::sleep(Duration::from_secs(11)).await;
+
+        // Resuming must drain the whole buffered burst, in order, with no error.
+        for i in 2..=6 {
+            let message = tokio::time::timeout(Duration::from_secs(5), messages.next())
+                .await
+                .expect("timed out waiting for buffered message")
+                .expect("stream ended unexpectedly")
+                .expect("buffered message was dropped on a false heartbeat timeout");
+            assert_eq!(message.payload.as_ref(), i.to_string().as_bytes());
+            assert_eq!(message.info().unwrap().stream_sequence, i);
+        }
+    }
+
     // test added just to be sure, that if messages have arrived to the stream already, we won't
     // miss them in AckPolicy::None setup.
     #[tokio::test]


### PR DESCRIPTION
While removing additional task in v0.43, we accidentaly introduced a regression taht in cases described in #1596 could cause a hanging push consumer.

fix #1596 

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>