### PR TITLE
Avoid panic in Subscriber::drop when dropped outside a runtime

### DIFF
--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1421,16 +1421,18 @@ impl From<tokio::sync::mpsc::error::SendError<Command>> for UnsubscribeError {
 impl Drop for Subscriber {
     fn drop(&mut self) {
         self.receiver.close();
-        tokio::spawn({
-            let sender = self.sender.clone();
-            let sid = self.sid;
-            async move {
-                sender
-                    .send(Command::Unsubscribe { sid, max: None })
-                    .await
-                    .ok();
-            }
-        });
+        // Best-effort unsubscribe. `tokio::spawn` would panic here since `Drop` can run outside
+        // any runtime (unwinding, teardown, a plain thread), so use synchronous `try_send`.
+        // If the channel is full or closed the unsubscribe is dropped; the server keeps interest
+        // only until the next unsubscribe or disconnect, so nothing lasting leaks.
+        // Debug, not warn: a closed channel is routine teardown and saturation already surfaces as
+        // `Event::SlowConsumer`.
+        if let Err(err) = self.sender.try_send(Command::Unsubscribe {
+            sid: self.sid,
+            max: None,
+        }) {
+            debug!("failed to send unsubscribe in Subscriber::drop: {err}");
+        }
     }
 }
 

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1437,18 +1437,27 @@ impl Drop for Subscriber {
     fn drop(&mut self) {
         self.receiver.close();
         // Best-effort unsubscribe. `Drop` can run outside a Tokio runtime (unwinding, teardown,
-        // plain threads), so only spawn when a runtime is available and otherwise use
-        // synchronous `try_send` to avoid panics.
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            let sender = self.sender.clone();
-            let sid = self.sid;
-            let _ = handle.spawn(async move {
-                if let Err(err) = sender.send(drop_unsubscribe_command(sid)).await {
-                    debug!("failed to send unsubscribe in Subscriber::drop: {err}");
+        // plain threads), so start with synchronous `try_send` and only spawn an async retry when
+        // the command channel is full and a runtime is available.
+        match self.sender.try_send(drop_unsubscribe_command(self.sid)) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(command)) => {
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    let sender = self.sender.clone();
+                    std::mem::drop(handle.spawn(async move {
+                        if let Err(err) = sender.send(command).await {
+                            debug!("failed to send unsubscribe in Subscriber::drop: {err}");
+                        }
+                    }));
+                } else {
+                    debug!(
+                        "failed to send unsubscribe in Subscriber::drop: command channel full and no runtime"
+                    );
                 }
-            });
-        } else if let Err(err) = self.sender.try_send(drop_unsubscribe_command(self.sid)) {
-            debug!("failed to send unsubscribe in Subscriber::drop: {err}");
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                debug!("failed to send unsubscribe in Subscriber::drop: command channel closed");
+            }
         }
     }
 }

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -1275,13 +1275,20 @@ impl From<io::Error> for ConnectError {
 /// Retrieves messages from given `subscription` created by [Client::subscribe].
 ///
 /// Implements [futures_util::stream::Stream] for ergonomic async message processing.
+/// For deterministic cleanup, prefer calling [`Subscriber::unsubscribe`] or
+/// [`Subscriber::drain`]. Dropping a [`Subscriber`] is best-effort.
 ///
 /// # Examples
-/// ```
+/// ```no_run
+/// # use futures_util::StreamExt;
 /// # #[tokio::main]
 /// # async fn main() ->  Result<(), async_nats::Error> {
-/// let mut nc = async_nats::connect("demo.nats.io").await?;
-/// # nc.publish("test", "data".into()).await?;
+/// let client = async_nats::connect("demo.nats.io").await?;
+/// let mut subscriber = client.subscribe("events.>").await?;
+///
+/// while let Some(message) = subscriber.next().await {
+///     println!("received: {message:?}");
+/// }
 /// # Ok(())
 /// # }
 /// ```
@@ -1308,7 +1315,7 @@ impl Subscriber {
     /// Unsubscribes from subscription, draining all remaining messages.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::Error> {
     /// let client = async_nats::connect("demo.nats.io").await?;
@@ -1319,6 +1326,9 @@ impl Subscriber {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// This method is the reliable unsubscribe path: it waits for the command to be accepted by
+    /// the client's command channel. Dropping [`Subscriber`] is best-effort.
     pub async fn unsubscribe(&mut self) -> Result<(), UnsubscribeError> {
         self.sender
             .send(Command::Unsubscribe {
@@ -1331,11 +1341,11 @@ impl Subscriber {
     }
 
     /// Unsubscribes from subscription after reaching given number of messages.
-    /// This is the total number of messages received by this subscription in it's whole
+    /// This is the total number of messages received by this subscription in its whole
     /// lifespan. If it already reached or surpassed the passed value, it will immediately stop.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use futures_util::StreamExt;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), async_nats::Error> {
@@ -1418,19 +1428,26 @@ impl From<tokio::sync::mpsc::error::SendError<Command>> for UnsubscribeError {
     }
 }
 
+#[inline]
+fn drop_unsubscribe_command(sid: u64) -> Command {
+    Command::Unsubscribe { sid, max: None }
+}
+
 impl Drop for Subscriber {
     fn drop(&mut self) {
         self.receiver.close();
-        // Best-effort unsubscribe. `tokio::spawn` would panic here since `Drop` can run outside
-        // any runtime (unwinding, teardown, a plain thread), so use synchronous `try_send`.
-        // If the channel is full or closed the unsubscribe is dropped; the server keeps interest
-        // only until the next unsubscribe or disconnect, so nothing lasting leaks.
-        // Debug, not warn: a closed channel is routine teardown and saturation already surfaces as
-        // `Event::SlowConsumer`.
-        if let Err(err) = self.sender.try_send(Command::Unsubscribe {
-            sid: self.sid,
-            max: None,
-        }) {
+        // Best-effort unsubscribe. `Drop` can run outside a Tokio runtime (unwinding, teardown,
+        // plain threads), so only spawn when a runtime is available and otherwise use
+        // synchronous `try_send` to avoid panics.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let sender = self.sender.clone();
+            let sid = self.sid;
+            let _ = handle.spawn(async move {
+                if let Err(err) = sender.send(drop_unsubscribe_command(sid)).await {
+                    debug!("failed to send unsubscribe in Subscriber::drop: {err}");
+                }
+            });
+        } else if let Err(err) = self.sender.try_send(drop_unsubscribe_command(self.sid)) {
             debug!("failed to send unsubscribe in Subscriber::drop: {err}");
         }
     }
@@ -1841,6 +1858,9 @@ use crate::message::OutboundMessage;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::mpsc;
+    use tokio::sync::mpsc::error::TryRecvError;
+    use tokio::time::{timeout, Duration};
 
     #[test]
     fn server_address_ipv6() {
@@ -1930,5 +1950,81 @@ mod tests {
             let mut addrs_iter = arr.to_server_addrs().unwrap();
             assert_eq!(addrs_iter.next().unwrap().port(), expected_port);
         }
+    }
+
+    #[tokio::test]
+    async fn drop_subscriber_in_runtime_full_command_channel_eventually_unsubscribes() {
+        let sid = 42;
+        let (sender, mut receiver) = mpsc::channel(1);
+        sender.try_send(Command::Reconnect).unwrap();
+
+        let (_message_sender, message_receiver) = mpsc::channel(1);
+        let subscriber = Subscriber::new(sid, sender, message_receiver);
+        drop(subscriber);
+
+        assert!(matches!(receiver.recv().await, Some(Command::Reconnect)));
+        assert!(matches!(
+            timeout(Duration::from_secs(1), receiver.recv()).await.unwrap(),
+            Some(Command::Unsubscribe {
+                sid: recv_sid,
+                max: None
+            }) if recv_sid == sid
+        ));
+    }
+
+    #[test]
+    fn drop_subscriber_outside_runtime_open_command_channel_sends_unsubscribe() {
+        let sid = 17;
+        let (sender, mut receiver) = mpsc::channel(1);
+
+        let (_message_sender, message_receiver) = mpsc::channel(1);
+        let subscriber = Subscriber::new(sid, sender, message_receiver);
+        drop(subscriber);
+
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(Command::Unsubscribe {
+                sid: recv_sid,
+                max: None
+            }) if recv_sid == sid
+        ));
+    }
+
+    #[test]
+    fn drop_subscriber_outside_runtime_full_command_channel_is_best_effort() {
+        let (sender, mut receiver) = mpsc::channel(1);
+        sender.try_send(Command::Reconnect).unwrap();
+
+        let (_message_sender, message_receiver) = mpsc::channel(1);
+        let subscriber = Subscriber::new(7, sender, message_receiver);
+        drop(subscriber);
+
+        assert!(matches!(receiver.try_recv(), Ok(Command::Reconnect)));
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(TryRecvError::Disconnected)
+        ));
+    }
+
+    #[test]
+    fn drop_subscriber_outside_runtime_closed_command_channel_does_not_panic() {
+        let (sender, receiver) = mpsc::channel(1);
+        drop(receiver);
+
+        let (_message_sender, message_receiver) = mpsc::channel(1);
+        let subscriber = Subscriber::new(9, sender, message_receiver);
+        drop(subscriber);
+    }
+
+    #[tokio::test]
+    async fn drop_subscriber_in_runtime_closed_command_channel_does_not_panic() {
+        let (sender, receiver) = mpsc::channel(1);
+        drop(receiver);
+
+        let (_message_sender, message_receiver) = mpsc::channel(1);
+        let subscriber = Subscriber::new(11, sender, message_receiver);
+        drop(subscriber);
+
+        tokio::task::yield_now().await;
     }
 }

--- a/async-nats/src/options.rs
+++ b/async-nats/src/options.rs
@@ -825,11 +825,11 @@ impl ConnectOptions {
         self
     }
 
-    /// By default, Client dispatches op's to the Client onto the channel with capacity of 128.
-    /// This option enables overriding it.
+    /// By default, Client dispatches commands onto a client channel with capacity `2048`.
+    /// This option lets you override that capacity.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     /// async_nats::ConnectOptions::new()

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -1874,4 +1874,19 @@ mod client {
             "disconnected too early ({elapsed:?}) to be the ping keepalive"
         );
     }
+
+    // `Subscriber::drop` must not assume a live runtime: dropping outside a runtime context
+    // (unwinding, teardown, a plain thread) must not panic.
+    #[test]
+    fn drop_subscriber_outside_runtime() {
+        let server = nats_server::run_basic_server();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let subscription = rt.block_on(async {
+            let client = async_nats::connect(server.client_url()).await.unwrap();
+            client.subscribe("foo").await.unwrap()
+        });
+        // `block_on` has returned, so this drop runs outside the runtime context — the condition
+        // under test.
+        drop(subscription);
+    }
 }

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -535,6 +535,131 @@ mod client {
     }
 
     #[tokio::test]
+    async fn dropped_subscriber_not_replayed_after_reconnect() {
+        let server = nats_server::run_basic_server();
+        let server_port = server.client_port();
+
+        let listen_fd = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_port = listen_fd.local_addr().unwrap().port();
+
+        let subject = "drop.reconnect";
+        let msg_prefix = format!("MSG {subject} ");
+        let seen = Arc::new(AtomicU64::new(0));
+        let seen_proxy = Arc::clone(&seen);
+
+        tokio::task::spawn(async move {
+            loop {
+                let Ok((downstream, _)) = listen_fd.accept().await else {
+                    break;
+                };
+
+                let upstream = tokio::net::TcpStream::connect(format!("127.0.0.1:{server_port}"))
+                    .await
+                    .unwrap();
+
+                let seen = Arc::clone(&seen_proxy);
+                let msg_prefix = msg_prefix.clone();
+
+                tokio::task::spawn(async move {
+                    let (dr, mut dw) = tokio::io::split(downstream);
+                    let (sr, mut sw) = tokio::io::split(upstream);
+
+                    let c2s = async move {
+                        let mut reader = tokio::io::BufReader::new(dr);
+                        let mut line = String::new();
+                        loop {
+                            line.clear();
+                            let n = reader.read_line(&mut line).await.unwrap_or(0);
+                            if n == 0 {
+                                break;
+                            }
+                            sw.write_all(line.as_bytes()).await.ok();
+                        }
+                    };
+
+                    let s2c = async move {
+                        let mut reader = tokio::io::BufReader::new(sr);
+                        let mut line = String::new();
+
+                        loop {
+                            line.clear();
+                            let n = reader.read_line(&mut line).await.unwrap_or(0);
+                            if n == 0 {
+                                break;
+                            }
+
+                            if line.starts_with(&msg_prefix) {
+                                seen.fetch_add(1, Ordering::Relaxed);
+                            }
+
+                            dw.write_all(line.as_bytes()).await.ok();
+
+                            if line.starts_with("MSG ") {
+                                let num_bytes: usize =
+                                    line.trim().rsplit(' ').next().unwrap().parse().unwrap();
+                                let mut payload = vec![0u8; num_bytes + 2];
+                                reader.read_exact(&mut payload).await.unwrap();
+                                dw.write_all(&payload).await.ok();
+                            }
+                        }
+                    };
+
+                    tokio::select! {
+                        _ = c2s => {},
+                        _ = s2c => {},
+                    }
+                });
+            }
+        });
+
+        let (dctx, mut dcrx) = tokio::sync::mpsc::channel(1);
+        let (rctx, mut rcrx) = tokio::sync::mpsc::channel(1);
+        let client = async_nats::ConnectOptions::new()
+            .event_callback(move |event| {
+                let dctx = dctx.clone();
+                let rctx = rctx.clone();
+                async move {
+                    match event {
+                        Event::Disconnected => dctx.send(()).await.unwrap(),
+                        Event::Connected => rctx.send(()).await.unwrap(),
+                        _ => (),
+                    }
+                }
+            })
+            .connect(format!("127.0.0.1:{proxy_port}"))
+            .await
+            .unwrap();
+
+        let subscription = client.subscribe(subject).await.unwrap();
+        drop(subscription);
+
+        client.force_reconnect().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            // initial connect event
+            rcrx.recv().await.unwrap();
+            dcrx.recv().await.unwrap();
+            rcrx.recv().await.unwrap();
+        })
+        .await
+        .unwrap();
+
+        for _ in 0..5 {
+            client
+                .publish(subject, Bytes::from_static(b"data"))
+                .await
+                .unwrap();
+        }
+        client.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert_eq!(
+            seen.load(Ordering::Relaxed),
+            0,
+            "dropped subscriber should not be replayed after reconnect"
+        );
+    }
+
+    #[tokio::test]
     async fn connect_invalid() {
         assert!(async_nats::connect("localhost:1111").await.is_err());
     }


### PR DESCRIPTION
Fixes #1607.

## Problem

`Subscriber::drop` unconditionally called `tokio::spawn` to send the final `Unsubscribe` command:

```rust
tokio::spawn({
    let sender = self.sender.clone();
    let sid = self.sid;
    async move { sender.send(Command::Unsubscribe { sid, max: None }).await.ok(); }
});
```

`tokio::spawn` panics when called outside a Tokio runtime context (`there is no reactor running, must be called from the context of a Tokio 1.x runtime`). `Drop` can run on arbitrary threads, during unwinding, and at teardown — so a `Subscriber` dropped in any of those contexts aborts.

## Fix

Replace the spawn with a synchronous, runtime-independent `try_send`, which removes the runtime dependency entirely (no `Handle::try_current()` guard needed). This matches the crate's existing best-effort `Drop` idioms (`PublishAckFuture::drop`, the connection handler's event sends).

On a full or closed command channel the unsubscribe is dropped and logged at `debug`; the server retains interest only until the next unsubscribe or disconnect, so nothing lasting leaks. `debug` (not `warn`) mirrors how the message-send path handles the same `TrySendError` cases: a closed channel is routine teardown, and channel saturation is already surfaced via `Event::SlowConsumer`. Callers needing guaranteed, back-pressured delivery still have `Subscriber::unsubscribe().await` / `drain().await`.

## Test

Adds `drop_subscriber_outside_runtime`, which builds the client inside a runtime and drops the subscriber outside the runtime context. It panics on the old implementation and passes with the fix.