### PR TITLE
Populate ObjectInfo modified from server message timestamp

### DIFF
--- a/async-nats/src/jetstream/object_store/mod.rs
+++ b/async-nats/src/jetstream/object_store/mod.rs
@@ -255,13 +255,16 @@ impl ObjectStore {
                 }
                 _ => InfoError::with_source(InfoErrorKind::Other, err),
             })?;
-        let object_info =
+        let mut object_info =
             serde_json::from_slice::<ObjectInfo>(&message.payload).map_err(|err| {
                 InfoError::with_source(
                     InfoErrorKind::Other,
                     format!("failed to decode info payload: {err}"),
                 )
             })?;
+        // Per ADR-20, `modified` is the server message timestamp, not the `mtime`
+        // stored in the JSON payload (which some clients leave zeroed)
+        object_info.modified = Some(message.time);
 
         Ok(object_info)
     }
@@ -903,13 +906,19 @@ impl Stream for List {
                             if info.pending == 0 {
                                 self.done = true;
                             }
-                            let response: ObjectInfo = serde_json::from_slice(&message.payload)
+                            // Copy the server timestamp out before borrowing the
+                            // payload below, since `info` borrows `message`
+                            let modified = info.published;
+                            let mut response: ObjectInfo = serde_json::from_slice(&message.payload)
                                 .map_err(|err| {
                                     ListerError::with_source(
                                         ListerErrorKind::Other,
                                         format!("failed deserializing object info: {err}"),
                                     )
                                 })?;
+                            // Per ADR-20, `modified` is the server message timestamp,
+                            // not the `mtime` stored in the JSON payload
+                            response.modified = Some(modified);
                             if response.deleted {
                                 continue;
                             }

--- a/async-nats/tests/object_store.rs
+++ b/async-nats/tests/object_store.rs
@@ -319,6 +319,81 @@ mod object_store {
     }
 
     #[tokio::test]
+    async fn modified_cross_client_parity() {
+        // Guards the cross-client parity fix: a foreign client (e.g. nats.go) may
+        // store a meta message whose JSON `mtime` is the zero time. Both Rust read
+        // paths must return the server message timestamp instead of that zeroed
+        // `mtime`, matching ADR-20 and the behavior of other clients
+        let server = nats_server::run_server("tests/configs/jetstream.conf");
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+        let jetstream = async_nats::jetstream::new(client);
+
+        let bucket = jetstream
+            .create_object_store(async_nats::jetstream::object_store::Config {
+                bucket: "bucket".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        // Simulate a foreign writer, this will publish a meta message with mtime = zero time
+        let name = "FOO";
+        let encoded = base64::engine::general_purpose::URL_SAFE.encode(name);
+        let subject = format!("$O.bucket.M.{encoded}");
+        let payload = format!(
+            r#"{{"name":"{name}","bucket":"bucket","nuid":"zzzzzzzzzzzzzzzzzzzzzz","size":4,"chunks":1,"mtime":"0001-01-01T00:00:00Z"}}"#
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("Nats-Rollup", "sub");
+        jetstream
+            .publish_with_headers(subject.clone(), headers, payload.clone().into())
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+
+        // The zero time as parsed from that JSON, in the crate's DateTime type
+        // (chrono or time depending on features). This is what a buggy read would return.
+        let zero = serde_json::from_str::<ObjectInfo>(&payload)
+            .unwrap()
+            .modified
+            .unwrap();
+
+        // The server timestamp IS available on the stored message
+        let raw = jetstream
+            .get_stream("OBJ_bucket")
+            .await
+            .unwrap()
+            .get_last_raw_message_by_subject(&subject)
+            .await
+            .unwrap();
+        let server_time = raw.time;
+        println!("server message time: {server_time}");
+
+        // info() path
+        let info_modified = bucket.info(name).await.unwrap().modified;
+        println!("info().modified:     {info_modified:?}");
+
+        // list() path
+        let mut list = bucket.list().await.unwrap();
+        let listed = list.next().await.unwrap().unwrap();
+        println!("list().modified:     {:?}", listed.modified);
+
+        // Both read paths must return the server timestamp, not the JSON zero time.
+        assert_ne!(server_time, zero, "server time should be non-zero");
+        assert_eq!(
+            info_modified,
+            Some(server_time),
+            "info() should return the server message timestamp"
+        );
+        assert_eq!(
+            listed.modified,
+            Some(server_time),
+            "list() should return the server message timestamp"
+        );
+    }
+
+    #[tokio::test]
     async fn delete() {
         let server = nats_server::run_server("tests/configs/jetstream.conf");
         let client = async_nats::connect(server.client_url()).await.unwrap();


### PR DESCRIPTION
Fixes #1605 

## Overview

`ObjectStore::info()` and `list()` populate `ObjectInfo.modified` directly from
the `mtime` field of the meta message JSON payload. Per [ADR-20](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-20.md#objectinfo-storage), the value
returned to the user should be the server-assigned message timestamp, not the
stored `mtime`, which some clients (e.g. nats.go) leave zeroed in the JSON.

As a result, an object written by such a client is read back in async-nats with
`modified` set to the zero time (`0001-01-01T00:00:00Z`) instead of the real
modification time, breaking cross-client parity.


## Changes

- `info()`: substitute `message.time` (the server publish time, already fetched)
  into `modified` after deserializing.
- `Lister::poll_next`: substitute `info.published` into `modified` (copied out
  before the payload borrow, since `info` borrows the message).
- Add `modified_cross_client_parity` test: simulates a foreign writer storing a
  zeroed `mtime` and asserts both read paths return the server timestamp.

Both paths use timestamps that were already being fetched and discarded, so
there should be no extra round-trip.

Signed-off-by: Prasant Koirala <koiralaprashanta10@gmail.com>