### PR TITLE
Replace dead feature-powerset CI job with curated feature check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
         working-directory: ./async-nats
     name: check feature flags (ubuntu-latest / stable)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -72,5 +73,5 @@ jobs:
           save-if: false # we only build docs, so we don't have the full build to be cached.
       - name: Install cargo hack
         run: cargo install cargo-hack
-      - name: Check lint
-        run: cargo hack check --feature-powerset --at-least-one-of aws-lc-rs,ring --no-dev-deps -p async-nats
+      - name: Check feature combinations
+        run: bash .cargo-hack-check.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,6 +231,29 @@ jobs:
       - name: Run datetime unit tests (chrono backend)
         run: cargo test --lib "datetime::" --features chrono
 
+  check_features:
+    defaults:
+      run:
+        working-directory: ./async-nats
+    name: check feature flags (ubuntu-latest / stable)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Install stable Rust on ubuntu-latest
+        id:   install-rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Restore cached build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-${{ steps.install-rust.outputs.cachekey }}-${{ hashFiles('**/Cargo.toml') }}
+          save-if: false # checks only, no full build to cache.
+      - name: Install cargo hack
+        run: cargo install cargo-hack
+      - name: Check feature combinations
+        run: bash .cargo-hack-check.sh
+
   check_docs:
     defaults:
       run:

--- a/async-nats/.cargo-hack-check.sh
+++ b/async-nats/.cargo-hack-check.sh
@@ -37,12 +37,19 @@ echo ""
 echo "=== Strategy 3: Test with aws-lc-rs backend ==="
 cargo check --no-default-features --features jetstream,kv,service,nkeys,aws-lc-rs
 cargo check --no-default-features --features aws-lc-rs
+# FIPS mode (implies aws-lc-rs)
+cargo check --no-default-features --features fips
 
 echo ""
 echo "=== Strategy 4: Test server version flags ==="
 cargo check --features server_2_10
 cargo check --features server_2_11
 cargo check --features server_2_12
+cargo check --features server_2_14
+
+echo ""
+echo "=== Strategy 5: Experimental ==="
+cargo check --features experimental
 
 echo ""
 echo "All checks passed!"


### PR DESCRIPTION
## Problem

The `check_features` job in `main.yml` runs `cargo hack check --feature-powerset`. With ~18 features the powerset explodes into hundreds of thousands of combinations, and the job has been cancelled at the 6h GitHub Actions cap on **every** recent push to main — feature-combination checking has never actually passed, while burning 6h of CI per push. Meanwhile `async-nats/.cargo-hack-check.sh` (written precisely to avoid the explosion) was referenced by no workflow.

This is exactly how feature-gated breakage can ship undetected (e.g. cfg-gated builder code only compiled under specific flag sets).

## Changes

- `main.yml`: `check_features` now runs `bash .cargo-hack-check.sh` with `timeout-minutes: 45` instead of the powerset.
- `test.yml`: new `check_features` job — feature combinations are now checked on pull requests, not only after merge.
- `.cargo-hack-check.sh`: extended for recent feature additions — `server_2_14` (now in defaults), `fips`, and `experimental`. Chrono-backend combinations were already covered.

## Verification

Full script run locally with `RUSTFLAGS="-D warnings"`: all strategies pass (`--each-feature` with ring, curated combinations incl. chrono backend, aws-lc-rs/fips, all server version flags, experimental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)