### PR TITLE
Add RAII guard around request() to cleanup

### DIFF
--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -85,6 +85,7 @@ fn max_payload_error(sizes: (usize, usize)) -> PublishError {
     )
 }
 
+#[derive(Debug)]
 pub(crate) struct RequestDropGuard {
     receiver: oneshot::Receiver<Message>,
     respond: Option<Subject>,

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -18,7 +18,7 @@ use std::future::Future;
 use crate::connection::State;
 use crate::message::OutboundMessage;
 use crate::subject::ToSubject;
-use crate::ServerInfo;
+use crate::{ServerInfo, Subject};
 
 use super::{header::HeaderMap, status::StatusCode, Command, Message, Subscriber};
 use crate::error::Error;
@@ -83,6 +83,74 @@ fn max_payload_error(sizes: (usize, usize)) -> PublishError {
         PublishErrorKind::MaxPayloadExceeded,
         max_payload_message(sizes),
     )
+}
+
+pub(crate) struct RequestDropGuard {
+    receiver: oneshot::Receiver<Message>,
+    respond: Option<Subject>,
+    client_sender: mpsc::WeakSender<Command>,
+}
+
+impl RequestDropGuard {
+    fn new(
+        receiver: oneshot::Receiver<Message>,
+        respond: Subject,
+        client_sender: mpsc::WeakSender<Command>,
+    ) -> Self {
+        Self {
+            receiver,
+            respond: Some(respond),
+            client_sender,
+        }
+    }
+}
+
+impl Future for RequestDropGuard {
+    type Output = Result<Message, oneshot::error::RecvError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.receiver.try_poll_unpin(cx)
+    }
+}
+
+impl Drop for RequestDropGuard {
+    fn drop(&mut self) {
+        match self.receiver.try_recv() {
+            // The message was sent, we just never consumed it
+            Ok(_) => return,
+            // The sender was dropped, or a message has already been sent + consumed
+            Err(oneshot::error::TryRecvError::Closed) => return,
+            // No message was sent -- this is the path we need to cleanup
+            Err(oneshot::error::TryRecvError::Empty) => (),
+        }
+
+        // client_sender is weak; if upgrade fails, Client was dropped; no cleanup needed
+        let Some(client_sender) = self.client_sender.upgrade() else {
+            return;
+        };
+
+        // should always be Some(); making it Option saves us an extra clone
+        let Some(respond) = self.respond.take() else {
+            return;
+        };
+
+        let op = Command::DiscardRespond { respond };
+
+        // try the happy-path cleanup (no runtime)
+        let op = match client_sender.try_send(op) {
+            Ok(_) => return,
+            Err(err) => err.into_inner(),
+        };
+
+        // fall-back to using the runtime, but only if one is available
+        let Ok(rt) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+
+        rt.spawn(async move {
+            let _ = client_sender.send(op).await;
+        });
+    }
 }
 
 /// Client is a `Cloneable` handle to NATS connection.
@@ -718,31 +786,22 @@ impl Client {
                 )),
             }
         } else {
-            let (sender, receiver) = oneshot::channel();
-
             let payload = request.payload.unwrap_or_default();
-            let respond = self.new_inbox().into();
             let headers = request.headers;
 
-            self.sender
-                .send(Command::Request {
-                    subject,
-                    payload,
-                    respond,
-                    headers,
-                    sender,
-                })
-                .map_err(|err| RequestError::with_source(RequestErrorKind::Other, err))
-                .await?;
+            let guarded_receiver = self
+                .send_guarded_request(subject, payload, headers)
+                .await
+                .map_err(|err| RequestError::with_source(RequestErrorKind::Other, err))?;
 
             let timeout = request.timeout.unwrap_or(self.request_timeout);
             let request = match timeout {
                 Some(timeout) => {
-                    tokio::time::timeout(timeout, receiver)
+                    tokio::time::timeout(timeout, guarded_receiver)
                         .map_err(|err| RequestError::with_source(RequestErrorKind::TimedOut, err))
                         .await?
                 }
-                None => receiver.await,
+                None => guarded_receiver.await,
             };
 
             match request {
@@ -758,6 +817,30 @@ impl Client {
                 Err(err) => Err(RequestError::with_source(RequestErrorKind::Other, err)),
             }
         }
+    }
+
+    #[expect(clippy::result_large_err)]
+    pub(crate) async fn send_guarded_request(
+        &self,
+        subject: Subject,
+        payload: Bytes,
+        headers: Option<HeaderMap>,
+    ) -> Result<RequestDropGuard, mpsc::error::SendError<Command>> {
+        let (sender, receiver) = oneshot::channel();
+        let respond: Subject = self.new_inbox().into();
+
+        self.sender
+            .send(Command::Request {
+                subject,
+                payload,
+                respond: respond.clone(),
+                headers,
+                sender,
+            })
+            .await?;
+
+        let guard = RequestDropGuard::new(receiver, respond, self.sender.downgrade());
+        Ok(guard)
     }
 
     /// Create a new globally unique inbox which can be used for replies.

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -1153,6 +1153,16 @@ impl Client {
     pub fn statistics(&self) -> Arc<Statistics> {
         self.connection_stats.clone()
     }
+
+    #[cfg(test)]
+    async fn multiplexer_stats(
+        &self,
+    ) -> Result<crate::MultiplexerStats, Box<dyn std::error::Error>> {
+        let (tx, rx) = oneshot::channel();
+
+        self.sender.send(Command::MultiplexerStats(tx)).await?;
+        Ok(rx.await?)
+    }
 }
 
 /// Used for building customized requests.
@@ -1427,4 +1437,41 @@ pub struct Statistics {
     /// Number of times connection was established.
     /// Initial connect will be counted as well, then all successful reconnects.
     pub connects: AtomicU64,
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use futures_util::StreamExt as _;
+
+    #[tokio::test]
+    async fn request_with_no_response_does_not_leak_memory() {
+        const SUBJECT: &str = "horizon";
+
+        let server = nats_server::run_basic_server();
+        let client = crate::connect(server.client_url()).await.unwrap();
+        let mut subscriber = client.subscribe(SUBJECT).await.unwrap();
+        client.flush().await.unwrap();
+
+        let stats = client.multiplexer_stats().await.unwrap();
+        assert_eq!(stats.waiting_senders, 0);
+
+        {
+            let request = client.request(SUBJECT, Bytes::from_static(b"spaceship"));
+            tokio::pin!(request);
+
+            tokio::select! {
+                result = &mut request => panic!("request unexpectedly completed: {result:?}"),
+                message = subscriber.next() => {
+                    message.expect("subscriber should receive the request");
+                }
+            }
+
+            let stats = client.multiplexer_stats().await.unwrap();
+            assert_eq!(stats.waiting_senders, 1);
+        }
+
+        let stats = client.multiplexer_stats().await.unwrap();
+        assert_eq!(stats.waiting_senders, 0);
+    }
 }

--- a/async-nats/src/client.rs
+++ b/async-nats/src/client.rs
@@ -89,6 +89,7 @@ fn max_payload_error(sizes: (usize, usize)) -> PublishError {
 pub(crate) struct RequestDropGuard {
     receiver: oneshot::Receiver<Message>,
     respond: Option<Subject>,
+    tokio_runtime_handle: tokio::runtime::Handle,
     client_sender: mpsc::WeakSender<Command>,
 }
 
@@ -96,11 +97,13 @@ impl RequestDropGuard {
     fn new(
         receiver: oneshot::Receiver<Message>,
         respond: Subject,
+        tokio_runtime_handle: tokio::runtime::Handle,
         client_sender: mpsc::WeakSender<Command>,
     ) -> Self {
         Self {
             receiver,
             respond: Some(respond),
+            tokio_runtime_handle,
             client_sender,
         }
     }
@@ -143,12 +146,8 @@ impl Drop for RequestDropGuard {
             Err(err) => err.into_inner(),
         };
 
-        // fall-back to using the runtime, but only if one is available
-        let Ok(rt) = tokio::runtime::Handle::try_current() else {
-            return;
-        };
-
-        rt.spawn(async move {
+        // fall-back to using the runtime
+        self.tokio_runtime_handle.spawn(async move {
             let _ = client_sender.send(op).await;
         });
     }
@@ -170,6 +169,7 @@ pub struct Client {
     max_payload: Arc<AtomicUsize>,
     connection_stats: Arc<Statistics>,
     skip_subject_validation: bool,
+    tokio_runtime_handle: tokio::runtime::Handle,
 }
 
 pub mod traits {
@@ -312,6 +312,7 @@ impl Client {
         max_payload: Arc<AtomicUsize>,
         statistics: Arc<Statistics>,
         skip_subject_validation: bool,
+        tokio_runtime_handle: tokio::runtime::Handle,
     ) -> Client {
         let poll_sender = PollSender::new(sender.clone());
         Client {
@@ -326,6 +327,7 @@ impl Client {
             max_payload,
             connection_stats: statistics,
             skip_subject_validation,
+            tokio_runtime_handle,
         }
     }
 
@@ -840,7 +842,12 @@ impl Client {
             })
             .await?;
 
-        let guard = RequestDropGuard::new(receiver, respond, self.sender.downgrade());
+        let guard = RequestDropGuard::new(
+            receiver,
+            respond,
+            self.tokio_runtime_handle.clone(),
+            self.sender.downgrade(),
+        );
         Ok(guard)
     }
 

--- a/async-nats/src/jetstream/context.rs
+++ b/async-nats/src/jetstream/context.rs
@@ -13,13 +13,14 @@
 //
 //! Manage operations on [Context], create/delete/update [Stream]
 
+use crate::client::RequestDropGuard;
 use crate::error::Error;
 use crate::jetstream::account::Account;
 use crate::jetstream::message::PublishMessage;
 use crate::jetstream::publish::PublishAck;
 use crate::jetstream::response::Response;
 use crate::subject::ToSubject;
-use crate::{is_valid_subject, jetstream, Client, Command, Message, StatusCode};
+use crate::{is_valid_subject, jetstream, Client, Message, StatusCode};
 use bytes::Bytes;
 use futures_util::future::BoxFuture;
 use futures_util::{Future, StreamExt, TryFutureExt};
@@ -34,7 +35,7 @@ use std::pin::Pin;
 use std::str::from_utf8;
 use std::sync::Arc;
 use std::task::Poll;
-use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, TryAcquireError};
+use tokio::sync::{mpsc, OwnedSemaphorePermit, TryAcquireError};
 use tokio::time::Duration;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::debug;
@@ -115,14 +116,13 @@ pub struct Context {
     pub(crate) prefix: String,
     pub(crate) timeout: Duration,
     pub(crate) max_ack_semaphore: Arc<tokio::sync::Semaphore>,
-    pub(crate) ack_sender:
-        tokio::sync::mpsc::Sender<(oneshot::Receiver<Message>, OwnedSemaphorePermit)>,
+    pub(crate) ack_sender: tokio::sync::mpsc::Sender<(RequestDropGuard, OwnedSemaphorePermit)>,
     pub(crate) backpressure_on_inflight: bool,
     pub(crate) semaphore_capacity: usize,
 }
 
 fn spawn_acker(
-    rx: ReceiverStream<(oneshot::Receiver<Message>, OwnedSemaphorePermit)>,
+    rx: ReceiverStream<(RequestDropGuard, OwnedSemaphorePermit)>,
     ack_timeout: Duration,
     concurrency: Option<usize>,
 ) -> tokio::task::JoinHandle<()> {
@@ -318,10 +318,9 @@ where
 
     /// Build the [Context] with the given settings.
     pub fn build(self, client: Client) -> Context {
-        let (tx, rx) = tokio::sync::mpsc::channel::<(
-            oneshot::Receiver<Message>,
-            OwnedSemaphorePermit,
-        )>(self.semaphore_capacity);
+        let (tx, rx) = tokio::sync::mpsc::channel::<(RequestDropGuard, OwnedSemaphorePermit)>(
+            self.semaphore_capacity,
+        );
         let stream = ReceiverStream::new(rx);
         spawn_acker(stream, self.ack_timeout, self.concurrency_limit);
         Context {
@@ -521,29 +520,18 @@ impl Context {
                 })?
         };
 
-        let (sender, receiver) = oneshot::channel();
-
-        let respond = self.client.new_inbox().into();
-
-        let send_fut = self
+        let guarded_receiver_fut = self
             .client
-            .sender
-            .send(Command::Request {
-                subject,
-                payload: publish.payload,
-                respond,
-                headers: publish.headers,
-                sender,
-            })
+            .send_guarded_request(subject, publish.payload, publish.headers)
             .map_err(|err| PublishError::with_source(PublishErrorKind::Other, err));
 
-        tokio::time::timeout(self.timeout, send_fut)
+        let guarded_receiver = tokio::time::timeout(self.timeout, guarded_receiver_fut)
             .map_err(|_elapsed| PublishError::new(PublishErrorKind::TimedOut))
             .await??;
 
         Ok(PublishAckFuture {
             timeout: self.timeout,
-            subscription: Some(receiver),
+            subscription: Some(guarded_receiver),
             permit: Some(permit),
             tx: self.ack_sender.clone(),
         })
@@ -1864,9 +1852,9 @@ pub type PublishError = Error<PublishErrorKind>;
 #[derive(Debug)]
 pub struct PublishAckFuture {
     timeout: Duration,
-    subscription: Option<oneshot::Receiver<Message>>,
+    subscription: Option<RequestDropGuard>,
     permit: Option<OwnedSemaphorePermit>,
-    tx: mpsc::Sender<(oneshot::Receiver<Message>, OwnedSemaphorePermit)>,
+    tx: mpsc::Sender<(RequestDropGuard, OwnedSemaphorePermit)>,
 }
 
 impl Drop for PublishAckFuture {

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -381,9 +381,17 @@ pub(crate) enum ServerOp {
 )]
 pub type PublishMessage = crate::message::OutboundMessage;
 
+#[cfg(test)]
+#[derive(Debug)]
+struct MultiplexerStats {
+    pub waiting_senders: usize,
+}
+
 /// `Command` represents all commands that a [`Client`] can handle
 #[derive(Debug)]
 pub(crate) enum Command {
+    #[cfg(test)]
+    MultiplexerStats(oneshot::Sender<MultiplexerStats>),
     Publish(OutboundMessage),
     Request {
         subject: Subject,
@@ -825,6 +833,20 @@ impl ConnectionHandler {
 
     fn handle_command(&mut self, command: Command) {
         match command {
+            #[cfg(test)]
+            Command::MultiplexerStats(observer) => {
+                let stats = MultiplexerStats {
+                    waiting_senders: self
+                        .multiplexer
+                        .as_ref()
+                        .map(|v| v.senders.len())
+                        .unwrap_or(0),
+                };
+
+                if let Err(err) = observer.send(stats) {
+                    tracing::warn!(?err);
+                }
+            }
             Command::Unsubscribe { sid, max } => {
                 if let Some(subscription) = self.subscriptions.get_mut(&sid) {
                     subscription.max = max;

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -226,7 +226,6 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use tokio::io;
 use tokio::sync::mpsc;
-use tokio::task;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -1123,6 +1122,8 @@ pub async fn connect_with_options<A: ToServerAddrs>(
     let (info_sender, info_watcher) = tokio::sync::watch::channel(info.clone());
     let (sender, mut receiver) = mpsc::channel(options.sender_capacity);
 
+    let handle = tokio::runtime::Handle::current();
+
     let client = Client::new(
         info_watcher,
         state_rx,
@@ -1133,9 +1134,10 @@ pub async fn connect_with_options<A: ToServerAddrs>(
         max_payload,
         statistics,
         options.skip_subject_validation,
+        handle.clone(),
     );
 
-    task::spawn(async move {
+    handle.spawn(async move {
         while let Some(event) = events_rx.recv().await {
             tracing::info!("event: {}", event);
             if let Some(event_callback) = &options.event_callback {
@@ -1144,7 +1146,7 @@ pub async fn connect_with_options<A: ToServerAddrs>(
         }
     });
 
-    task::spawn(async move {
+    handle.spawn(async move {
         if connection.is_none() && options.retry_on_initial_connect {
             let (info, connection_ok) = match connector.connect().await {
                 Ok((info, connection)) => (info, connection),

--- a/async-nats/src/lib.rs
+++ b/async-nats/src/lib.rs
@@ -392,6 +392,9 @@ pub(crate) enum Command {
         headers: Option<HeaderMap>,
         sender: oneshot::Sender<Message>,
     },
+    DiscardRespond {
+        respond: Subject,
+    },
     Subscribe {
         sid: u64,
         subject: Subject,
@@ -930,6 +933,16 @@ impl ConnectionHandler {
                 };
 
                 self.connection.enqueue_write_op(&pub_op);
+            }
+
+            Command::DiscardRespond { respond } => {
+                let Some(multiplexer) = self.multiplexer.as_mut() else {
+                    return;
+                };
+
+                let (_prefix, token) = respond.rsplit_once('.').expect("malformed subject");
+
+                multiplexer.senders.remove(token);
             }
 
             Command::Publish(OutboundMessage {

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -1874,32 +1874,4 @@ mod client {
             "disconnected too early ({elapsed:?}) to be the ping keepalive"
         );
     }
-
-    #[tokio::test]
-    async fn request_with_no_response_does_not_leak_memory() {
-        const SUBJECT: &str = "horizon";
-
-        let server = nats_server::run_basic_server();
-        let client = async_nats::connect(server.client_url()).await.unwrap();
-
-        let barrier = Arc::new(tokio::sync::Barrier::new(2));
-
-        let black_hole = tokio::spawn({
-            let client = client.clone();
-            let barrier = barrier.clone();
-            async move {
-                let mut sub = client.subscribe(SUBJECT).await.unwrap();
-                barrier.wait().await;
-
-                while let Some(event) = sub.next().await {
-                    drop(event); // gobble gobble
-                }
-            }
-        });
-
-        barrier.wait().await;
-        client.flush().await.unwrap();
-
-        todo!();
-    }
 }

--- a/async-nats/tests/client_tests.rs
+++ b/async-nats/tests/client_tests.rs
@@ -1874,4 +1874,32 @@ mod client {
             "disconnected too early ({elapsed:?}) to be the ping keepalive"
         );
     }
+
+    #[tokio::test]
+    async fn request_with_no_response_does_not_leak_memory() {
+        const SUBJECT: &str = "horizon";
+
+        let server = nats_server::run_basic_server();
+        let client = async_nats::connect(server.client_url()).await.unwrap();
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let black_hole = tokio::spawn({
+            let client = client.clone();
+            let barrier = barrier.clone();
+            async move {
+                let mut sub = client.subscribe(SUBJECT).await.unwrap();
+                barrier.wait().await;
+
+                while let Some(event) = sub.next().await {
+                    drop(event); // gobble gobble
+                }
+            }
+        });
+
+        barrier.wait().await;
+        client.flush().await.unwrap();
+
+        todo!();
+    }
 }


### PR DESCRIPTION
Closes #1617 

- Adds a new `Command::DiscardRespond` to discard the multiplexer entry. Uses the same pattern as `Command::Request`, which is to parse the token from the respond `Subject` and panic if the subject was "malformed".
- Adds a new (internal) `RequestDropGuard`, that wraps the `Receiver<Message>` resulting from a `Command::Request`; on drop it does a best-effort cleanup by sending `Command::DiscardRespond` if the `Receiver<Message>` never received any response.
- Adds test-only `MultiplexerStats`, `Command::MultiplexerStats`, and `Client::multiplexer_stats` for use by tests. This was the cleanest way I could think of to allow tests to "see into" the multiplexer
- Added a regression test to assert that the multiplexer returns to empty after the `RequestDropGuard` is dropped.
- Added a new (internal) `Client::send_guarded_request` to abstract the logic for sending `Command::Request` and building a `RequestDropGuard`, which would otherwise be duplicated by both `Client::request` and jetstream's `Context::send_publish`
- Updated `Client::request` and `Context::send_publish` to use the guarded path; I had to replace `Receiver<Message>` with `RequestDropGuard` in several places on the jetstream side.

This resolved the issue in my original [PoC](https://radicle.network/nodes/rosa.radicle.network/rad%3AzmeHKB1caC41XyVwfMz3L9WvyrBF):

<details>
<summary>async-nats 0.50.0</summary>

```
[async-nats-memory-leak] | baseline live heap: 0.2 MiB (pid 1)
[async-nats-memory-leak] |
[async-nats-memory-leak] |  round   requests live heap (MiB)  delta (MiB)
[async-nats-memory-leak] |      1     100000            29.5        +29.2
[async-nats-memory-leak] |      2     200000            58.6        +29.1
[async-nats-memory-leak] |      3     300000            91.8        +33.2
[async-nats-memory-leak] |      4     400000           116.8        +25.0
[async-nats-memory-leak] |      5     500000           158.3        +41.5
[async-nats-memory-leak] |      6     600000           183.3        +25.0
[async-nats-memory-leak] |      7     700000           208.3        +25.0
[async-nats-memory-leak] |      8     800000           233.3        +25.0
[async-nats-memory-leak] |      9     900000           258.2        +25.0
[async-nats-memory-leak] |     10    1000000           316.2        +58.0
[async-nats-memory-leak] |
[async-nats-memory-leak] | live heap grew by 316.0 MiB after 1000000 timed-out requests.
[async-nats-memory-leak] | after dropping client: 0.2 MiB (-316.1 MiB)
```
</details>

<details>
<summary>this branch</summary>

```
[async-nats-memory-leak] | baseline live heap: 0.2 MiB (pid 1)
[async-nats-memory-leak] |
[async-nats-memory-leak] |  round   requests live heap (MiB)  delta (MiB)
[async-nats-memory-leak] |      1     100000             4.5         +4.2
[async-nats-memory-leak] |      2     200000             4.5         +0.0
[async-nats-memory-leak] |      3     300000             8.6         +4.1
[async-nats-memory-leak] |      4     400000             8.6         +0.0
[async-nats-memory-leak] |      5     500000             8.6         +0.0
[async-nats-memory-leak] |      6     600000             8.6         +0.0
[async-nats-memory-leak] |      7     700000             8.6         -0.0
[async-nats-memory-leak] |      8     800000             8.6         +0.0
[async-nats-memory-leak] |      9     900000             8.6         +0.0
[async-nats-memory-leak] |     10    1000000             8.6         +0.0
[async-nats-memory-leak] |
[async-nats-memory-leak] | live heap grew by 8.4 MiB after 1000000 timed-out requests.
[async-nats-memory-leak] | after dropping client: 0.2 MiB (-8.5 MiB)
```
</details>

This will additionally handle aborted futures and panics, not just time-outs.