### PR TITLE
Release v0.49.1

### DIFF
--- a/async-nats/CHANGELOG.md
+++ b/async-nats/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.49.1
+## Overview
+Release focusing on fixing behaviour around server connectivity.
+
+## What's Changed
+* Fix ping interval reset by @Jarema in https://github.com/nats-io/nats.rs/pull/1594
+* Fix recreating ordered consumer on server restart by @Jarema in https://github.com/nats-io/nats.rs/pull/1599
+
+**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.49.0...async-nats/v0.49.1
+
 # v0.49.0
 ## Overview
 

--- a/async-nats/Cargo.toml
+++ b/async-nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-nats"
 authors = ["Tomasz Pietrek <tomasz@nats.io>", "Casper Beyer <caspervonb@pm.me>"]
-version = "0.49.0"
+version = "0.49.1"
 edition = "2021"
 rust-version = "1.88.0"
 description = "A async Rust NATS client"


### PR DESCRIPTION
## Overview

Release focusing on fixing behaviour around server connectivity.

## What's Changed
* Fix ping interval reset by @Jarema in https://github.com/nats-io/nats.rs/pull/1594
* Fix recreating ordered consumer on server restart by @Jarema in https://github.com/nats-io/nats.rs/pull/1599


**Full Changelog**: https://github.com/nats-io/nats.rs/compare/async-nats/v0.49.0...async-nats/v0.49.1

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>